### PR TITLE
Add client type validation in App/AsyncApp constructors

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -100,6 +100,8 @@ class App:
         self._token: Optional[str] = token
 
         if client is not None:
+            if not isinstance(client, WebClient):
+                raise BoltError("client must be a WebClient")
             self._client = client
             self._token = client.token
             if token is not None:

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -111,6 +111,8 @@ class AsyncApp:
         self._token: Optional[str] = token
 
         if client is not None:
+            if not isinstance(client, AsyncWebClient):
+                raise BoltError("client must be an AsyncWebClient")
             self._async_client = client
             self._token = client.token
             if token is not None:

--- a/tests/async_scenario_tests/test_app.py
+++ b/tests/async_scenario_tests/test_app.py
@@ -1,4 +1,5 @@
 import pytest
+from slack_sdk import WebClient
 from slack_sdk.oauth.installation_store import FileInstallationStore
 from slack_sdk.oauth.state_store import FileOAuthStateStore
 
@@ -36,6 +37,12 @@ class TestAsyncApp:
         app = AsyncApp(signing_secret="valid", token="xoxb-xxx")
         with pytest.raises(BoltError):
             app.action({"type": "invalid_type", "action_id": "a"})(self.simple_listener)
+
+    # NOTE: We intentionally don't have this test in scenario_tests
+    # to avoid having async dependencies in the tests.
+    def test_invalid_client_type(self):
+        with pytest.raises(BoltError):
+            AsyncApp(signing_secret="valid", client=WebClient(token="xoxb-xxx"))
 
     # --------------------------
     # single team auth


### PR DESCRIPTION
##  Summary

This pull request adds a validation logic for the `client` arg in `App`/`AsyncApp` constructors. The following examples raise an exception clearly telling what's wrong.

```python
app = App(signing_secret="valid", client=AsyncWebClient(token="xoxb-xxx"))
app = AsyncApp(signing_secret="valid", client=WebClient(token="xoxb-xxx"))
```

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.