### PR TITLE
Make app.shortcut compatible with Bolt for JS

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -6,7 +6,16 @@
 script_dir=`dirname $0`
 cd ${script_dir}/..
 
-pip install -e ".[testing]" && \
-  black slack_bolt/ tests/ && \
-  pytest $1 && \
-  pytype slack_bolt/
+test_target="$1"
+
+if [[ $test_target != "" ]]
+then
+  pip install -e ".[testing]" && \
+    black slack_bolt/ tests/ && \
+    pytest $1
+else
+  pip install -e ".[testing]" && \
+    black slack_bolt/ tests/ && \
+    pytest && \
+    pytype slack_bolt/
+fi

--- a/slack_bolt/listener_matcher/builtins.py
+++ b/slack_bolt/listener_matcher/builtins.py
@@ -127,8 +127,18 @@ def shortcut(
             return (
                 payload
                 and "callback_id" in payload
-                and payload["type"] == "shortcut"
-                and _matches(callback_id, payload["callback_id"])
+                and (
+                    (
+                        # global shortcut
+                        _is_expected_type(payload, "shortcut")
+                        and _matches(callback_id, payload["callback_id"])
+                    )
+                    or (
+                        # message shortcut
+                        _is_expected_type(payload, "message_action")
+                        and _matches(callback_id, payload["callback_id"])
+                    )
+                )
             )
 
         return build_listener_matcher(func, asyncio)

--- a/tests/async_scenario_tests/test_shortcut.py
+++ b/tests/async_scenario_tests/test_shortcut.py
@@ -56,8 +56,9 @@ class TestAsyncShortcut:
         resp = await self.web_client.api_test()
         assert resp != None
 
+    # NOTE: This is a compatible behavior with Bolt for JS
     @pytest.mark.asyncio
-    async def test_success_global(self):
+    async def test_success_both_global_and_message(self):
         app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret,)
         app.shortcut("test-shortcut")(simple_listener)
 
@@ -68,8 +69,18 @@ class TestAsyncShortcut:
 
         request = self.build_valid_request(message_shortcut_raw_body)
         response = await app.async_dispatch(request)
-        assert response.status == 404
+        assert response.status == 200
         assert self.mock_received_requests["/auth.test"] == 2
+
+    @pytest.mark.asyncio
+    async def test_success_global(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret,)
+        app.shortcut("test-shortcut")(simple_listener)
+
+        request = self.build_valid_request(global_shortcut_raw_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_success_global_2(self):

--- a/tests/scenario_tests/test_shortcut.py
+++ b/tests/scenario_tests/test_shortcut.py
@@ -49,7 +49,8 @@ class TestShortcut:
         resp = self.web_client.api_test()
         assert resp != None
 
-    def test_success_global(self):
+    # NOTE: This is a compatible behavior with Bolt for JS
+    def test_success_both_global_and_message(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
         app.shortcut("test-shortcut")(simple_listener)
 
@@ -60,8 +61,17 @@ class TestShortcut:
 
         request = self.build_valid_request(message_shortcut_raw_body)
         response = app.dispatch(request)
-        assert response.status == 404
+        assert response.status == 200
         assert self.mock_received_requests["/auth.test"] == 2
+
+    def test_success_global(self):
+        app = App(client=self.web_client, signing_secret=self.signing_secret,)
+        app.shortcut("test-shortcut")(simple_listener)
+
+        request = self.build_valid_request(global_shortcut_raw_body)
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_success_global_2(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)


### PR DESCRIPTION
##  Summary

This pull request changes the behavior of listener function registration by `app.shorcut(str, regexp)` to make it compatible with Bolt for JS.  If a given argument is either a string or regular expression value, its generated listener matcher accepts both global and message shortcut requests.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
