### PR TITLE
Update ack() repsond() args

### DIFF
--- a/samples/app.py
+++ b/samples/app.py
@@ -29,7 +29,7 @@ def event_test(payload, say, logger):
 if __name__ == "__main__":
     app.start(3000)
 
-# pip install -i https://test.pypi.org/simple/ slack_bolt
+# pip install slack_bolt
 # export SLACK_SIGNING_SECRET=***
 # export SLACK_BOT_TOKEN=xoxb-***
 # python app.py

--- a/samples/async_app.py
+++ b/samples/async_app.py
@@ -35,7 +35,7 @@ async def command(ack):
 if __name__ == "__main__":
     app.start(3000)
 
-# pip install -i https://test.pypi.org/simple/ slack_bolt
+# pip install slack_bolt
 # export SLACK_SIGNING_SECRET=***
 # export SLACK_BOT_TOKEN=xoxb-***
 # python app.py

--- a/samples/dialogs_app.py
+++ b/samples/dialogs_app.py
@@ -83,7 +83,7 @@ def dialog_cancellation(ack):
 if __name__ == "__main__":
     app.start(3000)
 
-# pip install -i https://test.pypi.org/simple/ slack_bolt
+# pip install slack_bolt
 # export SLACK_SIGNING_SECRET=***
 # export SLACK_BOT_TOKEN=xoxb-***
 # python dialogs_app.py

--- a/samples/events_app.py
+++ b/samples/events_app.py
@@ -67,7 +67,7 @@ def bot_message_deleted(logger):
 if __name__ == "__main__":
     app.start(3000)
 
-# pip install -i https://test.pypi.org/simple/ slack_bolt
+# pip install slack_bolt
 # export SLACK_SIGNING_SECRET=***
 # export SLACK_BOT_TOKEN=xoxb-***
 # python events_app.py

--- a/samples/modals_app_typed.py
+++ b/samples/modals_app_typed.py
@@ -1,0 +1,159 @@
+# ------------------------------------------------
+# instead of slack_bolt in requirements.txt
+import sys
+
+sys.path.insert(1, "..")
+# ------------------------------------------------
+
+import logging
+from typing import Callable
+from logging import Logger
+from slack_bolt import App, BoltResponse, Ack, Respond
+from slack_sdk import WebClient
+from slack_sdk.models.blocks import (
+    PlainTextObject,
+    InputBlock,
+    PlainTextInputElement,
+    ExternalDataSelectElement,
+    ExternalDataMultiSelectElement,
+    Option,
+    OptionGroup,
+    SectionBlock,
+    MarkdownTextObject,
+    ButtonElement,
+)
+from slack_sdk.models.views import View
+
+logging.basicConfig(level=logging.DEBUG)
+
+app = App()
+
+
+@app.middleware  # or app.use(log_request)
+def log_request(
+    logger: Logger, payload: dict, next: Callable[[], BoltResponse]
+) -> BoltResponse:
+    logger.debug(payload)
+    return next()
+
+
+@app.command("/hello-bolt-python")
+def handle_command(
+    payload: dict, ack: Ack, respond: Respond, client: WebClient, logger: Logger
+) -> None:
+    logger.info(payload)
+    ack(
+        text="Accepted!",
+        blocks=[
+            SectionBlock(
+                block_id="b",
+                text=MarkdownTextObject(text=":white_check_mark: Accepted!"),
+            )
+        ],
+    )
+
+    respond(
+        blocks=[
+            SectionBlock(
+                block_id="b",
+                text=MarkdownTextObject(
+                    text="You can add a button alongside text in your message. "
+                ),
+                accessory=ButtonElement(
+                    action_id="a", text=PlainTextObject(text="Button"), value="click_me_123",
+                ),
+            ),
+        ]
+    )
+
+    res = client.views_open(
+        trigger_id=payload["trigger_id"],
+        view=View(
+            type="modal",
+            callback_id="view-id",
+            title=PlainTextObject(text="My App"),
+            submit=PlainTextObject(text="Submit"),
+            close=PlainTextObject(text="Cancel"),
+            blocks=[
+                InputBlock(
+                    element=PlainTextInputElement(action_id="text"),
+                    label=PlainTextObject(text="Label"),
+                ),
+                InputBlock(
+                    block_id="es_b",
+                    element=ExternalDataSelectElement(
+                        action_id="es_a",
+                        placeholder=PlainTextObject(text="Select an item"),
+                        min_query_length=0,
+                    ),
+                    label=PlainTextObject(text="Search"),
+                ),
+                InputBlock(
+                    block_id="mes_b",
+                    element=ExternalDataMultiSelectElement(
+                        action_id="mes_a",
+                        placeholder=PlainTextObject(text="Select an item"),
+                        min_query_length=0,
+                    ),
+                    label=PlainTextObject(text="Search (multi)"),
+                ),
+            ],
+        ),
+    )
+    logger.info(res)
+
+
+@app.options("es_a")
+def show_options(ack: Ack) -> None:
+    ack(options=[Option(text=PlainTextObject(text="Maru"), value="maru")])
+
+
+@app.options("mes_a")
+def show_multi_options(ack: Ack) -> None:
+    ack(
+        option_groups=[
+            OptionGroup(
+                label=PlainTextObject(text="Group 1"),
+                options=[
+                    Option(text=PlainTextObject(text="Option 1"), value="1-1"),
+                    Option(text=PlainTextObject(text="Option 2"), value="1-2"),
+                ],
+            ),
+            OptionGroup(
+                label=PlainTextObject(text="Group 2"),
+                options=[Option(text=PlainTextObject(text="Option 1"), value="2-1"),],
+            ),
+        ]
+    )
+
+
+@app.view("view-id")
+def view_submission(ack: Ack, payload: dict, logger: Logger) -> None:
+    ack()
+    logger.info(payload["view"]["state"]["values"])
+
+
+@app.action("a")
+def button_click(ack: Ack, payload: dict, respond: Respond) -> None:
+    ack()
+
+    user_id: str = payload["user"]["id"]
+    # in_channel / dict
+    respond(
+        response_type="in_channel",
+        replace_original=False,
+        text=f"<@{user_id}> clicked a button! (in_channel)",
+    )
+    # ephemeral / kwargs
+    respond(
+        replace_original=False, text=":white_check_mark: Done!",
+    )
+
+
+if __name__ == "__main__":
+    app.start(3000)
+
+# pip install slack_bolt
+# export SLACK_SIGNING_SECRET=***
+# export SLACK_BOT_TOKEN=xoxb-***
+# python modals_app_typed.py

