### PR TITLE
Handle query arguments cleanly

### DIFF
--- a/src/slack_bolt/app/app.py
+++ b/src/slack_bolt/app/app.py
@@ -302,7 +302,7 @@ class SlackAppServer:
             default_request_version = "HTTP/1.1"
 
             def do_POST(self):
-                if _path != self.path.split('?')[0]:
+                if _path != self.path.split("?")[0]:
                     self.send_response(404)
                     return
 


### PR DESCRIPTION
The current version is very unhappy when query arguments are passed in the URL. This PR checks to make sure that the non-query-arg part of the URL matches the configured path, instead of checking the query arguments too.