### PR TITLE
Fix #38 by adding samples using Google Cloud Functions

### DIFF
--- a/samples/google_cloud_functions/.env.yaml.sample
+++ b/samples/google_cloud_functions/.env.yaml.sample
@@ -1,0 +1,2 @@
+SLACK_SIGNING_SECRET: xxx
+SLACK_BOT_TOKEN: xoxb-xxx

--- a/samples/google_cloud_functions/.gcloudignore
+++ b/samples/google_cloud_functions/.gcloudignore
@@ -1,0 +1,18 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+.env.yaml.sample
+
+node_modules
+#!include:.gitignore

--- a/samples/google_cloud_functions/.gitignore
+++ b/samples/google_cloud_functions/.gitignore
@@ -1,0 +1,1 @@
+.env.yaml

--- a/samples/google_cloud_functions/main.py
+++ b/samples/google_cloud_functions/main.py
@@ -6,7 +6,8 @@ logging.basicConfig(level=logging.DEBUG)
 
 from slack_bolt import App
 
-app = App()
+# process_before_response must be True when running on FaaS
+app = App(process_before_response=True)
 
 
 @app.command("/hello-bolt-python-gcp")

--- a/samples/google_cloud_functions/main.py
+++ b/samples/google_cloud_functions/main.py
@@ -1,0 +1,59 @@
+# https://cloud.google.com/functions/docs/first-python
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+from slack_bolt import App
+
+app = App()
+
+
+@app.command("/hello-bolt-python-gcp")
+def hello_command(ack):
+    ack("Hi from Google Cloud Functions!")
+
+
+@app.event("app_mention")
+def event_test(ack, payload, say, logger):
+    logger.info(payload)
+    say("Hi from Google Cloud Functions!")
+
+
+# Flask adapter
+from slack_bolt.adapter.flask import SlackRequestHandler
+
+handler = SlackRequestHandler(app)
+
+# Cloud Function
+def hello_bolt_app(request):
+    """HTTP Cloud Function.
+    Args:
+        request (flask.Request): The request object.
+        <https://flask.palletsprojects.com/en/1.1.x/api/#incoming-request-data>
+    Returns:
+        The response text, or any set of values that can be turned into a
+        Response object using `make_response`
+        <https://flask.palletsprojects.com/en/1.1.x/api/#flask.make_response>.
+    """
+    return handler.handle(request)
+
+# Step1: Create a new Slack App: https://api.slack.com/apps
+# Bot Token Scopes: chat:write, commands, app_mentions:read
+
+# Step2: Set env variables
+# cp .env.yaml.sample .env.yaml
+# vi .env.yaml
+
+# Step3: Create a new Google Cloud project
+# gcloud projects create YOUR_PROJECT_NAME
+# gcloud config set project YOUR_PROJECT_NAME
+
+# Step4: Deploy a function in the project
+# gcloud functions deploy hello_bolt_app --runtime python38 --trigger-http --allow-unauthenticated --env-vars-file .env.yaml
+# gcloud functions describe hello_bolt_app
+
+# Step5: Set Request URL
+# Set https://us-central1-YOUR_PROJECT_NAME.cloudfunctions.net/hello_bolt_app to the following:
+#  * slash command: /hello-bolt-python-gcp
+#  * Events Subscriptions & add `app_mention` event

--- a/samples/google_cloud_functions/requirements.txt
+++ b/samples/google_cloud_functions/requirements.txt
@@ -1,0 +1,2 @@
+Flask>1
+slack_bolt


### PR DESCRIPTION
This pull request fixes #38 by adding a sample for Google Cloud Functions users. As Google Cloud Functions relies on Flask, we don't need to implement yet another adapter for it. Regarding using lazy listener functions on the platform, I need to think of possible ways to support it (honestly, I don't have any good idea yet).

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/run_tests.sh` after making the changes.