--- a/samples/oauth_app.py
+++ b/samples/oauth_app.py
@@ -79,7 +79,7 @@ def button_click(logger, payload, ack, respond):
 if __name__ == "__main__":
     app.start(3000)
 
-# pip install -i https://test.pypi.org/simple/ slack_bolt
+# pip install slack_bolt
 # export SLACK_SIGNING_SECRET=***
 # export SLACK_BOT_TOKEN=xoxb-***
 # export SLACK_CLIENT_ID=111.111

--- a/samples/oauth_sqlite3_app.py
+++ b/samples/oauth_sqlite3_app.py
@@ -24,7 +24,7 @@ def handle_app_mentions(payload, say, logger):
 if __name__ == "__main__":
     app.start(3000)
 
-# pip install -i https://test.pypi.org/simple/ slack_bolt
+# pip install slack_bolt
 # export SLACK_SIGNING_SECRET=***
 # export SLACK_BOT_TOKEN=xoxb-***
 # export SLACK_CLIENT_ID=111.111

--- a/slack_bolt/context/ack/ack.py
+++ b/slack_bolt/context/ack/ack.py
@@ -1,8 +1,10 @@
 from typing import List, Optional, Union
 
+from slack_sdk.models.attachments import Attachment
+from slack_sdk.models.blocks import Block, Option, OptionGroup
+
 from slack_bolt.context.ack.internals import _set_response
 from slack_bolt.response.response import BoltResponse
-from slack_sdk.models.blocks import Block
 
 
 class Ack:
@@ -13,7 +15,17 @@ class Ack:
 
     def __call__(
         self,
-        text_or_whole_response: Union[str, dict] = "",
+        text: Union[str, dict] = "",  # text: str or whole_response: dict
         blocks: Optional[List[Union[dict, Block]]] = None,
+        attachments: Optional[List[Union[dict, Attachment]]] = None,
+        options: Optional[List[Union[dict, Option]]] = None,
+        option_groups: Optional[List[Union[dict, OptionGroup]]] = None,
     ) -> BoltResponse:
-        return _set_response(self, text_or_whole_response, blocks)
+        return _set_response(
+            self,
+            text_or_whole_response=text,
+            blocks=blocks,
+            attachments=attachments,
+            options=options,
+            option_groups=option_groups,
+        )

--- a/slack_bolt/context/ack/async_ack.py
+++ b/slack_bolt/context/ack/async_ack.py
@@ -1,8 +1,10 @@
 from typing import List, Optional, Union
 
