### PR TITLE
Return 404 when missing next() calls and returning response in global middleware

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -283,6 +283,10 @@ class App:
                 self._framework_logger.debug(f"Applying {middleware.name}")
             resp = middleware.process(req=req, resp=resp, next=middleware_next)
             if not middleware_state["next_called"]:
+                if resp is None:
+                    return BoltResponse(
+                        status=404, body={"error": "no next() calls in middleware"}
+                    )
                 return resp
 
         for listener in self._listeners:

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -304,6 +304,10 @@ class AsyncApp:
                 req=req, resp=resp, next=async_middleware_next
             )
             if not middleware_state["next_called"]:
+                if resp is None:
+                    return BoltResponse(
+                        status=404, body={"error": "no next() calls in middleware"}
+                    )
                 return resp
 
         for listener in self._async_listeners:

--- a/tests/async_scenario_tests/test_middleware.py
+++ b/tests/async_scenario_tests/test_middleware.py
@@ -1,0 +1,97 @@
+import asyncio
+import json
+from time import time
+
+import pytest
+
+from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.request.async_request import AsyncBoltRequest
+from slack_sdk.signature import SignatureVerifier
+from slack_sdk.web.async_client import AsyncWebClient
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class TestAsyncMiddleware:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = AsyncWebClient(token=valid_token, base_url=mock_api_server_base_url,)
+
+    @pytest.fixture
+    def event_loop(self):
+        old_os_env = remove_os_env_temporarily()
+        try:
+            setup_mock_web_api_server(self)
+            loop = asyncio.get_event_loop()
+            yield loop
+            loop.close()
+            cleanup_mock_web_api_server(self)
+        finally:
+            restore_os_env(old_os_env)
+
+    def build_request(self) -> AsyncBoltRequest:
+        payload = {
+            "type": "shortcut",
+            "token": "verification_token",
+            "action_ts": "111.111",
+            "team": {
+                "id": "T111",
+                "domain": "workspace-domain",
+                "enterprise_id": "E111",
+                "enterprise_name": "Org Name",
+            },
+            "user": {"id": "W111", "username": "primary-owner", "team_id": "T111"},
+            "callback_id": "test-shortcut",
+            "trigger_id": "111.111.xxxxxx",
+        }
+        timestamp, body = str(int(time())), json.dumps(payload)
+        return AsyncBoltRequest(
+            body=body,
+            headers={
+                "content-type": ["application/json"],
+                "x-slack-signature": [
+                    self.signature_verifier.generate_signature(
+                        body=body, timestamp=timestamp,
+                    )
+                ],
+                "x-slack-request-timestamp": [timestamp],
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_next_call(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret,)
+        app.use(no_next)
+        app.shortcut("test-shortcut")(just_ack)
+
+        response = await app.async_dispatch(self.build_request())
+        assert response.status == 404
+        assert self.mock_received_requests["/auth.test"] == 1
+
+    @pytest.mark.asyncio
+    async def test_next_call(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret,)
+        app.use(just_next)
+        app.shortcut("test-shortcut")(just_ack)
+
+        response = await app.async_dispatch(self.build_request())
+        assert response.status == 200
+        assert response.body == "acknowledged!"
+        assert self.mock_received_requests["/auth.test"] == 1
+
+
+async def just_ack(ack):
+    await ack("acknowledged!")
+
+
+async def no_next():
+    pass
+
+
+async def just_next(next):
+    await next()

--- a/tests/scenario_tests/test_middleware.py
+++ b/tests/scenario_tests/test_middleware.py
@@ -1,0 +1,90 @@
+import json
+from time import time
+from urllib.parse import quote
+
+from slack_sdk.signature import SignatureVerifier
+from slack_sdk.web import WebClient
+
+from slack_bolt.app import App
+from slack_bolt.request import BoltRequest
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class TestMiddleware:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = WebClient(token=valid_token, base_url=mock_api_server_base_url,)
+
+    def setup_method(self):
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
+
+    def build_request(self) -> BoltRequest:
+        payload = {
+            "type": "shortcut",
+            "token": "verification_token",
+            "action_ts": "111.111",
+            "team": {
+                "id": "T111",
+                "domain": "workspace-domain",
+                "enterprise_id": "E111",
+                "enterprise_name": "Org Name",
+            },
+            "user": {"id": "W111", "username": "primary-owner", "team_id": "T111"},
+            "callback_id": "test-shortcut",
+            "trigger_id": "111.111.xxxxxx",
+        }
+        timestamp, body = str(int(time())), json.dumps(payload)
+        return BoltRequest(
+            body=body,
+            headers={
+                "content-type": ["application/json"],
+                "x-slack-signature": [
+                    self.signature_verifier.generate_signature(
+                        body=body, timestamp=timestamp,
+                    )
+                ],
+                "x-slack-request-timestamp": [timestamp],
+            },
+        )
+
+    def test_no_next_call(self):
+        app = App(client=self.web_client, signing_secret=self.signing_secret,)
+        app.use(no_next)
+        app.shortcut("test-shortcut")(just_ack)
+
+        response = app.dispatch(self.build_request())
+        assert response.status == 404
+        assert self.mock_received_requests["/auth.test"] == 1
+
+    def test_next_call(self):
+        app = App(client=self.web_client, signing_secret=self.signing_secret,)
+        app.use(just_next)
+        app.shortcut("test-shortcut")(just_ack)
+
+        response = app.dispatch(self.build_request())
+        assert response.status == 200
+        assert response.body == "acknowledged!"
+        assert self.mock_received_requests["/auth.test"] == 1
+
+
+def just_ack(ack):
+    ack("acknowledged!")
+
+
+def no_next():
+    pass
+
+
+def just_next(next):
+    next()


### PR DESCRIPTION
This pull request improves Bolt's error when developers forget to call `next()` method in global middleware.

With the current implementation of `App` and `AsyncApp`, the following code results in `AttributeError: 'NoneType' object has no attribute 'status'` and returns 500 Internal Server Error to the Slack API Platform.

```python
from slack_bolt import App

app = App()

@app.middleware
def run_global_filter(next):
    pass # forget to call next()

@app.shortcut("awesome-shortcut")
def handle_shortcut(ack):
    ack()
```

The following is the failure in added tests.

```
=============================================================================================== FAILURES ===============================================================================================
___________________________________________________________________________________ TestMiddleware.test_no_next_call ___________________________________________________________________________________

self = <tests.scenario_tests.test_middleware.TestMiddleware object at 0x10e225af0>

    def test_no_next_call(self):
        app = App(client=self.web_client, signing_secret=self.signing_secret,)
        app.use(no_next)
        app.shortcut("test-shortcut")(just_ack)
    
        response = app.dispatch(self.build_request())
>       assert response.status == 404
E       AttributeError: 'NoneType' object has no attribute 'status'

tests/scenario_tests/test_middleware.py:67: AttributeError
------------------------------------------------------------------------------------------ Captured log call -------------------------------------------------------------------------------------------
2020-08-30 15:39:14 DEBUG Applying slack_bolt.middleware.ssl_check.SslCheck
2020-08-30 15:39:14 DEBUG Applying slack_bolt.middleware.request_verification.RequestVerification
2020-08-30 15:39:14 DEBUG Applying slack_bolt.middleware.authorization.single_team_authorization.SingleTeamAuthorization
2020-08-30 15:39:14 DEBUG Sending a request - url: http://localhost:8888/auth.test, query_params: {}, body_params: {}, files: {}, json_body: {}, headers: {'Content-Type': 'application/json;charset=utf-8', 'Authorization': '(redacted)', 'User-Agent': 'Python/3.8.5 slackclient/3.0.0a4 Darwin/19.6.0'}
2020-08-30 15:39:14 INFO request body: None
2020-08-30 15:39:14 DEBUG Received the following response - status: 200, headers: {'Server': 'SimpleHTTP/0.6 Python/3.8.5', 'Date': 'Sun, 30 Aug 2020 06:39:14 GMT', 'content-type': 'application/json;charset=utf-8', 'connection': 'close'}, body: {'ok': True}
2020-08-30 15:39:14 DEBUG Applying slack_bolt.middleware.ignoring_self_events.IgnoringSelfEvents
2020-08-30 15:39:14 DEBUG Applying slack_bolt.middleware.url_verification.UrlVerification
2020-08-30 15:39:14 DEBUG Applying CustomMiddleware(func=no_next)
======================================================================================= short test summary info ========================================================================================
FAILED tests/scenario_tests/test_middleware.py::TestMiddleware::test_no_next_call - AttributeError: 'NoneType' object has no attribute 'status'
===================================================================================== 1 failed, 1 passed in 0.31s ======================================================================================
```

From an end-user perspective, the status code this Slack app returns to the Slack API Platform doesn't matter. However, encountering a runtime error indicating that something unexpected is happening inside the framework is quite confusing for developers. This pull aims to improve the developer experience in the case.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
