### PR TITLE
Fix #56 by adding aliases to payload in listener/middleware args

### DIFF
--- a/slack_bolt/kwargs_injection/args.py
+++ b/slack_bolt/kwargs_injection/args.py
@@ -1,7 +1,7 @@
 # pytype: skip-file
 import logging
 from logging import Logger
-from typing import Callable, Dict, Any
+from typing import Callable, Dict, Any, Optional
 
 from slack_bolt.context import BoltContext
 from slack_bolt.context.ack import Ack
@@ -20,10 +20,20 @@ class Args:
     request: BoltRequest
     response: BoltResponse
     context: BoltContext
+    # payload
     payload: Dict[str, Any]
+    options: Optional[Dict[str, Any]]
+    shortcut: Optional[Dict[str, Any]]
+    action: Optional[Dict[str, Any]]
+    view: Optional[Dict[str, Any]]
+    command: Optional[Dict[str, Any]]
+    event: Optional[Dict[str, Any]]
+    message: Optional[Dict[str, Any]]
+    # utilities
     ack: Ack
     say: Say
     respond: Respond
+    # middleware
     next: Callable[[], None]
 
     def __init__(
@@ -35,6 +45,13 @@ class Args:
         resp: BoltResponse,
         context: BoltContext,
         payload: Dict[str, Any],
+        options: Optional[Dict[str, Any]] = None,
+        shortcut: Optional[Dict[str, Any]] = None,
+        action: Optional[Dict[str, Any]] = None,
+        view: Optional[Dict[str, Any]] = None,
+        command: Optional[Dict[str, Any]] = None,
+        event: Optional[Dict[str, Any]] = None,
+        message: Optional[Dict[str, Any]] = None,
         ack: Ack,
         say: Say,
         respond: Respond,
@@ -46,8 +63,17 @@ class Args:
         self.request = self.req = req
         self.response = self.resp = resp
         self.context: BoltContext = context
+
         self.payload: Dict[str, Any] = payload
         self.body: Dict[str, Any] = payload
+        self.options: Optional[Dict[str, Any]] = options
+        self.shortcut: Optional[Dict[str, Any]] = shortcut
+        self.action: Optional[Dict[str, Any]] = action
+        self.view: Optional[Dict[str, Any]] = view
+        self.command: Optional[Dict[str, Any]] = command
+        self.event: Optional[Dict[str, Any]] = event
+        self.message: Optional[Dict[str, Any]] = message
+
         self.ack: Ack = ack
         self.say: Say = say
         self.respond: Respond = respond

--- a/slack_bolt/kwargs_injection/async_args.py
+++ b/slack_bolt/kwargs_injection/async_args.py
@@ -1,6 +1,6 @@
 # pytype: skip-file
 from logging import Logger
-from typing import Callable, Awaitable, Dict, Any
+from typing import Callable, Awaitable, Dict, Any, Optional
 
 from slack_bolt.context.ack.async_ack import AsyncAck
 from slack_bolt.context.async_context import AsyncBoltContext
@@ -19,10 +19,20 @@ class AsyncArgs:
     request: AsyncBoltRequest
     response: BoltResponse
     context: AsyncBoltContext
+    # payload
     payload: Dict[str, Any]
+    options: Optional[Dict[str, Any]]
+    shortcut: Optional[Dict[str, Any]]
+    action: Optional[Dict[str, Any]]
+    view: Optional[Dict[str, Any]]
+    command: Optional[Dict[str, Any]]
+    event: Optional[Dict[str, Any]]
+    message: Optional[Dict[str, Any]]
+    # utilities
     ack: AsyncAck
     say: AsyncSay
     respond: AsyncRespond
+    # middleware
     next: Callable[[], Awaitable[None]]
 
     def __init__(
@@ -34,6 +44,13 @@ class AsyncArgs:
         resp: BoltResponse,
         context: AsyncBoltContext,
         payload: Dict[str, Any],
+        options: Optional[Dict[str, Any]] = None,
+        shortcut: Optional[Dict[str, Any]] = None,
+        action: Optional[Dict[str, Any]] = None,
+        view: Optional[Dict[str, Any]] = None,
+        command: Optional[Dict[str, Any]] = None,
+        event: Optional[Dict[str, Any]] = None,
+        message: Optional[Dict[str, Any]] = None,
         ack: AsyncAck,
         say: AsyncSay,
         respond: AsyncRespond,
@@ -45,8 +62,17 @@ class AsyncArgs:
         self.request = self.req = req
         self.response = self.resp = resp
         self.context: AsyncBoltContext = context
+
         self.payload: Dict[str, Any] = payload
         self.body: Dict[str, Any] = payload
+        self.options: Optional[Dict[str, Any]] = options
+        self.shortcut: Optional[Dict[str, Any]] = shortcut
+        self.action: Optional[Dict[str, Any]] = action
+        self.view: Optional[Dict[str, Any]] = view
+        self.command: Optional[Dict[str, Any]] = command
+        self.event: Optional[Dict[str, Any]] = event
+        self.message: Optional[Dict[str, Any]] = message
+
         self.ack: AsyncAck = ack
         self.say: AsyncSay = say
         self.respond: AsyncRespond = respond

--- a/slack_bolt/kwargs_injection/async_utils.py
+++ b/slack_bolt/kwargs_injection/async_utils.py
@@ -5,6 +5,15 @@ from typing import Callable, Dict, Optional, List, Any
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 from .async_args import AsyncArgs
+from slack_bolt.util.payload_utils import (
+    to_options,
+    to_shortcut,
+    to_action,
+    to_view,
+    to_command,
+    to_event,
+    to_message,
+)
 
 
 def build_async_required_kwargs(
@@ -23,11 +32,24 @@ def build_async_required_kwargs(
         "resp": response,
         "response": response,
         "context": request.context,
+        # payload
         "payload": request.payload,
         "body": request.payload,
+        # payload
+        "payload": request.payload,
+        "body": request.payload,
+        "options": to_options(request.payload),
+        "shortcut": to_shortcut(request.payload),
+        "action": to_action(request.payload),
+        "view": to_view(request.payload),
+        "command": to_command(request.payload),
+        "event": to_event(request.payload),
+        "message": to_message(request.payload),
+        # utilities
         "ack": request.context.ack,
         "say": request.context.say,
         "respond": request.context.respond,
+        # middleware
         "next": next_func,
     }
     kwargs: Dict[str, Any] = {

--- a/slack_bolt/kwargs_injection/async_utils.py
+++ b/slack_bolt/kwargs_injection/async_utils.py
@@ -35,9 +35,6 @@ def build_async_required_kwargs(
         # payload
         "payload": request.payload,
         "body": request.payload,
-        # payload
-        "payload": request.payload,
-        "body": request.payload,
         "options": to_options(request.payload),
         "shortcut": to_shortcut(request.payload),
         "action": to_action(request.payload),

--- a/slack_bolt/kwargs_injection/utils.py
+++ b/slack_bolt/kwargs_injection/utils.py
@@ -5,6 +5,15 @@ from typing import Callable, Dict, Optional, List, Any
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 from .args import Args
+from slack_bolt.util.payload_utils import (
+    to_options,
+    to_shortcut,
+    to_action,
+    to_view,
+    to_command,
+    to_event,
+    to_message,
+)
 
 
 def build_required_kwargs(
@@ -23,11 +32,21 @@ def build_required_kwargs(
         "resp": response,
         "response": response,
         "context": request.context,
+        # payload
         "payload": request.payload,
         "body": request.payload,
+        "options": to_options(request.payload),
+        "shortcut": to_shortcut(request.payload),
+        "action": to_action(request.payload),
+        "view": to_view(request.payload),
+        "command": to_command(request.payload),
+        "event": to_event(request.payload),
+        "message": to_message(request.payload),
+        # utilities
         "ack": request.context.ack,
         "say": request.context.say,
         "respond": request.context.respond,
+        # middleware
         "next": next_func,
     }
     kwargs: Dict[str, Any] = {

--- a/slack_bolt/util/payload_utils.py
+++ b/slack_bolt/util/payload_utils.py
@@ -1,0 +1,210 @@
+from typing import Dict, Any, Optional
+
+
+# ------------------------------------------
+# Public Utilities
+# ------------------------------------------
+
+# -------------------
+# Events API
+# -------------------
+
+
+def to_event(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    return payload["event"] if is_event(payload) else None
+
+
+def to_message(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if is_event(payload) and payload["event"]["type"] == "message":
+        return to_event(payload)
+    return None
+
+
+def is_event(payload: Dict[str, Any]) -> bool:
+    return (
+        payload is not None
+        and _is_expected_type(payload, "event_callback")
+        and "event" in payload
+        and "type" in payload["event"]
+    )
+
+
+# -------------------
+# Slash Commands
+# -------------------
+
+
+def to_command(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    return payload if is_slash_command(payload) else None
+
+
+def is_slash_command(payload: Dict[str, Any]) -> bool:
+    return payload is not None and "command" in payload
+
+
+# -------------------
+# Actions
+# -------------------
+
+
+def to_action(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if is_action(payload):
+        if is_block_actions(payload):
+            return payload["actions"][0]
+        else:
+            return payload
+    return None
+
+
+def is_action(payload: Dict[str, Any]) -> bool:
+    return (
+        is_attachment_action(payload)
+        or is_block_actions(payload)
+        or is_dialog_submission(payload)
+        or is_dialog_cancellation(payload)
+        or is_workflow_step_edit(payload)
+    )
+
+
+def is_attachment_action(payload: Dict[str, Any]) -> bool:
+    return (
+        payload is not None
+        and _is_expected_type(payload, "interactive_message")
+        and "callback_id" in payload
+    )
+
+
+def is_block_actions(payload: Dict[str, Any]) -> bool:
+    return (
+        payload is not None
+        and _is_expected_type(payload, "block_actions")
+        and "actions" in payload
+    )
+
+
+def is_dialog_submission(payload: Dict[str, Any]) -> bool:
+    return (
+        payload is not None
+        and _is_expected_type(payload, "dialog_submission")
+        and "callback_id" in payload
+    )
+
+
+def is_dialog_cancellation(payload: Dict[str, Any]) -> bool:
+    return (
+        payload is not None
+        and _is_expected_type(payload, "dialog_cancellation")
+        and "callback_id" in payload
+    )
+
+
+def is_workflow_step_edit(payload: Dict[str, Any]) -> bool:
+    return (
+        payload is not None
+        and _is_expected_type(payload, "workflow_step_edit")
+        and "callback_id" in payload
+    )
+
+
+# -------------------
+# Options
+# -------------------
+
+
+def to_options(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if is_options(payload):
+        return payload
+    return None
+
+
+def is_options(payload: Dict[str, Any]) -> bool:
+    return is_block_suggestion(payload) or is_dialog_suggestion(payload)
+
+
+def is_block_suggestion(payload: Dict[str, Any]) -> bool:
+    return (
+        payload is not None
+        and _is_expected_type(payload, "block_suggestion")
+        and "action_id" in payload
+    )
+
+
+def is_dialog_suggestion(payload: Dict[str, Any]) -> bool:
+    return (
+        payload is not None
+        and _is_expected_type(payload, "dialog_suggestion")
+        and "callback_id" in payload
+    )
+
+
+# -------------------
+# Shortcut
+# -------------------
+
+
+def to_shortcut(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if is_shortcut(payload):
+        return payload
+    return None
+
+
+def is_shortcut(payload: Dict[str, Any]) -> bool:
+    return is_global_shortcut(payload) or is_message_shortcut(payload)
+
+
+def is_global_shortcut(payload: Dict[str, Any]) -> bool:
+    return (
+        payload is not None
+        and _is_expected_type(payload, "shortcut")
+        and "callback_id" in payload
+    )
+
+
+def is_message_shortcut(payload: Dict[str, Any]) -> bool:
+    return (
+        payload is not None
+        and _is_expected_type(payload, "message_action")
+        and "callback_id" in payload
+    )
+
+
+# -------------------
+# View
+# -------------------
+
+
+def to_view(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if is_view(payload):
+        return payload["view"]
+    return None
+
+
+def is_view(payload: Dict[str, Any]) -> bool:
+    return is_view_submission(payload) or is_view_closed(payload)
+
+
+def is_view_submission(payload: Dict[str, Any]) -> bool:
+    return (
+        payload is not None
+        and _is_expected_type(payload, "view_submission")
+        and "view" in payload
+        and "callback_id" in payload["view"]
+    )
+
+
+def is_view_closed(payload: Dict[str, Any]) -> bool:
+    return (
+        payload is not None
+        and _is_expected_type(payload, "view_closed")
+        and "view" in payload
+        and "callback_id" in payload["view"]
+    )
+
+
+# ------------------------------------------
+# Internal Utilities
+# ------------------------------------------
+
+
+def _is_expected_type(payload: dict, expected: str) -> bool:
+    return payload is not None and "type" in payload and payload["type"] == expected

--- a/tests/async_scenario_tests/test_attachment_actions.py
+++ b/tests/async_scenario_tests/test_attachment_actions.py
@@ -191,6 +191,7 @@ payload = {
 raw_body = f"payload={quote(json.dumps(payload))}"
 
 
-async def simple_listener(ack, body):
+async def simple_listener(ack, body, action):
+    assert body == action
     assert body["trigger_id"] == "111.222.valid"
     await ack()

--- a/tests/async_scenario_tests/test_block_actions.py
+++ b/tests/async_scenario_tests/test_block_actions.py
@@ -173,6 +173,8 @@ payload = {
 raw_body = f"payload={quote(json.dumps(payload))}"
 
 
-async def simple_listener(ack, body):
+async def simple_listener(ack, body, action):
     assert body["trigger_id"] == "111.222.valid"
+    assert body["actions"][0] == action
+    assert action["action_id"] == "a"
     await ack()

--- a/tests/async_scenario_tests/test_block_suggestion.py
+++ b/tests/async_scenario_tests/test_block_suggestion.py
@@ -278,9 +278,11 @@ multi_response = {
 expected_multi_response_body = json.dumps(multi_response)
 
 
-async def show_options(ack):
+async def show_options(ack, body, options):
+    assert body == options
     await ack(response)
 
 
-async def show_multi_options(ack):
+async def show_multi_options(ack, body, options):
+    assert body == options
     await ack(multi_response)

--- a/tests/async_scenario_tests/test_dialogs.py
+++ b/tests/async_scenario_tests/test_dialogs.py
@@ -343,9 +343,11 @@ options_response = {
 }
 
 
-async def handle_suggestion(ack):
+async def handle_suggestion(ack, body, options):
+    assert body == options
     await ack(options_response)
 
 
-async def handle_cancellation(ack):
+async def handle_cancellation(ack, body, action):
+    assert body == action
     await ack()

--- a/tests/async_scenario_tests/test_events.py
+++ b/tests/async_scenario_tests/test_events.py
@@ -136,15 +136,17 @@ app_mention_payload = {
 }
 
 
-async def random_sleeper(payload, say):
+async def random_sleeper(payload, say, event):
     assert payload == app_mention_payload
+    assert payload["event"] == event
     seconds = random() + 2  # 2-3 seconds
     await asyncio.sleep(seconds)
     await say(f"Sending this message after sleeping for {seconds} seconds")
 
 
-async def whats_up(payload, say):
+async def whats_up(payload, say, event):
     assert payload == app_mention_payload
+    assert payload["event"] == event
     await say("What's up?")
 
 

--- a/tests/async_scenario_tests/test_shortcut.py
+++ b/tests/async_scenario_tests/test_shortcut.py
@@ -235,5 +235,6 @@ global_shortcut_raw_body = f"payload={quote(json.dumps(global_shortcut_payload))
 message_shortcut_raw_body = f"payload={quote(json.dumps(message_shortcut_payload))}"
 
 
-async def simple_listener(ack):
+async def simple_listener(ack, body, shortcut):
+    assert body == shortcut
     await ack()

--- a/tests/async_scenario_tests/test_slash_command.py
+++ b/tests/async_scenario_tests/test_slash_command.py
@@ -110,5 +110,6 @@ slash_command_payload = (
 )
 
 
-async def commander(ack):
+async def commander(ack, body, command):
+    assert body == command
     await ack()

--- a/tests/async_scenario_tests/test_view_closed.py
+++ b/tests/async_scenario_tests/test_view_closed.py
@@ -183,6 +183,7 @@ payload = {
 raw_body = f"payload={quote(json.dumps(payload))}"
 
 
-async def simple_listener(ack, body):
-    assert body["view"]["private_metadata"] == "This is for you!"
+async def simple_listener(ack, body, view):
+    assert body["view"] == view
+    assert view["private_metadata"] == "This is for you!"
     await ack()

--- a/tests/async_scenario_tests/test_view_submission.py
+++ b/tests/async_scenario_tests/test_view_submission.py
@@ -173,7 +173,8 @@ payload = {
 raw_body = f"payload={quote(json.dumps(payload))}"
 
 
-async def simple_listener(ack, body):
+async def simple_listener(ack, body, view):
     assert body["trigger_id"] == "111.222.valid"
-    assert body["view"]["private_metadata"] == "This is for you!"
+    assert body["view"] == view
+    assert view["private_metadata"] == "This is for you!"
     await ack()

--- a/tests/scenario_tests/test_attachment_actions.py
+++ b/tests/scenario_tests/test_attachment_actions.py
@@ -165,6 +165,7 @@ payload = {
 raw_body = f"payload={quote(json.dumps(payload))}"
 
 
-def simple_listener(ack, body):
+def simple_listener(ack, body, action):
+    assert body == action
     assert body["trigger_id"] == "111.222.valid"
     ack()

--- a/tests/scenario_tests/test_block_actions.py
+++ b/tests/scenario_tests/test_block_actions.py
@@ -147,6 +147,8 @@ payload = {
 raw_body = f"payload={quote(json.dumps(payload))}"
 
 
-def simple_listener(ack, body):
+def simple_listener(ack, body, action):
     assert body["trigger_id"] == "111.222.valid"
+    assert body["actions"][0] == action
+    assert action["action_id"] == "a"
     ack()

--- a/tests/scenario_tests/test_block_suggestion.py
+++ b/tests/scenario_tests/test_block_suggestion.py
@@ -263,9 +263,11 @@ multi_response = {
 expected_multi_response_body = json.dumps(multi_response)
 
 
-def show_options(ack):
+def show_options(ack, body, options):
+    assert body == options
     ack(response)
 
 
-def show_multi_options(ack):
+def show_multi_options(ack, body, options):
+    assert body == options
     ack(multi_response)

--- a/tests/scenario_tests/test_dialogs.py
+++ b/tests/scenario_tests/test_dialogs.py
@@ -326,9 +326,11 @@ options_response = {
 }
 
 
-def handle_suggestion(ack):
+def handle_suggestion(ack, body, options):
+    assert body == options
     ack(options_response)
 
 
-def handle_cancellation(ack):
+def handle_cancellation(ack, body, action):
+    assert body == action
     ack()

--- a/tests/scenario_tests/test_events.py
+++ b/tests/scenario_tests/test_events.py
@@ -68,8 +68,9 @@ class TestEvents:
         app = App(client=self.web_client, signing_secret=self.signing_secret)
 
         @app.event("app_mention")
-        def handle_app_mention(payload, say):
+        def handle_app_mention(payload, say, event):
             assert payload == self.valid_event_payload
+            assert payload["event"] == event
             say("What's up?")
 
         timestamp, body = str(int(time())), json.dumps(self.valid_event_payload)
@@ -90,7 +91,8 @@ class TestEvents:
             pass
 
         @app.event("app_mention", middleware=[skip_middleware])
-        def handle_app_mention(payload, logger):
+        def handle_app_mention(payload, logger, event):
+            assert payload["event"] == event
             logger.info(payload)
 
         timestamp, body = str(int(time())), json.dumps(self.valid_event_payload)

--- a/tests/scenario_tests/test_message.py
+++ b/tests/scenario_tests/test_message.py
@@ -177,7 +177,8 @@ message_payload2 = {
 }
 
 
-def verify_matches(context, say):
+def verify_matches(context, say, body, message):
     assert context["matches"] == ("103", "you")
     assert context.matches == ("103", "you")
+    assert body["event"] == message
     say("Thanks!")

--- a/tests/scenario_tests/test_shortcut.py
+++ b/tests/scenario_tests/test_shortcut.py
@@ -220,5 +220,6 @@ global_shortcut_raw_body = f"payload={quote(json.dumps(global_shortcut_payload))
 message_shortcut_raw_body = f"payload={quote(json.dumps(message_shortcut_payload))}"
 
 
-def simple_listener(ack):
+def simple_listener(ack, body, shortcut):
+    assert body == shortcut
     ack()

--- a/tests/scenario_tests/test_slash_command.py
+++ b/tests/scenario_tests/test_slash_command.py
@@ -100,5 +100,6 @@ slash_command_payload = (
 )
 
 
-def commander(ack):
+def commander(ack, body, command):
+    assert body == command
     ack()

--- a/tests/scenario_tests/test_view_closed.py
+++ b/tests/scenario_tests/test_view_closed.py
@@ -170,6 +170,7 @@ payload = {
 raw_body = f"payload={quote(json.dumps(payload))}"
 
 
-def simple_listener(ack, body):
-    assert body["view"]["private_metadata"] == "This is for you!"
+def simple_listener(ack, body, view):
+    assert body["view"] == view
+    assert view["private_metadata"] == "This is for you!"
     ack()

--- a/tests/scenario_tests/test_view_submission.py
+++ b/tests/scenario_tests/test_view_submission.py
@@ -161,7 +161,8 @@ payload = {
 raw_body = f"payload={quote(json.dumps(payload))}"
 
 
-def simple_listener(ack, body):
+def simple_listener(ack, body, view):
     assert body["trigger_id"] == "111.222.valid"
-    assert body["view"]["private_metadata"] == "This is for you!"
+    assert body["view"] == view
+    assert view["private_metadata"] == "This is for you!"
     ack()


### PR DESCRIPTION
This pull request fixes #56 by adding `options`, `action`, `shortcut`, and so on to listener/middleware arguments.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
