### PR TITLE
Update to support org-level apps

### DIFF
--- a/src/slack_bolt/request/utils.py
+++ b/src/slack_bolt/request/utils.py
@@ -40,12 +40,14 @@ def extract_team_id(payload: Dict[str, any]) -> Optional[str]:
         team = payload.get("team")
         if isinstance(team, str):
             return team
-        elif "id" in team:
+        elif team and "id" in team:
             return team.get("id")
     if "team_id" in payload:
         return payload.get("team_id")
     if "event" in payload:
         return extract_team_id(payload["event"])
+    if "user" in payload:
+        return payload.get("user")["team_id"]    
     return None
 
 


### PR DESCRIPTION
I recently converted a bolt-python app to use the new "org-level app" installation, and the structure of the `payload` for incoming interactive elements has changed slightly. The new structure is:

```
{'action_ts': '1596092005.320510',
 'callback_id': 'name',
 'enterprise': {'id': 'Exxx', 'name': 'Slack Corp'},
 'is_enterprise_install': True,
 'team': None,
 'token': 'xxx',
 'trigger_id': 'xxx,
 'type': 'shortcut',
 'user': {'id': 'Wxxx', 'team_id': 'Txxx', 'username': 'acompton'}}
```

The `team` being `None` in this case confused bolt-python. This PR addresses that issue so it works again.