+from slack_sdk.models.attachments import Attachment
+from slack_sdk.models.blocks import Block, Option, OptionGroup
+
 from slack_bolt.context.ack.internals import _set_response
 from slack_bolt.response.response import BoltResponse
-from slack_sdk.models.blocks import Block
 
 
 class AsyncAck:
@@ -13,7 +15,17 @@ class AsyncAck:
 
     async def __call__(
         self,
-        text_or_whole_response: Union[str, dict] = "",
+        text: Union[str, dict] = "",  # text: str or whole_response: dict
         blocks: Optional[List[Union[dict, Block]]] = None,
+        attachments: Optional[List[Union[dict, Attachment]]] = None,
+        options: Optional[List[Union[dict, Option]]] = None,
+        option_groups: Optional[List[Union[dict, OptionGroup]]] = None,
     ) -> BoltResponse:
-        return _set_response(self, text_or_whole_response, blocks)
+        return _set_response(
+            self,
+            text_or_whole_response=text,
+            blocks=blocks,
+            attachments=attachments,
+            options=options,
+            option_groups=option_groups,
+        )

--- a/slack_bolt/context/ack/internals.py
+++ b/slack_bolt/context/ack/internals.py
@@ -1,28 +1,54 @@
 from typing import Optional, List, Union
 
-from slack_sdk.models.blocks import Block
+from slack_sdk.models.attachments import Attachment
+from slack_sdk.models.blocks import Block, Option, OptionGroup
 
 from slack_bolt.error import BoltError
 from slack_bolt.response import BoltResponse
+from slack_bolt.util.utils import convert_to_dict_list
 
 
 def _set_response(
     self: any,
     text_or_whole_response: Union[str, dict] = "",
     blocks: Optional[List[Union[dict, Block]]] = None,
+    attachments: Optional[List[Union[dict, Attachment]]] = None,
+    options: Optional[List[Union[dict, Option]]] = None,
+    option_groups: Optional[List[Union[dict, OptionGroup]]] = None,
 ) -> BoltResponse:
-    print(text_or_whole_response)
     if isinstance(text_or_whole_response, str):
-        text = text_or_whole_response
-        if not text and (not blocks or len(blocks) == 0):
-            self.response = BoltResponse(status=200, body="")
-        else:
+        text: str = text_or_whole_response
+        if attachments and len(attachments) > 0:
             self.response = BoltResponse(
-                status=200, body={"text": text, "blocks": blocks,}
+                status=200,
+                body={"text": text, "attachments": convert_to_dict_list(attachments),},
             )
+        elif blocks and len(blocks) > 0:
+            self.response = BoltResponse(
+                status=200, body={"text": text, "blocks": convert_to_dict_list(blocks),}
+            )
+        elif options and len(options) > 0:
+            self.response = BoltResponse(
+                status=200, body={"options": convert_to_dict_list(options),}
+            )
+        elif option_groups and len(option_groups) > 0:
+            self.response = BoltResponse(
+                status=200, body={"option_groups": convert_to_dict_list(option_groups),}
+            )
+        else:
+            self.response = BoltResponse(status=200, body=text)
         return self.response
     elif isinstance(text_or_whole_response, dict):
         body = text_or_whole_response
