### PR TITLE
Fixing Python 3.6 compatibility

### DIFF
--- a/src/slack_bolt/listener_matcher/builtins.py
+++ b/src/slack_bolt/listener_matcher/builtins.py
@@ -1,8 +1,9 @@
 import inspect
-try:
-    from re import Pattern
-except ImportError:
+import sys
+if sys.version_info.major == 3 and sys.version_info.minor <= 6:
     from re import _pattern_type as Pattern
+else:
+    from re import Pattern
 from typing import Callable
 from typing import Union, Optional, Dict
 


### PR DESCRIPTION
The `Pattern` attribute was [introduced in Python 3.7](https://bugs.python.org/issue30397). This PR attempts to load the 3.7+ attribute, and falls back to the 3.6-compatible name if it fails.