### PR TITLE
Update app.start()'s message and docstring

### DIFF
--- a/samples/app.py
+++ b/samples/app.py
@@ -20,6 +20,12 @@ def log_request(logger, payload, next):
     return next()
 
 
+@app.command("/hello-bolt-python")
+def hello_command(ack, payload):
+    user_id = payload["user_id"]
+    ack(f"Hi <@{user_id}>!")
+
+
 @app.event("app_mention")
 def event_test(payload, say, logger):
     logger.info(payload)

--- a/samples/async_app.py
+++ b/samples/async_app.py
@@ -28,8 +28,9 @@ async def event_test(payload, say, logger):
 
 @app.command("/hello-bolt-python")
 # or app.command(re.compile(r"/hello-.+"))(test_command)
-async def command(ack):
-    await ack("Thanks!")
+async def command(ack, payload):
+    user_id = payload["user_id"]
+    await ack(f"Hi <@{user_id}>!")
 
 
 if __name__ == "__main__":

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -260,10 +260,10 @@ class App:
     # standalone server
 
     def start(self, port: int = 3000, path: str = "/slack/events") -> None:
-        self.server = SlackAppServer(
+        self._development_server = SlackAppDevelopmentServer(
             port=port, path=path, app=self, oauth_flow=self.oauth_flow,
         )
-        self.server.start()
+        self._development_server.start()
 
     # -------------------------
     # main dispatcher
@@ -799,10 +799,20 @@ class App:
 # -------------------------
 
 
-class SlackAppServer:
+class SlackAppDevelopmentServer:
     def __init__(
         self, port: int, path: str, app: App, oauth_flow: Optional[OAuthFlow] = None,
     ):
+        """Slack App Development Server
+
+        This is a thin wrapper of http.server.HTTPServer and is good enough
+        for your local development or prototyping.
+
+        However, as mentioned in Python official documents, using http.server module in production
+        is not recommended. Please consider using an adapter (refer to slack_bolt.adapter.*)
+        along with a production-grade server when running the app for end users.
+        https://docs.python.org/3/library/http.server.html#http.server.HTTPServer
+        """
         self._port: int = port
         self._bolt_endpoint_path: str = path
         self._bolt_app: App = app
@@ -877,9 +887,9 @@ class SlackAppServer:
 
     def start(self):
         if self._bolt_app.logger.level > logging.INFO:
-            print("⚡️ Bolt app is running!")
+            print("⚡️ Bolt app is running! (development server)")
         else:
-            self._bolt_app.logger.info("⚡️ Bolt app is running!")
+            self._bolt_app.logger.info("⚡️ Bolt app is running! (development server)")
 
         try:
             self._server.serve_forever(0.05)

--- a/slack_bolt/app/async_server.py
+++ b/slack_bolt/app/async_server.py
@@ -10,6 +10,11 @@ class AsyncSlackAppServer:
     def __init__(
         self, port: int, path: str, app,  # AsyncApp
     ):
+        """Standalone AIOHTTP Web Server
+
+        Refer to AIOHTTP documents for details.
+        https://docs.aiohttp.org/en/stable/web.html
+        """
         self._port = port
         self._endpoint_path = path
         self._bolt_app: "AsyncApp" = app


### PR DESCRIPTION
`App#start()` uses `http.server` module for starting a web server. Using the module in production is [not recommended](https://docs.python.org/3/library/http.server.html).

> http.server is not recommended for production. It only implements basic security checks.

This pull request makes `App#start()`'s message and related comments in `App` clearer.

I think depending on a specific WSGI server just for offering a production-ready `App#start()` method is not a great idea. Some may prefer Gunicorn while others may want to use uWSGI. This product should not narrow any developers' options. Thus, implying the necessity to use a production WGSI server by having `(development server)` in the message and renaming the server implementation to `SlackAppDevelopmentServer` should be a reasonable option.

`AsyncApp#start()` starts AIOHTTP's web server. Using this in production doesn't have any issues. So, I don't apply the same changes to `AsyncApp`.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