+        if "attachments" in body:
+            body["attachments"] = convert_to_dict_list(body["attachments"])
+        if "blocks" in body:
+            body["blocks"] = convert_to_dict_list(body["blocks"])
+        if "options" in body:
+            body["options"] = convert_to_dict_list(body["options"])
+        if "option_groups" in body:
+            body["option_groups"] = convert_to_dict_list(body["option_groups"])
+
         self.response = BoltResponse(status=200, body=body)
     else:
         raise BoltError(

--- a/slack_bolt/context/respond/async_respond.py
+++ b/slack_bolt/context/respond/async_respond.py
@@ -1,7 +1,10 @@
-from typing import Optional, List
+from typing import Optional, List, Union
+
+from slack_sdk.models.attachments import Attachment
+from slack_sdk.models.blocks import Block
+from slack_sdk.webhook.async_client import AsyncWebhookClient, WebhookResponse
 
 from slack_bolt.context.respond.internals import _build_message
-from slack_sdk.webhook.async_client import AsyncWebhookClient, WebhookResponse
 
 
 class AsyncRespond:
@@ -12,21 +15,31 @@ class AsyncRespond:
 
     async def __call__(
         self,
-        text: str = "",
-        blocks: Optional[List[dict]] = None,
+        text: Union[str, dict] = "",
+        blocks: Optional[List[Union[dict, Block]]] = None,
+        attachments: Optional[List[Union[dict, Attachment]]] = None,
         response_type: Optional[str] = None,
         replace_original: Optional[bool] = None,
         delete_original: Optional[bool] = None,
     ) -> WebhookResponse:
         if self.response_url is not None:
             client = AsyncWebhookClient(self.response_url)
-            message = _build_message(
-                text=text,
-                blocks=blocks,
-                response_type=response_type,
-                replace_original=replace_original,
-                delete_original=delete_original,
-            )
-            return await client.send_dict(message)
+            text_or_whole_response: Union[str, dict] = text
+            if isinstance(text_or_whole_response, str):
+                message = _build_message(
+                    text=text,
+                    blocks=blocks,
+                    attachments=attachments,
+                    response_type=response_type,
+                    replace_original=replace_original,
+                    delete_original=delete_original,
+                )
+                return await client.send_dict(message)
+            elif isinstance(text_or_whole_response, dict):
+                whole_response: dict = text_or_whole_response
+                message = _build_message(**whole_response)
+                return await client.send_dict(message)
+            else:
+                raise ValueError(f"The arg is unexpected type ({type(text)})")
         else:
             raise ValueError("respond is unsupported here as there is no response_url")

--- a/slack_bolt/context/respond/internals.py
+++ b/slack_bolt/context/respond/internals.py
@@ -1,16 +1,24 @@
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Union
+
+from slack_sdk.models.attachments import Attachment
+from slack_sdk.models.blocks import Block
+
+from slack_bolt.util.utils import convert_to_dict_list
 
 
 def _build_message(
     text: str = "",
-    blocks: Optional[List[dict]] = None,
+    blocks: Optional[List[Union[dict, Block]]] = None,
+    attachments: Optional[List[Union[dict, Attachment]]] = None,
     response_type: Optional[str] = None,
     replace_original: Optional[bool] = None,
     delete_original: Optional[bool] = None,
 ) -> Dict[str, any]:
     message = {"text": text}
-    if blocks is not None:
-        message["blocks"] = blocks
+    if blocks is not None and len(blocks) > 0:
+        message["blocks"] = convert_to_dict_list(blocks)
+    if attachments is not None and len(attachments) > 0:
+        message["attachments"] = convert_to_dict_list(attachments)
     if response_type is not None:
         message["response_type"] = response_type
     if replace_original is not None:

--- a/slack_bolt/context/respond/respond.py
+++ b/slack_bolt/context/respond/respond.py
@@ -1,7 +1,10 @@
-from typing import Optional, List
+from typing import Optional, List, Union
+
+from slack_sdk.models.attachments import Attachment
+from slack_sdk.models.blocks import Block
+from slack_sdk.webhook import WebhookClient, WebhookResponse
 
 from slack_bolt.context.respond.internals import _build_message
-from slack_sdk.webhook import WebhookClient, WebhookResponse
 
 
 class Respond:
@@ -12,21 +15,33 @@ class Respond:
 
     def __call__(
         self,
-        text: str = "",
-        blocks: Optional[List[dict]] = None,
+        text: Union[str, dict] = "",
+        blocks: Optional[List[Union[dict, Block]]] = None,
+        attachments: Optional[List[Union[dict, Attachment]]] = None,
         response_type: Optional[str] = None,
         replace_original: Optional[bool] = None,
         delete_original: Optional[bool] = None,
     ) -> WebhookResponse:
         if self.response_url is not None:
             client = WebhookClient(self.response_url)
-            message = _build_message(
-                text=text,
-                blocks=blocks,
-                response_type=response_type,
-                replace_original=replace_original,
-                delete_original=delete_original,
-            )
-            return client.send_dict(message)
+            text_or_whole_response: Union[str, dict] = text
+            if isinstance(text_or_whole_response, str):
+                text = text_or_whole_response
+                message = _build_message(
+                    text=text,
+                    blocks=blocks,
+                    attachments=attachments,
+                    response_type=response_type,
+                    replace_original=replace_original,
+                    delete_original=delete_original,
+                )
+                return client.send_dict(message)
+            elif isinstance(text_or_whole_response, dict):
+                message = _build_message(**text_or_whole_response)
+                return client.send_dict(message)
+            else:
+                raise ValueError(
+                    f"The arg is unexpected type ({type(text_or_whole_response)})"
+                )
         else:
             raise ValueError("respond is unsupported here as there is no response_url")

--- a/slack_bolt/context/say/async_say.py
+++ b/slack_bolt/context/say/async_say.py
@@ -19,17 +19,29 @@ class AsyncSay:
 
     async def __call__(
         self,
-        text: str = "",
+        text: Union[str, dict] = "",
         blocks: Optional[List[Union[Dict, Block]]] = None,
         attachments: Optional[List[Union[Dict, Attachment]]] = None,
         channel: Optional[str] = None,
     ) -> AsyncSlackResponse:
         if _can_say(self, channel):
-            return await self.client.chat_postMessage(
-                channel=channel or self.channel,
-                text=text,
-                blocks=blocks,
-                attachments=attachments,
-            )
+            text_or_whole_response: Union[str, dict] = text
+            if isinstance(text_or_whole_response, str):
+                text = text_or_whole_response
+                return await self.client.chat_postMessage(
+                    channel=channel or self.channel,
+                    text=text,
+                    blocks=blocks,
+                    attachments=attachments,
+                )
+            elif isinstance(text_or_whole_response, dict):
+                message: dict = text_or_whole_response
+                if "channel" not in message:
+                    message["channel"] = channel or self.channel
+                return await self.client.chat_postMessage(**message)
+            else:
+                raise ValueError(
+                    f"The arg is unexpected type ({type(text_or_whole_response)})"
+                )
         else:
             raise ValueError("say without channel_id here is unsupported")

--- a/slack_bolt/context/say/say.py
+++ b/slack_bolt/context/say/say.py
@@ -1,10 +1,11 @@
 from typing import Optional, List, Union, Dict
 
-from slack_bolt.context.say.internals import _can_say
 from slack_sdk import WebClient
 from slack_sdk.models.attachments import Attachment
 from slack_sdk.models.blocks import Block
 from slack_sdk.web import SlackResponse
+
+from slack_bolt.context.say.internals import _can_say
 
 
 class Say:
@@ -19,17 +20,29 @@ class Say:
 
     def __call__(
         self,
-        text: str = "",
+        text: Union[str, dict] = "",
         blocks: Optional[List[Union[Dict, Block]]] = None,
         attachments: Optional[List[Union[Dict, Attachment]]] = None,
         channel: Optional[str] = None,
     ) -> SlackResponse:
         if _can_say(self, channel):
-            return self.client.chat_postMessage(
-                channel=channel or self.channel,
-                text=text,
-                blocks=blocks,
-                attachments=attachments,
-            )
+            text_or_whole_response: Union[str, dict] = text
+            if isinstance(text_or_whole_response, str):
+                text = text_or_whole_response
+                return self.client.chat_postMessage(
+                    channel=channel or self.channel,
+                    text=text,
+                    blocks=blocks,
+                    attachments=attachments,
+                )
+            elif isinstance(text_or_whole_response, dict):
+                message: dict = text_or_whole_response
+                if "channel" not in message:
+                    message["channel"] = channel or self.channel
+                return self.client.chat_postMessage(**message)
+            else:
+                raise ValueError(
+                    f"The arg is unexpected type ({type(text_or_whole_response)})"
+                )
         else:
             raise ValueError("say without channel_id here is unsupported")

--- a/slack_bolt/util/utils.py
+++ b/slack_bolt/util/utils.py
@@ -1,9 +1,23 @@
-from typing import Optional
+from typing import Optional, Union, Dict, List
 
 from slack_sdk import WebClient
+from slack_sdk.models import JsonObject
 
+from slack_bolt.error import BoltError
 from slack_bolt.version import __version__ as bolt_version
 
 
 def create_web_client(token: Optional[str] = None) -> WebClient:
     return WebClient(token=token, user_agent_prefix=f"Bolt/{bolt_version}",)
+
+
+def convert_to_dict_list(objects: List[Union[Dict, JsonObject]]) -> List[Dict]:
+    return [_to_dict(elm) for elm in objects]
+
+
+def _to_dict(obj: Union[Dict, JsonObject]) -> Dict:
+    if isinstance(obj, dict):
+        return obj
+    if isinstance(obj, JsonObject) or hasattr(obj, "to_dict"):
+        return obj.to_dict()
+    raise BoltError(f"{obj} (type: {type(obj)}) is unsupported")


### PR DESCRIPTION
##  Summary

This pull request updates `Ack` and `Respond` to cover more patterns by applying the following changes:

* Add attachments, options, option_groups to ack()
* Add attachments to respond()
* Enable ack(), respond() to accept dict values
* Enable ack(), respond() to accept slack_sdk.models.JsonObject in arrays

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
