### PR TITLE
Update say utility to accept any arguments

### DIFF
--- a/samples/events_app.py
+++ b/samples/events_app.py
@@ -37,33 +37,6 @@ def mention_bug(logger, payload):
     logger.info(payload)
 
 
-@app.event(
-    event={"type": "message", "subtype": "message_deleted"},
-    matchers=[
-        lambda payload: payload["event"]["previous_message"].get("bot_id", None) is None
-    ],
-)
-def deleted(payload, say):
-    message = payload["event"]["previous_message"]["text"]
-    say(f"I've noticed you deleted: {message}")
-
-
-def print_bot(req, resp, next):
-    bot_id = req.global_shortcut_payload["event"]["previous_message"]["bot_id"]
-    logger = logging.getLogger(__name__)
-    logger.info(f"bot_id surely exists here: {bot_id}")
-    return next()
-
-
-@app.event(
-    event={"type": "message", "subtype": "message_deleted"},
-    matchers=[lambda payload: payload["event"]["previous_message"].get("bot_id", None)],
-    middleware=[print_bot],
-)
-def bot_message_deleted(logger):
-    logger.info("A bot message has been deleted")
-
-
 if __name__ == "__main__":
     app.start(3000)
 

--- a/samples/message_events.py
+++ b/samples/message_events.py
@@ -1,0 +1,101 @@
+# ------------------------------------------------
+# instead of slack_bolt in requirements.txt
+import sys
+
+sys.path.insert(1, "..")
+# ------------------------------------------------
+
+import logging
+import re
+from typing import Callable
+
+from slack_bolt import App, Say, BoltContext
+from slack_sdk import WebClient
+
+logging.basicConfig(level=logging.DEBUG)
+
+app = App()
+
+
+@app.middleware
+def log_request(logger: logging.Logger, payload: dict, next: Callable):
+    logger.debug(payload)
+    return next()
+
+
+@app.message("test")
+def reply_to_test(say):
+    say("Yes, tests are important!")
+
+
+@app.message(re.compile("bug"))
+def mention_bug(say):
+    say("Do you mind filing a ticket?")
+
+
+# middleware function
+def extract_subtype(payload: dict, context: BoltContext, next: Callable):
+    context["subtype"] = payload.get("event", {}).get("subtype", None)
+    next()
+
+
+# https://api.slack.com/events/message
+# Newly posted messages only
+# or @app.event("message")
+@app.event({"type": "message", "subtype": None})
+def reply_in_thread(payload: dict, say: Say):
+    event = payload["event"]
+    thread_ts = event.get("thread_ts", None) or event["ts"]
+    say(text="Hey, what's up?", thread_ts=thread_ts)
+
+
+@app.event(
+    event={"type": "message", "subtype": "message_deleted"},
+    matchers=[
+        # Skip the deletion of messages by this listener
+        lambda payload: "You've deleted a message: " not in payload["event"]["previous_message"]["text"]
+    ]
+)
+def detect_deletion(say: Say, payload: dict):
+    text = payload["event"]["previous_message"]["text"]
+    say(f"You've deleted a message: {text}")
+
+
+# https://api.slack.com/events/message/file_share
+# https://api.slack.com/events/message/bot_message
+@app.event(
+    event={"type": "message", "subtype": re.compile("(me_message)|(file_share)")},
+    middleware=[extract_subtype],
+)
+def add_reaction(
+    payload: dict,
+    client: WebClient,
+    context: BoltContext,
+    logger: logging.Logger
+):
+    subtype = context["subtype"]  # by extract_subtype
+    logger.info(f"subtype: {subtype}")
+    message_ts = payload["event"]["ts"]
+    api_response = client.reactions_add(
+        channel=context.channel_id,
+        timestamp=message_ts,
+        name="eyes",
+    )
+    logger.info(f"api_response: {api_response}")
+
+
+# This listener handles all uncaught message events
+# (The position in source code matters)
+@app.event({"type": "message"}, middleware=[extract_subtype])
+def just_ack(logger, context):
+    subtype = context["subtype"]  # by extract_subtype
+    logger.info(f"{subtype} is ignored")
+
+
+if __name__ == "__main__":
+    app.start(3000)
+
+# pip install slack_bolt
+# export SLACK_SIGNING_SECRET=***
+# export SLACK_BOT_TOKEN=xoxb-***
+# python message_events.py

--- a/slack_bolt/context/say/async_say.py
+++ b/slack_bolt/context/say/async_say.py
@@ -23,6 +23,8 @@ class AsyncSay:
         blocks: Optional[List[Union[Dict, Block]]] = None,
         attachments: Optional[List[Union[Dict, Attachment]]] = None,
         channel: Optional[str] = None,
+        thread_ts: Optional[str] = None,
+        **kwargs,
     ) -> AsyncSlackResponse:
         if _can_say(self, channel):
             text_or_whole_response: Union[str, dict] = text
@@ -33,6 +35,8 @@ class AsyncSay:
                     text=text,
                     blocks=blocks,
                     attachments=attachments,
+                    thread_ts=thread_ts,
+                    **kwargs,
                 )
             elif isinstance(text_or_whole_response, dict):
                 message: dict = text_or_whole_response

--- a/slack_bolt/context/say/say.py
+++ b/slack_bolt/context/say/say.py
@@ -24,6 +24,8 @@ class Say:
         blocks: Optional[List[Union[Dict, Block]]] = None,
         attachments: Optional[List[Union[Dict, Attachment]]] = None,
         channel: Optional[str] = None,
+        thread_ts: Optional[str] = None,
+        **kwargs,
     ) -> SlackResponse:
         if _can_say(self, channel):
             text_or_whole_response: Union[str, dict] = text
@@ -34,6 +36,8 @@ class Say:
                     text=text,
                     blocks=blocks,
                     attachments=attachments,
+                    thread_ts=thread_ts,
+                    **kwargs,
                 )
             elif isinstance(text_or_whole_response, dict):
                 message: dict = text_or_whole_response


### PR DESCRIPTION
This pull request changes `say` utility to accept any arguments. Also, it improves samples for Events API.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
