### PR TITLE
Fix #61 by correcting payload in middleware/listener args

### DIFF
--- a/samples/app.py
+++ b/samples/app.py
@@ -15,27 +15,27 @@ app = App()
 
 
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.debug(payload)
+def log_request(logger, body, next):
+    logger.debug(body)
     return next()
 
 
 @app.command("/hello-bolt-python")
-def hello_command(ack, payload):
-    user_id = payload["user_id"]
+def hello_command(ack, body):
+    user_id = body["user_id"]
     ack(f"Hi <@{user_id}>!")
 
 
 @app.event("app_mention")
-def event_test(payload, say, logger):
-    logger.info(payload)
+def event_test(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 
 @app.error
-def global_error_handler(error, payload, logger):
+def global_error_handler(error, body, logger):
     logger.exception(error)
-    logger.info(payload)
+    logger.info(body)
 
 
 if __name__ == "__main__":

--- a/samples/async_app.py
+++ b/samples/async_app.py
@@ -15,21 +15,21 @@ app = AsyncApp()
 
 
 @app.middleware  # or app.use(log_request)
-async def log_request(logger, payload, next):
-    logger.debug(payload)
+async def log_request(logger, body, next):
+    logger.debug(body)
     return await next()
 
 
 @app.event("app_mention")
-async def event_test(payload, say, logger):
-    logger.info(payload)
+async def event_test(body, say, logger):
+    logger.info(body)
     await say("What's up?")
 
 
 @app.command("/hello-bolt-python")
 # or app.command(re.compile(r"/hello-.+"))(test_command)
-async def command(ack, payload):
-    user_id = payload["user_id"]
+async def command(ack, body):
+    user_id = body["user_id"]
     await ack(f"Hi <@{user_id}>!")
 
 

--- a/samples/async_steps_from_apps.py
+++ b/samples/async_steps_from_apps.py
@@ -19,6 +19,7 @@ app = AsyncApp()
 
 # https://api.slack.com/tutorials/workflow-builder-steps
 
+
 @app.action({"type": "workflow_step_edit", "callback_id": "copy_review"})
 async def edit(body: dict, ack: AsyncAck, client: AsyncWebClient):
     await ack()
@@ -33,8 +34,8 @@ async def edit(body: dict, ack: AsyncAck, client: AsyncWebClient):
                     "block_id": "intro-section",
                     "text": {
                         "type": "plain_text",
-                        "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps."
-                    }
+                        "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps.",
+                    },
                 },
                 {
                     "type": "input",
@@ -44,13 +45,10 @@ async def edit(body: dict, ack: AsyncAck, client: AsyncWebClient):
                         "action_id": "task_name",
                         "placeholder": {
                             "type": "plain_text",
-                            "text": "Write a task name"
-                        }
+                            "text": "Write a task name",
+                        },
                     },
-                    "label": {
-                        "type": "plain_text",
-                        "text": "Task name"
-                    }
+                    "label": {"type": "plain_text", "text": "Task name"},
                 },
                 {
                     "type": "input",
@@ -60,13 +58,10 @@ async def edit(body: dict, ack: AsyncAck, client: AsyncWebClient):
                         "action_id": "task_description",
                         "placeholder": {
                             "type": "plain_text",
-                            "text": "Write a description for your task"
-                        }
+                            "text": "Write a description for your task",
+                        },
                     },
-                    "label": {
-                        "type": "plain_text",
-                        "text": "Task description"
-                    }
+                    "label": {"type": "plain_text", "text": "Task description"},
                 },
                 {
                     "type": "input",
@@ -76,15 +71,12 @@ async def edit(body: dict, ack: AsyncAck, client: AsyncWebClient):
                         "action_id": "task_author",
                         "placeholder": {
                             "type": "plain_text",
-                            "text": "Write a task name"
-                        }
+                            "text": "Write a task name",
+                        },
                     },
-                    "label": {
-                        "type": "plain_text",
-                        "text": "Task author"
-                    }
+                    "label": {"type": "plain_text", "text": "Task author"},
                 },
-            ]
+            ],
         },
     )
 
@@ -101,18 +93,16 @@ async def save(ack: AsyncAck, client: AsyncWebClient, body: dict):
                     "value": state_values["task_name_input"]["task_name"]["value"],
                 },
                 "taskDescription": {
-                    "value": state_values["task_description_input"]["task_description"]["value"],
+                    "value": state_values["task_description_input"]["task_description"][
+                        "value"
+                    ],
                 },
                 "taskAuthorEmail": {
                     "value": state_values["task_author_input"]["task_author"]["value"],
-                }
+                },
             },
             "outputs": [
-                {
-                    "name": "taskName",
-                    "type": "text",
-                    "label": "Task Name",
-                },
+                {"name": "taskName", "type": "text", "label": "Task Name",},
                 {
                     "name": "taskDescription",
                     "type": "text",
@@ -123,8 +113,8 @@ async def save(ack: AsyncAck, client: AsyncWebClient, body: dict):
                     "type": "text",
                     "label": "Task Author Email",
                 },
-            ]
-        }
+            ],
+        },
     )
     await ack()
 
@@ -143,10 +133,12 @@ async def execute(body: dict, client: AsyncWebClient):
                 "taskName": step["inputs"]["taskName"]["value"],
                 "taskDescription": step["inputs"]["taskDescription"]["value"],
                 "taskAuthorEmail": step["inputs"]["taskAuthorEmail"]["value"],
-            }
-        }
+            },
+        },
     )
-    user: AsyncSlackResponse = await client.users_lookupByEmail(email=step["inputs"]["taskAuthorEmail"]["value"])
+    user: AsyncSlackResponse = await client.users_lookupByEmail(
+        email=step["inputs"]["taskAuthorEmail"]["value"]
+    )
     user_id = user["user"]["id"]
     new_task = {
         "task_name": step["inputs"]["taskName"]["value"],
@@ -158,19 +150,21 @@ async def execute(body: dict, client: AsyncWebClient):
 
     blocks = []
     for task in tasks:
-        blocks.append({"type": "section", "text": {"type": "plain_text", "text": task["task_name"]}})
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "plain_text", "text": task["task_name"]},
+            }
+        )
         blocks.append({"type": "divider"})
 
     home_tab_update: AsyncSlackResponse = await client.views_publish(
         user_id=user_id,
         view={
             "type": "home",
-            "title": {
-                "type": 'plain_text',
-                "text": 'Your tasks!'
-            },
-            "blocks": blocks
-        }
+            "title": {"type": "plain_text", "text": "Your tasks!"},
+            "blocks": blocks,
+        },
     )
 
 

--- a/samples/aws_chalice/app.py
+++ b/samples/aws_chalice/app.py
@@ -10,8 +10,8 @@ bolt_app = App(process_before_response=True, authorization_test_enabled=False,)
 
 
 @bolt_app.event("app_mention")
-def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+def handle_app_mentions(body, say, logger):
+    logger.info(body)
     say("What's up? I'm a Chalice app :wave:")
 
 

--- a/samples/aws_chalice/oauth_app.py
+++ b/samples/aws_chalice/oauth_app.py
@@ -18,8 +18,8 @@ bolt_app = App(
 
 
 @bolt_app.event("app_mention")
-def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+def handle_app_mentions(body, say, logger):
+    logger.info(body)
     say("What's up? I'm a Chalice app :wave:")
 
 

--- a/samples/aws_chalice/simple_app.py
+++ b/samples/aws_chalice/simple_app.py
@@ -10,8 +10,8 @@ bolt_app = App(process_before_response=True, authorization_test_enabled=False,)
 
 
 @bolt_app.event("app_mention")
-def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+def handle_app_mentions(body, say, logger):
+    logger.info(body)
     say("What's up? I'm a Chalice app :wave:")
 
 

--- a/samples/aws_lambda/aws_lambda.py
+++ b/samples/aws_lambda/aws_lambda.py
@@ -15,8 +15,8 @@ app = App(process_before_response=True)
 
 
 @app.event("app_mention")
-def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+def handle_app_mentions(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/aws_lambda/aws_lambda_oauth.py
+++ b/samples/aws_lambda/aws_lambda_oauth.py
@@ -16,8 +16,8 @@ app = App(process_before_response=True, oauth_flow=LambdaS3OAuthFlow(),)
 
 
 @app.event("app_mention")
-def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+def handle_app_mentions(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/aws_lambda/lazy_aws_lambda.py
+++ b/samples/aws_lambda/lazy_aws_lambda.py
@@ -16,25 +16,25 @@ app = App(process_before_response=True)
 
 
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.debug(payload)
+def log_request(logger, body, next):
+    logger.debug(body)
     return next()
 
 
 command = "/hello-bolt-python-lambda"
 
 
-def respond_to_slack_within_3_seconds(payload, ack):
-    if payload.get("text", None) is None:
+def respond_to_slack_within_3_seconds(body, ack):
+    if body.get("text", None) is None:
         ack(f":x: Usage: {command} (description here)")
     else:
-        title = payload["text"]
+        title = body["text"]
         ack(f"Accepted! (task: {title})")
 
 
-def process_request(respond, payload):
+def process_request(respond, body):
     time.sleep(5)
-    title = payload["text"]
+    title = body["text"]
     respond(f"Completed! (task: {title})")
 
 

--- a/samples/bottle/app.py
+++ b/samples/bottle/app.py
@@ -16,14 +16,14 @@ app = App()
 
 
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.debug(payload)
+def log_request(logger, body, next):
+    logger.debug(body)
     return next()
 
 
 @app.event("app_mention")
-def event_test(ack, payload, say, logger):
-    logger.info(payload)
+def event_test(ack, body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/bottle/oauth_app.py
+++ b/samples/bottle/oauth_app.py
@@ -14,14 +14,14 @@ app = App()
 
 
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.debug(payload)
+def log_request(logger, body, next):
+    logger.debug(body)
     return next()
 
 
 @app.event("app_mention")
-def event_test(ack, payload, say, logger):
-    logger.info(payload)
+def event_test(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/cherrypy/app.py
+++ b/samples/cherrypy/app.py
@@ -16,8 +16,8 @@ app = App()
 
 
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.debug(payload)
+def log_request(logger, body, next):
+    logger.debug(body)
     return next()
 
 
@@ -27,8 +27,8 @@ def hello_command(ack):
 
 
 @app.event("app_mention")
-def event_test(payload, say, logger):
-    logger.info(payload)
+def event_test(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/cherrypy/oauth_app.py
+++ b/samples/cherrypy/oauth_app.py
@@ -14,8 +14,8 @@ app = App()
 
 
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.debug(payload)
+def log_request(logger, body, next):
+    logger.debug(body)
     return next()
 
 
@@ -25,8 +25,8 @@ def hello_command(ack):
 
 
 @app.event("app_mention")
-def event_test(payload, say, logger):
-    logger.info(payload)
+def event_test(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/dialogs_app.py
+++ b/samples/dialogs_app.py
@@ -15,17 +15,17 @@ app = App()
 
 
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.debug(payload)
+def log_request(logger, body, next):
+    logger.debug(body)
     return next()
 
 
 @app.command("/hello-bolt-python")
-def test_command(payload, client, ack, logger):
-    logger.info(payload)
+def test_command(body, client, ack, logger):
+    logger.info(body)
     ack("I got it!")
     res = client.dialog_open(
-        trigger_id=payload["trigger_id"],
+        trigger_id=body["trigger_id"],
         dialog={
             "callback_id": "dialog-callback-id",
             "title": "Request a Ride",

--- a/samples/django/slackapp/slackapp/views.py
+++ b/samples/django/slackapp/slackapp/views.py
@@ -8,8 +8,8 @@ app = App()
 
 
 @app.event("app_mention")
-def event_test(ack, payload, say, logger):
-    logger.info(payload)
+def event_test(ack, body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/docker/aiohttp/main.py
+++ b/samples/docker/aiohttp/main.py
@@ -8,8 +8,8 @@ app = AsyncApp()
 
 
 @app.command("/hello-bolt-python")
-async def hello(payload, ack):
-    user_id = payload["user_id"]
+async def hello(body, ack):
+    user_id = body["user_id"]
     await ack(f"Hi <@{user_id}>!")
 
 

--- a/samples/docker/fastapi-gunicorn/main.py
+++ b/samples/docker/fastapi-gunicorn/main.py
@@ -7,8 +7,8 @@ app = AsyncApp()
 
 
 @app.command("/hello-bolt-python")
-async def hello(payload, ack):
-    user_id = payload["user_id"]
+async def hello(body, ack):
+    user_id = body["user_id"]
     await ack(f"Hi <@{user_id}>!")
 
 

--- a/samples/docker/flask-gunicorn/main.py
+++ b/samples/docker/flask-gunicorn/main.py
@@ -7,8 +7,8 @@ app = App()
 
 
 @app.command("/hello-bolt-python")
-def hello(payload, ack):
-    user_id = payload["user_id"]
+def hello(body, ack):
+    user_id = body["user_id"]
     ack(f"Hi <@{user_id}>!")
 
 

--- a/samples/docker/flask-uwsgi/main.py
+++ b/samples/docker/flask-uwsgi/main.py
@@ -7,8 +7,8 @@ app = App()
 
 
 @app.command("/hello-bolt-python")
-def hello(payload, ack):
-    user_id = payload["user_id"]
+def hello(body, ack):
+    user_id = body["user_id"]
     ack(f"Hi <@{user_id}>!")
 
 

--- a/samples/docker/sanic/main.py
+++ b/samples/docker/sanic/main.py
@@ -10,8 +10,8 @@ app_handler = AsyncSlackRequestHandler(app)
 
 
 @app.command("/hello-bolt-python")
-async def hello(payload, ack):
-    user_id = payload["user_id"]
+async def hello(body, ack):
+    user_id = body["user_id"]
     await ack(f"Hi <@{user_id}>!")
 
 

--- a/samples/events_app.py
+++ b/samples/events_app.py
@@ -16,25 +16,25 @@ app = App()
 
 
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.debug(payload)
+def log_request(logger, body, next):
+    logger.debug(body)
     return next()
 
 
 @app.event("app_mention")
-def event_test(payload, say, logger):
-    logger.info(payload)
+def event_test(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 
 @app.message("test")
-def test_message(logger, payload):
-    logger.info(payload)
+def test_message(logger, body):
+    logger.info(body)
 
 
 @app.message(re.compile("bug"))
-def mention_bug(logger, payload):
-    logger.info(payload)
+def mention_bug(logger, body):
+    logger.info(body)
 
 
 if __name__ == "__main__":

--- a/samples/falcon/app.py
+++ b/samples/falcon/app.py
@@ -16,9 +16,9 @@ logging.basicConfig(level=logging.DEBUG)
 app = App()
 
 
-# @app.command("/bolt-py-proto", [lambda payload: payload["team_id"] == "T03E94MJU"])
-def test_command(logger: logging.Logger, payload: dict, ack: Ack, respond: Respond):
-    logger.info(payload)
+# @app.command("/bolt-py-proto", [lambda body: body["team_id"] == "T03E94MJU"])
+def test_command(logger: logging.Logger, body: dict, ack: Ack, respond: Respond):
+    logger.info(body)
     ack("thanks!")
     respond(
         blocks=[
@@ -40,15 +40,15 @@ def test_command(logger: logging.Logger, payload: dict, ack: Ack, respond: Respo
     )
 
 
-app.command(re.compile(r"/bolt-.+"))(test_command)
+app.command(re.compile(r"/hello-bolt-.+"))(test_command)
 
 
 @app.shortcut("test-shortcut")
-def test_shortcut(ack, client: WebClient, logger, payload):
-    logger.info(payload)
+def test_shortcut(ack, client: WebClient, logger, body):
+    logger.info(body)
     ack()
     res = client.views_open(
-        trigger_id=payload["trigger_id"],
+        trigger_id=body["trigger_id"],
         view={
             "type": "modal",
             "callback_id": "view-id",
@@ -68,22 +68,21 @@ def test_shortcut(ack, client: WebClient, logger, payload):
 
 
 @app.view("view-id")
-def view_submission(ack, payload, logger):
-    logger.info(payload)
+def view_submission(ack, body, logger):
+    logger.info(body)
     ack()
 
 
 @app.action("a")
-def button_click(logger, payload, say, ack, respond):
-    logger.info(payload)
+def button_click(logger, action, ack, respond):
+    logger.info(action)
     ack()
-    respond("respond!")
-    # say(text="say!")
+    respond("Here is my response")
 
 
 @app.event("app_mention")
-def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+def handle_app_mentions(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/falcon/oauth_app.py
+++ b/samples/falcon/oauth_app.py
@@ -16,9 +16,9 @@ logging.basicConfig(level=logging.DEBUG)
 app = App()
 
 
-# @app.command("/bolt-py-proto", [lambda payload: payload["team_id"] == "T03E94MJU"])
-def test_command(logger: logging.Logger, payload: dict, ack: Ack, respond: Respond):
-    logger.info(payload)
+# @app.command("/bolt-py-proto", [lambda body: body["team_id"] == "T03E94MJU"])
+def test_command(logger: logging.Logger, body: dict, ack: Ack, respond: Respond):
+    logger.info(body)
     ack("thanks!")
     respond(
         blocks=[
@@ -40,15 +40,15 @@ def test_command(logger: logging.Logger, payload: dict, ack: Ack, respond: Respo
     )
 
 
-app.command(re.compile(r"/bolt-.+"))(test_command)
+app.command(re.compile(r"/hello-bolt-.+"))(test_command)
 
 
 @app.shortcut("test-shortcut")
-def test_shortcut(ack, client: WebClient, logger, payload):
-    logger.info(payload)
+def test_shortcut(ack, client: WebClient, logger, body):
+    logger.info(body)
     ack()
     res = client.views_open(
-        trigger_id=payload["trigger_id"],
+        trigger_id=body["trigger_id"],
         view={
             "type": "modal",
             "callback_id": "view-id",
@@ -68,22 +68,22 @@ def test_shortcut(ack, client: WebClient, logger, payload):
 
 
 @app.view("view-id")
-def view_submission(ack, payload, logger):
-    logger.info(payload)
+def view_submission(ack, body, logger):
+    logger.info(body)
     ack()
 
 
 @app.action("a")
-def button_click(logger, payload, say, ack, respond):
-    logger.info(payload)
+def button_click(logger, action, ack, respond):
+    logger.info(action)
     ack()
-    respond("respond!")
+    respond("Here is my response.")
     # say(text="say!")
 
 
 @app.event("app_mention")
-def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+def handle_app_mentions(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/fastapi/app.py
+++ b/samples/fastapi/app.py
@@ -13,9 +13,14 @@ app_handler = SlackRequestHandler(app)
 
 
 @app.event("app_mention")
-def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+def handle_app_mentions(body, say, logger):
+    logger.info(body)
     say("What's up?")
+
+
+@app.event("message")
+def handle_message():
+    pass
 
 
 from fastapi import FastAPI, Request
@@ -31,4 +36,4 @@ async def endpoint(req: Request):
 # pip install -r requirements.txt
 # export SLACK_SIGNING_SECRET=***
 # export SLACK_BOT_TOKEN=xoxb-***
-# uvicorn app:api --reload --port 3000 --log-level debug
+# uvicorn app:api --reload --port 3000 --log-level warning

--- a/samples/fastapi/async_app.py
+++ b/samples/fastapi/async_app.py
@@ -5,6 +5,10 @@ import sys
 sys.path.insert(1, "../..")
 # ------------------------------------------------
 
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
 from slack_bolt.async_app import AsyncApp
 from slack_bolt.adapter.fastapi.async_handler import AsyncSlackRequestHandler
 
@@ -13,9 +17,14 @@ app_handler = AsyncSlackRequestHandler(app)
 
 
 @app.event("app_mention")
-async def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+async def handle_app_mentions(body, say, logger):
+    logger.info(body)
     await say("What's up?")
+
+
+@app.event("message")
+async def handle_message():
+    pass
 
 
 from fastapi import FastAPI, Request
@@ -31,4 +40,4 @@ async def endpoint(req: Request):
 # pip install -r requirements.txt
 # export SLACK_SIGNING_SECRET=***
 # export SLACK_BOT_TOKEN=xoxb-***
-# uvicorn async_app:api --reload --port 3000 --log-level debug
+# uvicorn async_app:api --reload --port 3000 --log-level warning

--- a/samples/fastapi/async_oauth_app.py
+++ b/samples/fastapi/async_oauth_app.py
@@ -13,9 +13,14 @@ app_handler = AsyncSlackRequestHandler(app)
 
 
 @app.event("app_mention")
-async def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+async def handle_app_mentions(body, say, logger):
+    logger.info(body)
     await say("What's up?")
+
+
+@app.event("message")
+async def handle_message():
+    pass
 
 
 from fastapi import FastAPI, Request

--- a/samples/fastapi/oauth_app.py
+++ b/samples/fastapi/oauth_app.py
@@ -13,9 +13,14 @@ app_handler = SlackRequestHandler(app)
 
 
 @app.event("app_mention")
-def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+def handle_app_mentions(body, say, logger):
+    logger.info(body)
     say("What's up?")
+
+
+@app.event("message")
+async def handle_message():
+    pass
 
 
 from fastapi import FastAPI, Request
@@ -46,4 +51,4 @@ async def oauth_redirect(req: Request):
 # export SLACK_CLIENT_SECRET=***
 # export SLACK_SCOPES=app_mentions:read,channels:history,im:history,chat:write
 
-# uvicorn oauth_app:api --reload --port 3000 --log-level debug
+# uvicorn oauth_app:api --reload --port 3000 --log-level warning

--- a/samples/flask/app.py
+++ b/samples/flask/app.py
@@ -16,15 +16,20 @@ app = App()
 
 
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.debug(payload)
+def log_request(logger, body, next):
+    logger.debug(body)
     return next()
 
 
 @app.event("app_mention")
-def event_test(ack, payload, say, logger):
-    logger.info(payload)
+def event_test(body, say, logger):
+    logger.info(body)
     say("What's up?")
+
+
+@app.event("message")
+def handle_message():
+    pass
 
 
 from flask import Flask, request

--- a/samples/flask/oauth_app.py
+++ b/samples/flask/oauth_app.py
@@ -14,15 +14,20 @@ app = App()
 
 
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.debug(payload)
+def log_request(logger, body, next):
+    logger.debug(body)
     return next()
 
 
 @app.event("app_mention")
-def event_test(ack, payload, say, logger):
-    logger.info(payload)
+def event_test(body, say, logger):
+    logger.info(body)
     say("What's up?")
+
+
+@app.event("message")
+def handle_message():
+    pass
 
 
 from flask import Flask, request

--- a/samples/google_app_engine/flask/main.py
+++ b/samples/google_app_engine/flask/main.py
@@ -8,8 +8,8 @@ bolt_app = App()
 
 
 @bolt_app.command("/hey-google-app-engine")
-def hello(payload, ack):
-    user_id = payload["user_id"]
+def hello(body, ack):
+    user_id = body["user_id"]
     ack(f"Hi <@{user_id}>!")
 
 
@@ -20,7 +20,7 @@ app = Flask(__name__)
 handler = SlackRequestHandler(bolt_app)
 
 
-@app.route('/_ah/warmup')
+@app.route("/_ah/warmup")
 def warmup():
     # Handle your warmup logic here, e.g. set up a database connection pool
     return "", 200, {}

--- a/samples/google_cloud_functions/main.py
+++ b/samples/google_cloud_functions/main.py
@@ -16,8 +16,8 @@ def hello_command(ack):
 
 
 @app.event("app_mention")
-def event_test(ack, payload, say, logger):
-    logger.info(payload)
+def event_test(body, say, logger):
+    logger.info(body)
     say("Hi from Google Cloud Functions!")
 
 

--- a/samples/google_cloud_run/aiohttp/main.py
+++ b/samples/google_cloud_run/aiohttp/main.py
@@ -8,8 +8,8 @@ app = AsyncApp()
 
 
 @app.command("/hey-google")
-async def hello(payload, ack):
-    user_id = payload["user_id"]
+async def hello(body, ack):
+    user_id = body["user_id"]
     await ack(f"Hi <@{user_id}>!")
 
 

--- a/samples/google_cloud_run/flask-gunicorn/main.py
+++ b/samples/google_cloud_run/flask-gunicorn/main.py
@@ -8,8 +8,8 @@ app = App()
 
 
 @app.command("/hey-google")
-def hello(payload, ack):
-    user_id = payload["user_id"]
+def hello(body, ack):
+    user_id = body["user_id"]
     ack(f"Hi <@{user_id}>!")
 
 

--- a/samples/google_cloud_run/sanic/main.py
+++ b/samples/google_cloud_run/sanic/main.py
@@ -10,8 +10,8 @@ app_handler = AsyncSlackRequestHandler(app)
 
 
 @app.command("/hey-google")
-async def hello(payload, ack):
-    user_id = payload["user_id"]
+async def hello(body, ack):
+    user_id = body["user_id"]
     await ack(f"Hi <@{user_id}>!")
 
 

--- a/samples/lazy_async_modals_app.py
+++ b/samples/lazy_async_modals_app.py
@@ -15,13 +15,13 @@ app = AsyncApp()
 
 
 @app.middleware  # or app.use(log_request)
-async def log_request(logger, payload, next):
-    logger.debug(payload)
+async def log_request(logger, body, next):
+    logger.debug(body)
     return await next()
 
 
-async def ack_command(payload, ack, logger):
-    logger.info(payload)
+async def ack_command(body, ack, logger):
+    logger.info(body)
     await ack("Thanks!")
 
 
@@ -46,9 +46,9 @@ async def post_button_message(respond):
     )
 
 
-async def open_modal(payload, client, logger):
+async def open_modal(body, client, logger):
     res = await client.views_open(
-        trigger_id=payload["trigger_id"],
+        trigger_id=body["trigger_id"],
         view={
             "type": "modal",
             "callback_id": "view-id",
@@ -134,9 +134,9 @@ async def show_multi_options(ack):
 
 
 @app.view("view-id")
-async def handle_view_submission(ack, payload, logger):
+async def handle_view_submission(ack, body, logger):
     await ack()
-    logger.info(payload["view"]["state"]["values"])
+    logger.info(body["view"]["state"]["values"])
 
 
 async def ack_button_click(ack, respond):

--- a/samples/lazy_modals_app.py
+++ b/samples/lazy_modals_app.py
@@ -16,13 +16,13 @@ app = App()
 
 
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.debug(payload)
+def log_request(logger, body, next):
+    logger.debug(body)
     return next()
 
 
-def ack_command(payload, ack, logger):
-    logger.info(payload)
+def ack_command(body, ack, logger):
+    logger.info(body)
     ack("Thanks!")
 
 
@@ -47,9 +47,9 @@ def post_button_message(respond):
     )
 
 
-def open_modal(payload, client, logger):
+def open_modal(body, client, logger):
     res = client.views_open(
-        trigger_id=payload["trigger_id"],
+        trigger_id=body["trigger_id"],
         view={
             "type": "modal",
             "callback_id": "view-id",
@@ -135,9 +135,9 @@ def show_multi_options(ack):
 
 
 @app.view("view-id")
-def handle_view_submission(ack, payload, logger):
+def handle_view_submission(ack, body, logger):
     ack()
-    logger.info(payload["view"]["state"]["values"])
+    logger.info(body["view"]["state"]["values"])
 
 
 def ack_button_click(ack, respond):

--- a/samples/modals_app.py
+++ b/samples/modals_app.py
@@ -15,14 +15,14 @@ app = App()
 
 
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.debug(payload)
+def log_request(logger, body, next):
+    logger.debug(body)
     return next()
 
 
 @app.command("/hello-bolt-python")
-def handle_command(payload, ack, respond, client, logger):
-    logger.info(payload)
+def handle_command(body, ack, respond, client, logger):
+    logger.info(body)
     ack(
         text="Accepted!",
         blocks=[
@@ -54,7 +54,7 @@ def handle_command(payload, ack, respond, client, logger):
     )
 
     res = client.views_open(
-        trigger_id=payload["trigger_id"],
+        trigger_id=body["trigger_id"],
         view={
             "type": "modal",
             "callback_id": "view-id",
@@ -135,16 +135,16 @@ def show_multi_options(ack):
 
 
 @app.view("view-id")
-def view_submission(ack, payload, logger):
+def view_submission(ack, body, logger):
     ack()
-    logger.info(payload["view"]["state"]["values"])
+    logger.info(body["view"]["state"]["values"])
 
 
 @app.action("a")
-def button_click(ack, payload, respond):
+def button_click(ack, body, respond):
     ack()
 
-    user_id = payload["user"]["id"]
+    user_id = body["user"]["id"]
     # in_channel / dict
     respond(
         {

--- a/samples/modals_app_typed.py
+++ b/samples/modals_app_typed.py
@@ -31,17 +31,17 @@ app = App()
 
 @app.middleware  # or app.use(log_request)
 def log_request(
-    logger: Logger, payload: dict, next: Callable[[], BoltResponse]
+    logger: Logger, body: dict, next: Callable[[], BoltResponse]
 ) -> BoltResponse:
-    logger.debug(payload)
+    logger.debug(body)
     return next()
 
 
 @app.command("/hello-bolt-python")
 def handle_command(
-    payload: dict, ack: Ack, respond: Respond, client: WebClient, logger: Logger
+    body: dict, ack: Ack, respond: Respond, client: WebClient, logger: Logger
 ) -> None:
-    logger.info(payload)
+    logger.info(body)
     ack(
         text="Accepted!",
         blocks=[
@@ -69,7 +69,7 @@ def handle_command(
     )
 
     res = client.views_open(
-        trigger_id=payload["trigger_id"],
+        trigger_id=body["trigger_id"],
         view=View(
             type="modal",
             callback_id="view-id",
@@ -130,16 +130,16 @@ def show_multi_options(ack: Ack) -> None:
 
 
 @app.view("view-id")
-def view_submission(ack: Ack, payload: dict, logger: Logger) -> None:
+def view_submission(ack: Ack, body: dict, logger: Logger) -> None:
     ack()
-    logger.info(payload["view"]["state"]["values"])
+    logger.info(body["view"]["state"]["values"])
 
 
 @app.action("a")
-def button_click(ack: Ack, payload: dict, respond: Respond) -> None:
+def button_click(ack: Ack, body: dict, respond: Respond) -> None:
     ack()
 
-    user_id: str = payload["user"]["id"]
+    user_id: str = body["user"]["id"]
     # in_channel / dict
     respond(
         response_type="in_channel",

--- a/samples/oauth_app.py
+++ b/samples/oauth_app.py
@@ -13,15 +13,15 @@ app = App()
 
 
 @app.event("app_mention")
-def event_test(payload, say, logger):
-    logger.info(payload)
+def event_test(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 
 @app.command("/hello-bolt-python")
 # or app.command(re.compile(r"/hello-.+"))(test_command)
-def test_command(payload, respond, client, ack, logger):
-    logger.info(payload)
+def test_command(body, respond, client, ack, logger):
+    logger.info(body)
     ack("Thanks!")
 
     respond(
@@ -44,7 +44,7 @@ def test_command(payload, respond, client, ack, logger):
     )
 
     res = client.views_open(
-        trigger_id=payload["trigger_id"],
+        trigger_id=body["trigger_id"],
         view={
             "type": "modal",
             "callback_id": "view-id",
@@ -64,14 +64,14 @@ def test_command(payload, respond, client, ack, logger):
 
 
 @app.view("view-id")
-def view_submission(ack, payload, logger):
-    logger.info(payload)
+def view_submission(ack, body, logger):
+    logger.info(body)
     return ack()
 
 
 @app.action("a")
-def button_click(logger, payload, ack, respond):
-    logger.info(payload)
+def button_click(logger, body, ack, respond):
+    logger.info(body)
     respond("respond!")
     ack()
 

--- a/samples/oauth_sqlite3_app.py
+++ b/samples/oauth_sqlite3_app.py
@@ -16,8 +16,8 @@ app = App(oauth_flow=OAuthFlow.sqlite3(database="./slackapp.db"))
 
 
 @app.event("app_mention")
-def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+def handle_app_mentions(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/pyramid/app.py
+++ b/samples/pyramid/app.py
@@ -15,8 +15,8 @@ app = App()
 
 
 @app.event("app_mention")
-def event_test(payload, say, logger):
-    logger.info(payload)
+def event_test(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/pyramid/oauth_app.py
+++ b/samples/pyramid/oauth_app.py
@@ -15,8 +15,8 @@ app = App()
 
 
 @app.event("app_mention")
-def event_test(payload, say, logger):
-    logger.info(payload)
+def event_test(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/readme_app.py
+++ b/samples/readme_app.py
@@ -11,8 +11,8 @@ app = App()
 
 # Middleware
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.info(payload)
+def log_request(logger, body, next):
+    logger.info(body)
     return next()
 
 
@@ -25,12 +25,12 @@ def event_test(say):
 # Interactivity: https://api.slack.com/interactivity
 @app.shortcut("callback-id-here")
 # @app.command("/hello-bolt-python")
-def open_modal(ack, client, logger, payload):
+def open_modal(ack, client, logger, body):
     # acknowledge the incoming request from Slack immediately
     ack()
     # open a modal
     api_response = client.views_open(
-        trigger_id=payload["trigger_id"],
+        trigger_id=body["trigger_id"],
         view={
             "type": "modal",
             "callback_id": "view-id",
@@ -50,10 +50,10 @@ def open_modal(ack, client, logger, payload):
 
 
 @app.view("view-id")
-def view_submission(ack, payload, logger):
+def view_submission(ack, body, logger):
     ack()
     # Prints {'b': {'a': {'type': 'plain_text_input', 'value': 'Your Input'}}}
-    logger.info(payload["view"]["state"]["values"])
+    logger.info(body["view"]["state"]["values"])
 
 
 if __name__ == "__main__":

--- a/samples/readme_async_app.py
+++ b/samples/readme_async_app.py
@@ -12,8 +12,8 @@ app = AsyncApp()
 
 # Middleware
 @app.middleware  # or app.use(log_request)
-async def log_request(logger, payload, next):
-    logger.info(payload)
+async def log_request(logger, body, next):
+    logger.info(body)
     return await next()
 
 
@@ -26,12 +26,12 @@ async def event_test(say):
 # Interactivity: https://api.slack.com/interactivity
 @app.shortcut("callback-id-here")
 # @app.command("/hello-bolt-python")
-async def open_modal(ack, client, logger, payload):
+async def open_modal(ack, client, logger, body):
     # acknowledge the incoming request from Slack immediately
     await ack()
     # open a modal
     api_response = await client.views_open(
-        trigger_id=payload["trigger_id"],
+        trigger_id=body["trigger_id"],
         view={
             "type": "modal",
             "callback_id": "view-id",
@@ -51,10 +51,10 @@ async def open_modal(ack, client, logger, payload):
 
 
 @app.view("view-id")
-async def view_submission(ack, payload, logger):
+async def view_submission(ack, body, logger):
     await ack()
     # Prints {'b': {'a': {'type': 'plain_text_input', 'value': 'Your Input'}}}
-    logger.info(payload["view"]["state"]["values"])
+    logger.info(body["view"]["state"]["values"])
 
 
 if __name__ == "__main__":

--- a/samples/sanic/async_app.py
+++ b/samples/sanic/async_app.py
@@ -14,8 +14,8 @@ app_handler = AsyncSlackRequestHandler(app)
 
 
 @app.event("app_mention")
-async def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+async def handle_app_mentions(body, say, logger):
+    logger.info(body)
     await say("What's up?")
 
 

--- a/samples/sanic/async_oauth_app.py
+++ b/samples/sanic/async_oauth_app.py
@@ -14,8 +14,8 @@ app_handler = AsyncSlackRequestHandler(app)
 
 
 @app.event("app_mention")
-async def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+async def handle_app_mentions(body, say, logger):
+    logger.info(body)
     await say("What's up?")
 
 

--- a/samples/starlette/app.py
+++ b/samples/starlette/app.py
@@ -12,8 +12,8 @@ app = App()
 
 
 @app.event("app_mention")
-def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+def handle_app_mentions(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/starlette/async_app.py
+++ b/samples/starlette/async_app.py
@@ -12,8 +12,8 @@ app = AsyncApp()
 
 
 @app.event("app_mention")
-async def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+async def handle_app_mentions(body, say, logger):
+    logger.info(body)
     await say("What's up?")
 
 

--- a/samples/starlette/async_oauth_app.py
+++ b/samples/starlette/async_oauth_app.py
@@ -13,8 +13,8 @@ app_handler = AsyncSlackRequestHandler(app)
 
 
 @app.event("app_mention")
-async def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+async def handle_app_mentions(body, say, logger):
+    logger.info(body)
     await say("What's up?")
 
 

--- a/samples/starlette/oauth_app.py
+++ b/samples/starlette/oauth_app.py
@@ -13,8 +13,8 @@ app_handler = SlackRequestHandler(app)
 
 
 @app.event("app_mention")
-def handle_app_mentions(payload, say, logger):
-    logger.info(payload)
+def handle_app_mentions(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/steps_from_apps.py
+++ b/samples/steps_from_apps.py
@@ -21,6 +21,7 @@ app = App()
 
 # https://api.slack.com/tutorials/workflow-builder-steps
 
+
 @app.action({"type": "workflow_step_edit", "callback_id": "copy_review"})
 def edit(body: dict, ack: Ack, client: WebClient):
     ack()
@@ -35,8 +36,8 @@ def edit(body: dict, ack: Ack, client: WebClient):
                     "block_id": "intro-section",
                     "text": {
                         "type": "plain_text",
-                        "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps."
-                    }
+                        "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps.",
+                    },
                 },
                 {
                     "type": "input",
@@ -46,13 +47,10 @@ def edit(body: dict, ack: Ack, client: WebClient):
                         "action_id": "task_name",
                         "placeholder": {
                             "type": "plain_text",
-                            "text": "Write a task name"
-                        }
+                            "text": "Write a task name",
+                        },
                     },
-                    "label": {
-                        "type": "plain_text",
-                        "text": "Task name"
-                    }
+                    "label": {"type": "plain_text", "text": "Task name"},
                 },
                 {
                     "type": "input",
@@ -62,13 +60,10 @@ def edit(body: dict, ack: Ack, client: WebClient):
                         "action_id": "task_description",
                         "placeholder": {
                             "type": "plain_text",
-                            "text": "Write a description for your task"
-                        }
+                            "text": "Write a description for your task",
+                        },
                     },
-                    "label": {
-                        "type": "plain_text",
-                        "text": "Task description"
-                    }
+                    "label": {"type": "plain_text", "text": "Task description"},
                 },
                 {
                     "type": "input",
@@ -78,15 +73,12 @@ def edit(body: dict, ack: Ack, client: WebClient):
                         "action_id": "task_author",
                         "placeholder": {
                             "type": "plain_text",
-                            "text": "Write a task name"
-                        }
+                            "text": "Write a task name",
+                        },
                     },
-                    "label": {
-                        "type": "plain_text",
-                        "text": "Task author"
-                    }
+                    "label": {"type": "plain_text", "text": "Task author"},
                 },
-            ]
+            ],
         },
     )
 
@@ -103,18 +95,16 @@ def save(ack: Ack, client: WebClient, body: dict):
                     "value": state_values["task_name_input"]["task_name"]["value"],
                 },
                 "taskDescription": {
-                    "value": state_values["task_description_input"]["task_description"]["value"],
+                    "value": state_values["task_description_input"]["task_description"][
+                        "value"
+                    ],
                 },
                 "taskAuthorEmail": {
                     "value": state_values["task_author_input"]["task_author"]["value"],
-                }
+                },
             },
             "outputs": [
-                {
-                    "name": "taskName",
-                    "type": "text",
-                    "label": "Task Name",
-                },
+                {"name": "taskName", "type": "text", "label": "Task Name",},
                 {
                     "name": "taskDescription",
                     "type": "text",
@@ -125,8 +115,8 @@ def save(ack: Ack, client: WebClient, body: dict):
                     "type": "text",
                     "label": "Task Author Email",
                 },
-            ]
-        }
+            ],
+        },
     )
     ack()
 
@@ -145,10 +135,12 @@ def execute(body: dict, client: WebClient):
                 "taskName": step["inputs"]["taskName"]["value"],
                 "taskDescription": step["inputs"]["taskDescription"]["value"],
                 "taskAuthorEmail": step["inputs"]["taskAuthorEmail"]["value"],
-            }
-        }
+            },
+        },
     )
-    user: SlackResponse = client.users_lookupByEmail(email=step["inputs"]["taskAuthorEmail"]["value"])
+    user: SlackResponse = client.users_lookupByEmail(
+        email=step["inputs"]["taskAuthorEmail"]["value"]
+    )
     user_id = user["user"]["id"]
     new_task = {
         "task_name": step["inputs"]["taskName"]["value"],
@@ -160,19 +152,21 @@ def execute(body: dict, client: WebClient):
 
     blocks = []
     for task in tasks:
-        blocks.append({"type": "section", "text": {"type": "plain_text", "text": task["task_name"]}})
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "plain_text", "text": task["task_name"]},
+            }
+        )
         blocks.append({"type": "divider"})
 
     home_tab_update: SlackResponse = client.views_publish(
         user_id=user_id,
         view={
             "type": "home",
-            "title": {
-                "type": 'plain_text',
-                "text": 'Your tasks!'
-            },
-            "blocks": blocks
-        }
+            "title": {"type": "plain_text", "text": "Your tasks!"},
+            "blocks": blocks,
+        },
     )
 
 

--- a/samples/tornado/app.py
+++ b/samples/tornado/app.py
@@ -16,14 +16,14 @@ app = App()
 
 
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.debug(payload)
+def log_request(logger, body, next):
+    logger.debug(body)
     return next()
 
 
 @app.event("app_mention")
-def event_test(ack, payload, say, logger):
-    logger.info(payload)
+def event_test(body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/samples/tornado/oauth_app.py
+++ b/samples/tornado/oauth_app.py
@@ -14,14 +14,14 @@ app = App()
 
 
 @app.middleware  # or app.use(log_request)
-def log_request(logger, payload, next):
-    logger.debug(payload)
+def log_request(logger, body, next):
+    logger.debug(body)
     return next()
 
 
 @app.event("app_mention")
-def event_test(ack, payload, say, logger):
-    logger.info(payload)
+def event_test(ack, body, say, logger):
+    logger.info(body)
     say("What's up?")
 
 

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -310,7 +310,7 @@ class App:
                 if listener_response is not None:
                     return listener_response
 
-        self._framework_logger.warning(f"Unhandled request ({req.payload})")
+        self._framework_logger.warning(f"Unhandled request ({req.body})")
         return BoltResponse(status=404, body={"error": "unhandled request"})
 
     def run_listener(

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -333,7 +333,7 @@ class AsyncApp:
                 if listener_response is not None:
                     return listener_response
 
-        self._framework_logger.warning(f"Unhandled request ({req.payload})")
+        self._framework_logger.warning(f"Unhandled request ({req.body})")
         return BoltResponse(status=404, body={"error": "unhandled request"})
 
     async def run_async_listener(

--- a/slack_bolt/kwargs_injection/args.py
+++ b/slack_bolt/kwargs_injection/args.py
@@ -20,6 +20,7 @@ class Args:
     request: BoltRequest
     response: BoltResponse
     context: BoltContext
+    body: Dict[str, Any]
     # payload
     payload: Dict[str, Any]
     options: Optional[Dict[str, Any]]
@@ -44,6 +45,7 @@ class Args:
         req: BoltRequest,
         resp: BoltResponse,
         context: BoltContext,
+        body: Dict[str, Any],
         payload: Dict[str, Any],
         options: Optional[Dict[str, Any]] = None,
         shortcut: Optional[Dict[str, Any]] = None,
@@ -64,8 +66,8 @@ class Args:
         self.response = self.resp = resp
         self.context: BoltContext = context
 
+        self.body: Dict[str, Any] = body
         self.payload: Dict[str, Any] = payload
-        self.body: Dict[str, Any] = payload
         self.options: Optional[Dict[str, Any]] = options
         self.shortcut: Optional[Dict[str, Any]] = shortcut
         self.action: Optional[Dict[str, Any]] = action

--- a/slack_bolt/kwargs_injection/async_args.py
+++ b/slack_bolt/kwargs_injection/async_args.py
@@ -19,6 +19,7 @@ class AsyncArgs:
     request: AsyncBoltRequest
     response: BoltResponse
     context: AsyncBoltContext
+    body: Dict[str, Any]
     # payload
     payload: Dict[str, Any]
     options: Optional[Dict[str, Any]]
@@ -43,6 +44,7 @@ class AsyncArgs:
         req: AsyncBoltRequest,
         resp: BoltResponse,
         context: AsyncBoltContext,
+        body: Dict[str, Any],
         payload: Dict[str, Any],
         options: Optional[Dict[str, Any]] = None,
         shortcut: Optional[Dict[str, Any]] = None,
@@ -63,8 +65,8 @@ class AsyncArgs:
         self.response = self.resp = resp
         self.context: AsyncBoltContext = context
 
+        self.body: Dict[str, Any] = body
         self.payload: Dict[str, Any] = payload
-        self.body: Dict[str, Any] = payload
         self.options: Optional[Dict[str, Any]] = options
         self.shortcut: Optional[Dict[str, Any]] = shortcut
         self.action: Optional[Dict[str, Any]] = action

--- a/slack_bolt/kwargs_injection/async_utils.py
+++ b/slack_bolt/kwargs_injection/async_utils.py
@@ -32,16 +32,15 @@ def build_async_required_kwargs(
         "resp": response,
         "response": response,
         "context": request.context,
+        "body": request.body,
         # payload
-        "payload": request.payload,
-        "body": request.payload,
-        "options": to_options(request.payload),
-        "shortcut": to_shortcut(request.payload),
-        "action": to_action(request.payload),
-        "view": to_view(request.payload),
-        "command": to_command(request.payload),
-        "event": to_event(request.payload),
-        "message": to_message(request.payload),
+        "options": to_options(request.body),
+        "shortcut": to_shortcut(request.body),
+        "action": to_action(request.body),
+        "view": to_view(request.body),
+        "command": to_command(request.body),
+        "event": to_event(request.body),
+        "message": to_message(request.body),
         # utilities
         "ack": request.context.ack,
         "say": request.context.say,
@@ -49,6 +48,17 @@ def build_async_required_kwargs(
         # middleware
         "next": next_func,
     }
+    all_available_args["payload"] = (
+        all_available_args["options"]
+        or all_available_args["shortcut"]
+        or all_available_args["action"]
+        or all_available_args["view"]
+        or all_available_args["command"]
+        or all_available_args["event"]
+        or all_available_args["message"]
+        or request.body
+    )
+
     kwargs: Dict[str, Any] = {
         k: v for k, v in all_available_args.items() if k in required_arg_names
     }

--- a/slack_bolt/kwargs_injection/utils.py
+++ b/slack_bolt/kwargs_injection/utils.py
@@ -33,15 +33,14 @@ def build_required_kwargs(
         "response": response,
         "context": request.context,
         # payload
-        "payload": request.payload,
-        "body": request.payload,
-        "options": to_options(request.payload),
-        "shortcut": to_shortcut(request.payload),
-        "action": to_action(request.payload),
-        "view": to_view(request.payload),
-        "command": to_command(request.payload),
-        "event": to_event(request.payload),
-        "message": to_message(request.payload),
+        "body": request.body,
+        "options": to_options(request.body),
+        "shortcut": to_shortcut(request.body),
+        "action": to_action(request.body),
+        "view": to_view(request.body),
+        "command": to_command(request.body),
+        "event": to_event(request.body),
+        "message": to_message(request.body),
         # utilities
         "ack": request.context.ack,
         "say": request.context.say,
@@ -49,6 +48,17 @@ def build_required_kwargs(
         # middleware
         "next": next_func,
     }
+    all_available_args["payload"] = (
+        all_available_args["options"]
+        or all_available_args["shortcut"]
+        or all_available_args["action"]
+        or all_available_args["view"]
+        or all_available_args["command"]
+        or all_available_args["event"]
+        or all_available_args["message"]
+        or request.body
+    )
+
     kwargs: Dict[str, Any] = {
         k: v for k, v in all_available_args.items() if k in required_arg_names
     }

--- a/slack_bolt/listener/async_listener_error_handler.py
+++ b/slack_bolt/listener/async_listener_error_handler.py
@@ -6,6 +6,16 @@ from typing import Callable, Dict, Any, Awaitable, Optional
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 
+from slack_bolt.util.payload_utils import (
+    to_options,
+    to_shortcut,
+    to_action,
+    to_view,
+    to_command,
+    to_event,
+    to_message,
+)
+
 
 class AsyncListenerErrorHandler(metaclass=ABCMeta):
     @abstractmethod
@@ -39,11 +49,31 @@ class AsyncCustomListenerErrorHandler(AsyncListenerErrorHandler):
             "resp": response,
             "response": response,
             "context": request.context,
-            "payload": request.payload,
-            "body": request.payload,
+            "body": request.body,
+            # payload
+            "body": request.body,
+            "options": to_options(request.body),
+            "shortcut": to_shortcut(request.body),
+            "action": to_action(request.body),
+            "view": to_view(request.body),
+            "command": to_command(request.body),
+            "event": to_event(request.body),
+            "message": to_message(request.body),
+            # utilities
             "say": request.context.say,
             "respond": request.context.respond,
         }
+        all_available_args["payload"] = (
+            all_available_args["options"]
+            or all_available_args["shortcut"]
+            or all_available_args["action"]
+            or all_available_args["view"]
+            or all_available_args["command"]
+            or all_available_args["event"]
+            or all_available_args["message"]
+            or request.body
+        )
+
         kwargs: Dict[str, Any] = {  # type: ignore
             k: v for k, v in all_available_args.items() if k in self.arg_names  # type: ignore
         }

--- a/slack_bolt/listener/listener_error_handler.py
+++ b/slack_bolt/listener/listener_error_handler.py
@@ -6,6 +6,16 @@ from typing import Callable, Dict, Any, Optional
 from slack_bolt.request.request import BoltRequest
 from slack_bolt.response.response import BoltResponse
 
+from slack_bolt.util.payload_utils import (
+    to_options,
+    to_shortcut,
+    to_action,
+    to_view,
+    to_command,
+    to_event,
+    to_message,
+)
+
 
 class ListenerErrorHandler(metaclass=ABCMeta):
     @abstractmethod
@@ -33,11 +43,31 @@ class CustomListenerErrorHandler(ListenerErrorHandler):
             "resp": response,
             "response": response,
             "context": request.context,
-            "payload": request.payload,
-            "body": request.payload,
+            "body": request.body,
+            # payload
+            "body": request.body,
+            "options": to_options(request.body),
+            "shortcut": to_shortcut(request.body),
+            "action": to_action(request.body),
+            "view": to_view(request.body),
+            "command": to_command(request.body),
+            "event": to_event(request.body),
+            "message": to_message(request.body),
+            # utilities
             "say": request.context.say,
             "respond": request.context.respond,
         }
+        all_available_args["payload"] = (
+            all_available_args["options"]
+            or all_available_args["shortcut"]
+            or all_available_args["action"]
+            or all_available_args["view"]
+            or all_available_args["command"]
+            or all_available_args["event"]
+            or all_available_args["message"]
+            or request.body
+        )
+
         kwargs: Dict[str, Any] = {  # type: ignore
             k: v for k, v in all_available_args.items() if k in self.arg_names  # type: ignore
         }

--- a/slack_bolt/listener_matcher/builtins.py
+++ b/slack_bolt/listener_matcher/builtins.py
@@ -59,8 +59,8 @@ def build_listener_matcher(
     if asyncio:
         from .async_builtins import AsyncBuiltinListenerMatcher
 
-        async def async_fun(payload: Dict[str, Any]) -> bool:
-            return func(payload)
+        async def async_fun(body: Dict[str, Any]) -> bool:
+            return func(body)
 
         return AsyncBuiltinListenerMatcher(func=async_fun)
     else:
@@ -75,22 +75,22 @@ def event(
     constraints: Union[str, Pattern, Dict[str, str]], asyncio: bool = False,
 ) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
     if constraints == "message":
-        # matches message events that don't have subtype in payload
+        # matches message events that don't have subtype in body
         constraints = {"type": "message", "subtype": None}
 
     if isinstance(constraints, (str, Pattern)):
         event_type: Union[str, Pattern] = constraints
 
-        def func(payload: Dict[str, Any]) -> bool:
-            return is_event(payload) and _matches(event_type, payload["event"]["type"])
+        def func(body: Dict[str, Any]) -> bool:
+            return is_event(body) and _matches(event_type, body["event"]["type"])
 
         return build_listener_matcher(func, asyncio)
 
     elif "type" in constraints:
 
-        def func(payload: Dict[str, Any]) -> bool:
-            if is_event(payload):
-                event = payload["event"]
+        def func(body: Dict[str, Any]) -> bool:
+            if is_event(body):
+                event = body["event"]
                 if not _matches(constraints["type"], event["type"]):
                     return False
                 if "subtype" in constraints:
@@ -119,8 +119,8 @@ def event(
 def command(
     command: Union[str, Pattern], asyncio: bool = False,
 ) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
-    def func(payload: Dict[str, Any]) -> bool:
-        return is_slash_command(payload) and _matches(command, payload["command"])
+    def func(body: Dict[str, Any]) -> bool:
+        return is_slash_command(body) and _matches(command, body["command"])
 
     return build_listener_matcher(func, asyncio)
 
@@ -136,10 +136,8 @@ def shortcut(
     if isinstance(constraints, (str, Pattern)):
         callback_id: Union[str, Pattern] = constraints
 
-        def func(payload: Dict[str, Any]) -> bool:
-            return is_shortcut(payload) and _matches(
-                callback_id, payload["callback_id"]
-            )
+        def func(body: Dict[str, Any]) -> bool:
+            return is_shortcut(body) and _matches(callback_id, body["callback_id"])
 
         return build_listener_matcher(func, asyncio)
 
@@ -157,10 +155,8 @@ def shortcut(
 def global_shortcut(
     callback_id: Union[str, Pattern], asyncio: bool = False,
 ) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
-    def func(payload: Dict[str, Any]) -> bool:
-        return is_global_shortcut(payload) and _matches(
-            callback_id, payload["callback_id"]
-        )
+    def func(body: Dict[str, Any]) -> bool:
+        return is_global_shortcut(body) and _matches(callback_id, body["callback_id"])
 
     return build_listener_matcher(func, asyncio)
 
@@ -168,10 +164,8 @@ def global_shortcut(
 def message_shortcut(
     callback_id: Union[str, Pattern], asyncio: bool = False,
 ) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
-    def func(payload: Dict[str, Any]) -> bool:
-        return is_message_shortcut(payload) and _matches(
-            callback_id, payload["callback_id"]
-        )
+    def func(body: Dict[str, Any]) -> bool:
+        return is_message_shortcut(body) and _matches(callback_id, body["callback_id"])
 
     return build_listener_matcher(func, asyncio)
 
@@ -212,9 +206,9 @@ def action(
 def block_action(
     action_id: Union[str, Pattern], asyncio: bool = False,
 ) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
-    def func(payload: Dict[str, Any]) -> bool:
-        return is_block_actions(payload) and _matches(
-            action_id, to_action(payload)["action_id"]
+    def func(body: Dict[str, Any]) -> bool:
+        return is_block_actions(body) and _matches(
+            action_id, to_action(body)["action_id"]
         )
 
     return build_listener_matcher(func, asyncio)
@@ -223,10 +217,8 @@ def block_action(
 def attachment_action(
     callback_id: Union[str, Pattern], asyncio: bool = False,
 ) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
-    def func(payload: Dict[str, Any]) -> bool:
-        return is_attachment_action(payload) and _matches(
-            callback_id, payload["callback_id"]
-        )
+    def func(body: Dict[str, Any]) -> bool:
+        return is_attachment_action(body) and _matches(callback_id, body["callback_id"])
 
     return build_listener_matcher(func, asyncio)
 
@@ -234,10 +226,8 @@ def attachment_action(
 def dialog_submission(
     callback_id: Union[str, Pattern], asyncio: bool = False,
 ) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
-    def func(payload: Dict[str, Any]) -> bool:
-        return is_dialog_submission(payload) and _matches(
-            callback_id, payload["callback_id"]
-        )
+    def func(body: Dict[str, Any]) -> bool:
+        return is_dialog_submission(body) and _matches(callback_id, body["callback_id"])
 
     return build_listener_matcher(func, asyncio)
 
@@ -245,9 +235,9 @@ def dialog_submission(
 def dialog_cancellation(
     callback_id: Union[str, Pattern], asyncio: bool = False,
 ) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
-    def func(payload: Dict[str, Any]) -> bool:
-        return is_dialog_cancellation(payload) and _matches(
-            callback_id, payload["callback_id"]
+    def func(body: Dict[str, Any]) -> bool:
+        return is_dialog_cancellation(body) and _matches(
+            callback_id, body["callback_id"]
         )
 
     return build_listener_matcher(func, asyncio)
@@ -256,9 +246,9 @@ def dialog_cancellation(
 def workflow_step_edit(
     callback_id: Union[str, Pattern], asyncio: bool = False,
 ) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
-    def func(payload: Dict[str, Any]) -> bool:
-        return is_workflow_step_edit(payload) and _matches(
-            callback_id, payload["callback_id"]
+    def func(body: Dict[str, Any]) -> bool:
+        return is_workflow_step_edit(body) and _matches(
+            callback_id, body["callback_id"]
         )
 
     return build_listener_matcher(func, asyncio)
@@ -288,9 +278,9 @@ def view(
 def view_submission(
     callback_id: Union[str, Pattern], asyncio: bool = False,
 ) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
-    def func(payload: Dict[str, Any]) -> bool:
-        return is_view_submission(payload) and _matches(
-            callback_id, payload["view"]["callback_id"]
+    def func(body: Dict[str, Any]) -> bool:
+        return is_view_submission(body) and _matches(
+            callback_id, body["view"]["callback_id"]
         )
 
     return build_listener_matcher(func, asyncio)
@@ -299,9 +289,9 @@ def view_submission(
 def view_closed(
     callback_id: Union[str, Pattern], asyncio: bool = False,
 ) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
-    def func(payload: Dict[str, Any]) -> bool:
-        return is_view_closed(payload) and _matches(
-            callback_id, payload["view"]["callback_id"]
+    def func(body: Dict[str, Any]) -> bool:
+        return is_view_closed(body) and _matches(
+            callback_id, body["view"]["callback_id"]
         )
 
     return build_listener_matcher(func, asyncio)
@@ -330,10 +320,8 @@ def options(
 def block_suggestion(
     action_id: Union[str, Pattern], asyncio: bool = False,
 ) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
-    def func(payload: Dict[str, Any]) -> bool:
-        return is_block_suggestion(payload) and _matches(
-            action_id, payload["action_id"]
-        )
+    def func(body: Dict[str, Any]) -> bool:
+        return is_block_suggestion(body) and _matches(action_id, body["action_id"])
 
     return build_listener_matcher(func, asyncio)
 
@@ -341,10 +329,8 @@ def block_suggestion(
 def dialog_suggestion(
     callback_id: Union[str, Pattern], asyncio: bool = False,
 ) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
-    def func(payload: Dict[str, Any]) -> bool:
-        return is_dialog_suggestion(payload) and _matches(
-            callback_id, payload["callback_id"]
-        )
+    def func(body: Dict[str, Any]) -> bool:
+        return is_dialog_suggestion(body) and _matches(callback_id, body["callback_id"])
 
     return build_listener_matcher(func, asyncio)
 

--- a/slack_bolt/middleware/authorization/async_internals.py
+++ b/slack_bolt/middleware/authorization/async_internals.py
@@ -5,16 +5,16 @@ from slack_bolt.response import BoltResponse
 def _is_url_verification(req: AsyncBoltRequest) -> bool:
     return (
         req is not None
-        and req.payload is not None
-        and req.payload.get("type", None) == "url_verification"
+        and req.body is not None
+        and req.body.get("type", None) == "url_verification"
     )
 
 
 def _is_ssl_check(req: AsyncBoltRequest) -> bool:
     return (
         req is not None
-        and req.payload is not None
-        and req.payload.get("type", None) == "ssl_check"
+        and req.body is not None
+        and req.body.get("type", None) == "ssl_check"
     )
 
 

--- a/slack_bolt/middleware/authorization/internals.py
+++ b/slack_bolt/middleware/authorization/internals.py
@@ -5,16 +5,16 @@ from slack_bolt.response import BoltResponse
 def _is_url_verification(req: BoltRequest) -> bool:
     return (
         req is not None
-        and req.payload is not None
-        and req.payload.get("type", None) == "url_verification"
+        and req.body is not None
+        and req.body.get("type", None) == "url_verification"
     )
 
 
 def _is_ssl_check(req: BoltRequest) -> bool:
     return (
         req is not None
-        and req.payload is not None
-        and req.payload.get("type", None) == "ssl_check"
+        and req.body is not None
+        and req.body.get("type", None) == "ssl_check"
     )
 
 

--- a/slack_bolt/middleware/ignoring_self_events/async_ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/async_ignoring_self_events.py
@@ -16,7 +16,7 @@ class AsyncIgnoringSelfEvents(IgnoringSelfEvents, AsyncMiddleware):
     ) -> BoltResponse:
         auth_result = req.context.authorization_result
         if self._is_self_event(auth_result, req.context.user_id):
-            self._debug_log(req.payload)
+            self._debug_log(req.body)
             return await req.context.ack()
         else:
             return await next()

--- a/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
@@ -17,7 +17,7 @@ class IgnoringSelfEvents(Middleware):
     ) -> BoltResponse:
         auth_result = req.context.authorization_result
         if self._is_self_event(auth_result, req.context.user_id):
-            self._debug_log(req.payload)
+            self._debug_log(req.body)
             return req.context.ack()
         else:
             return next()
@@ -28,7 +28,7 @@ class IgnoringSelfEvents(Middleware):
     def _is_self_event(auth_result: AuthorizationResult, user_id: str):
         return auth_result is not None and user_id == auth_result.bot_user_id
 
-    def _debug_log(self, payload: dict):
+    def _debug_log(self, body: dict):
         if self.logger.level <= logging.DEBUG:
-            event = payload["event"]
+            event = body["event"]
             self.logger.debug(f"Skipped self event: {event}")

--- a/slack_bolt/middleware/message_listener_matches/async_message_listener_matches.py
+++ b/slack_bolt/middleware/message_listener_matches/async_message_listener_matches.py
@@ -17,7 +17,7 @@ class AsyncMessageListenerMatches(AsyncMiddleware):
         resp: BoltResponse,
         next: Callable[[], Awaitable[BoltResponse]],
     ) -> BoltResponse:
-        text = req.payload.get("event", {}).get("text", "")
+        text = req.body.get("event", {}).get("text", "")
         if text:
             m = re.search(self.keyword, text)
             if m is not None:

--- a/slack_bolt/middleware/message_listener_matches/message_listener_matches.py
+++ b/slack_bolt/middleware/message_listener_matches/message_listener_matches.py
@@ -13,7 +13,7 @@ class MessageListenerMatches(Middleware):  # type: ignore
     def process(
         self, *, req: BoltRequest, resp: BoltResponse, next: Callable[[], BoltResponse],
     ) -> BoltResponse:
-        text = req.payload.get("event", {}).get("text", "")
+        text = req.body.get("event", {}).get("text", "")
         if text:
             m = re.search(self.keyword, text)
             if m is not None:

--- a/slack_bolt/middleware/request_verification/async_request_verification.py
+++ b/slack_bolt/middleware/request_verification/async_request_verification.py
@@ -14,10 +14,10 @@ class AsyncRequestVerification(RequestVerification, AsyncMiddleware):
         resp: BoltResponse,
         next: Callable[[], Awaitable[BoltResponse]],
     ) -> BoltResponse:
-        if self._can_skip(req.payload):
+        if self._can_skip(req.body):
             return await next()
 
-        body = req.body
+        body = req.raw_body
         timestamp = req.headers.get("x-slack-request-timestamp", ["0"])[0]
         signature = req.headers.get("x-slack-signature", [""])[0]
         if self.verifier.is_valid(body, timestamp, signature):

--- a/slack_bolt/middleware/request_verification/request_verification.py
+++ b/slack_bolt/middleware/request_verification/request_verification.py
@@ -16,10 +16,10 @@ class RequestVerification(Middleware):  # type: ignore
     def process(
         self, *, req: BoltRequest, resp: BoltResponse, next: Callable[[], BoltResponse],
     ) -> BoltResponse:
-        if self._can_skip(req.payload):
+        if self._can_skip(req.body):
             return next()
 
-        body = req.body
+        body = req.raw_body
         timestamp = req.headers.get("x-slack-request-timestamp", ["0"])[0]
         signature = req.headers.get("x-slack-signature", [""])[0]
         if self.verifier.is_valid(body, timestamp, signature):
@@ -31,8 +31,8 @@ class RequestVerification(Middleware):  # type: ignore
     # -----------------------------------------
 
     @staticmethod
-    def _can_skip(payload: Dict[str, Any]) -> bool:
-        return payload is not None and payload.get("ssl_check", None) == "1"
+    def _can_skip(body: Dict[str, Any]) -> bool:
+        return body is not None and body.get("ssl_check", None) == "1"
 
     @staticmethod
     def _build_error_response() -> BoltResponse:

--- a/slack_bolt/middleware/ssl_check/async_ssl_check.py
+++ b/slack_bolt/middleware/ssl_check/async_ssl_check.py
@@ -14,8 +14,8 @@ class AsyncSslCheck(SslCheck, AsyncMiddleware):
         resp: BoltResponse,
         next: Callable[[], Awaitable[BoltResponse]],
     ) -> BoltResponse:
-        if self._is_ssl_check_request(req.payload):
-            if self._verify_token_if_needed(req.payload):
+        if self._is_ssl_check_request(req.body):
+            if self._verify_token_if_needed(req.body):
                 return self._build_error_response()
             return self._build_success_response()
         else:

--- a/slack_bolt/middleware/ssl_check/ssl_check.py
+++ b/slack_bolt/middleware/ssl_check/ssl_check.py
@@ -14,8 +14,8 @@ class SslCheck(Middleware):  # type: ignore
     def process(
         self, *, req: BoltRequest, resp: BoltResponse, next: Callable[[], BoltResponse],
     ) -> BoltResponse:
-        if self._is_ssl_check_request(req.payload):
-            if self._verify_token_if_needed(req.payload):
+        if self._is_ssl_check_request(req.body):
+            if self._verify_token_if_needed(req.body):
                 return self._build_error_response()
             return self._build_success_response()
         else:
@@ -24,11 +24,11 @@ class SslCheck(Middleware):  # type: ignore
     # -----------------------------------------
 
     @staticmethod
-    def _is_ssl_check_request(payload: dict):
-        return "ssl_check" in payload and payload["ssl_check"] == "1"
+    def _is_ssl_check_request(body: dict):
+        return "ssl_check" in body and body["ssl_check"] == "1"
 
-    def _verify_token_if_needed(self, payload: dict):
-        return self.verification_token and self.verification_token == payload["token"]
+    def _verify_token_if_needed(self, body: dict):
+        return self.verification_token and self.verification_token == body["token"]
 
     @staticmethod
     def _build_success_response() -> BoltResponse:

--- a/slack_bolt/middleware/url_verification/async_url_verification.py
+++ b/slack_bolt/middleware/url_verification/async_url_verification.py
@@ -18,7 +18,7 @@ class AsyncUrlVerification(UrlVerification, AsyncMiddleware):
         resp: BoltResponse,
         next: Callable[[], Awaitable[BoltResponse]],
     ) -> BoltResponse:
-        if self._is_url_verification_request(req.payload):
-            return self._build_success_response(req.payload)
+        if self._is_url_verification_request(req.body):
+            return self._build_success_response(req.body)
         else:
             return await next()

--- a/slack_bolt/middleware/url_verification/url_verification.py
+++ b/slack_bolt/middleware/url_verification/url_verification.py
@@ -13,17 +13,17 @@ class UrlVerification(Middleware):  # type: ignore
     def process(
         self, *, req: BoltRequest, resp: BoltResponse, next: Callable[[], BoltResponse],
     ) -> BoltResponse:
-        if self._is_url_verification_request(req.payload):
-            return self._build_success_response(req.payload)
+        if self._is_url_verification_request(req.body):
+            return self._build_success_response(req.body)
         else:
             return next()
 
     # -----------------------------------------
 
     @staticmethod
-    def _is_url_verification_request(payload: dict) -> bool:
-        return payload is not None and payload.get("type", None) == "url_verification"
+    def _is_url_verification_request(body: dict) -> bool:
+        return body is not None and body.get("type", None) == "url_verification"
 
     @staticmethod
-    def _build_success_response(payload: dict) -> BoltResponse:
-        return BoltResponse(status=200, body={"challenge": payload.get("challenge")})
+    def _build_success_response(body: dict) -> BoltResponse:
+        return BoltResponse(status=200, body={"challenge": body.get("challenge")})

--- a/slack_bolt/request/async_request.py
+++ b/slack_bolt/request/async_request.py
@@ -4,18 +4,18 @@ from slack_bolt.context.async_context import AsyncBoltContext
 from slack_bolt.request.async_internals import build_async_context
 from slack_bolt.request.internals import (
     parse_query,
-    parse_payload,
+    parse_body,
     build_normalized_headers,
     extract_content_type,
 )
 
 
 class AsyncBoltRequest:
-    body: str
+    raw_body: str
+    body: Dict[str, Any]
     query: Dict[str, List[str]]
     headers: Dict[str, List[str]]
     content_type: Optional[str]
-    payload: Dict[str, Any]
     context: AsyncBoltContext
     lazy_only: bool
     lazy_function_name: Optional[str]
@@ -29,13 +29,13 @@ class AsyncBoltRequest:
         headers: Optional[Dict[str, Union[str, List[str]]]] = None,
         context: Optional[Dict[str, str]] = None,
     ):
-        self.body = body
+        self.raw_body = body
         self.query = parse_query(query)
         self.headers = build_normalized_headers(headers)
         self.content_type = extract_content_type(self.headers)
-        self.payload = parse_payload(self.body, self.content_type)
+        self.body = parse_body(self.raw_body, self.content_type)
         self.context = build_async_context(
-            AsyncBoltContext(context if context else {}), self.payload
+            AsyncBoltContext(context if context else {}), self.body
         )
         self.lazy_only = self.headers.get("x-slack-bolt-lazy-only", [False])[0]
         self.lazy_function_name = self.headers.get(

--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -28,7 +28,7 @@ def parse_query(
         raise ValueError(f"Unsupported type of query detected ({type(query)})")
 
 
-def parse_payload(body: str, content_type: Optional[str]) -> Dict[str, Any]:
+def parse_body(body: str, content_type: Optional[str]) -> Dict[str, Any]:
     if not body:
         return {}
     if content_type == "application/json" or body.startswith("{"):

--- a/slack_bolt/request/request.py
+++ b/slack_bolt/request/request.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, List, Union, Any
 from slack_bolt.context.context import BoltContext
 from slack_bolt.request.internals import (
     parse_query,
-    parse_payload,
+    parse_body,
     build_normalized_headers,
     build_context,
     extract_content_type,
@@ -11,11 +11,11 @@ from slack_bolt.request.internals import (
 
 
 class BoltRequest:
-    body: str
+    raw_body: str
     query: Dict[str, List[str]]
     headers: Dict[str, List[str]]
     content_type: Optional[str]
-    payload: Dict[str, Any]
+    body: Dict[str, Any]
     context: BoltContext
     lazy_only: bool
     lazy_function_name: Optional[str]
@@ -29,14 +29,12 @@ class BoltRequest:
         headers: Optional[Dict[str, Union[str, List[str]]]] = None,
         context: Optional[Dict[str, str]] = None,
     ):
-        self.body = body
+        self.raw_body = body
         self.query = parse_query(query)
         self.headers = build_normalized_headers(headers)
         self.content_type = extract_content_type(self.headers)
-        self.payload = parse_payload(self.body, self.content_type)
-        self.context = build_context(
-            BoltContext(context if context else {}), self.payload
-        )
+        self.body = parse_body(self.raw_body, self.content_type)
+        self.context = build_context(BoltContext(context if context else {}), self.body)
         self.lazy_only = self.headers.get("x-slack-bolt-lazy-only", [False])[0]
         self.lazy_function_name = self.headers.get(
             "x-slack-bolt-lazy-function-name", [None]

--- a/slack_bolt/util/payload_utils.py
+++ b/slack_bolt/util/payload_utils.py
@@ -10,22 +10,22 @@ from typing import Dict, Any, Optional
 # -------------------
 
 
-def to_event(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    return payload["event"] if is_event(payload) else None
+def to_event(body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    return body["event"] if is_event(body) else None
 
 
-def to_message(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    if is_event(payload) and payload["event"]["type"] == "message":
-        return to_event(payload)
+def to_message(body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if is_event(body) and body["event"]["type"] == "message":
+        return to_event(body)
     return None
 
 
-def is_event(payload: Dict[str, Any]) -> bool:
+def is_event(body: Dict[str, Any]) -> bool:
     return (
-        payload is not None
-        and _is_expected_type(payload, "event_callback")
-        and "event" in payload
-        and "type" in payload["event"]
+        body is not None
+        and _is_expected_type(body, "event_callback")
+        and "event" in body
+        and "type" in body["event"]
     )
 
 
@@ -34,12 +34,12 @@ def is_event(payload: Dict[str, Any]) -> bool:
 # -------------------
 
 
-def to_command(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    return payload if is_slash_command(payload) else None
+def to_command(body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    return body if is_slash_command(body) else None
 
 
-def is_slash_command(payload: Dict[str, Any]) -> bool:
-    return payload is not None and "command" in payload
+def is_slash_command(body: Dict[str, Any]) -> bool:
+    return body is not None and "command" in body
 
 
 # -------------------
@@ -47,62 +47,62 @@ def is_slash_command(payload: Dict[str, Any]) -> bool:
 # -------------------
 
 
-def to_action(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    if is_action(payload):
-        if is_block_actions(payload):
-            return payload["actions"][0]
+def to_action(body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if is_action(body):
+        if is_block_actions(body) or is_attachment_action(body):
+            return body["actions"][0]
         else:
-            return payload
+            return body
     return None
 
 
-def is_action(payload: Dict[str, Any]) -> bool:
+def is_action(body: Dict[str, Any]) -> bool:
     return (
-        is_attachment_action(payload)
-        or is_block_actions(payload)
-        or is_dialog_submission(payload)
-        or is_dialog_cancellation(payload)
-        or is_workflow_step_edit(payload)
+        is_attachment_action(body)
+        or is_block_actions(body)
+        or is_dialog_submission(body)
+        or is_dialog_cancellation(body)
+        or is_workflow_step_edit(body)
     )
 
 
-def is_attachment_action(payload: Dict[str, Any]) -> bool:
+def is_attachment_action(body: Dict[str, Any]) -> bool:
     return (
-        payload is not None
-        and _is_expected_type(payload, "interactive_message")
-        and "callback_id" in payload
+        body is not None
+        and _is_expected_type(body, "interactive_message")
+        and "callback_id" in body
     )
 
 
-def is_block_actions(payload: Dict[str, Any]) -> bool:
+def is_block_actions(body: Dict[str, Any]) -> bool:
     return (
-        payload is not None
-        and _is_expected_type(payload, "block_actions")
-        and "actions" in payload
+        body is not None
+        and _is_expected_type(body, "block_actions")
+        and "actions" in body
     )
 
 
-def is_dialog_submission(payload: Dict[str, Any]) -> bool:
+def is_dialog_submission(body: Dict[str, Any]) -> bool:
     return (
-        payload is not None
-        and _is_expected_type(payload, "dialog_submission")
-        and "callback_id" in payload
+        body is not None
+        and _is_expected_type(body, "dialog_submission")
+        and "callback_id" in body
     )
 
 
-def is_dialog_cancellation(payload: Dict[str, Any]) -> bool:
+def is_dialog_cancellation(body: Dict[str, Any]) -> bool:
     return (
-        payload is not None
-        and _is_expected_type(payload, "dialog_cancellation")
-        and "callback_id" in payload
+        body is not None
+        and _is_expected_type(body, "dialog_cancellation")
+        and "callback_id" in body
     )
 
 
-def is_workflow_step_edit(payload: Dict[str, Any]) -> bool:
+def is_workflow_step_edit(body: Dict[str, Any]) -> bool:
     return (
-        payload is not None
-        and _is_expected_type(payload, "workflow_step_edit")
-        and "callback_id" in payload
+        body is not None
+        and _is_expected_type(body, "workflow_step_edit")
+        and "callback_id" in body
     )
 
 
@@ -111,29 +111,29 @@ def is_workflow_step_edit(payload: Dict[str, Any]) -> bool:
 # -------------------
 
 
-def to_options(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    if is_options(payload):
-        return payload
+def to_options(body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if is_options(body):
+        return body
     return None
 
 
-def is_options(payload: Dict[str, Any]) -> bool:
-    return is_block_suggestion(payload) or is_dialog_suggestion(payload)
+def is_options(body: Dict[str, Any]) -> bool:
+    return is_block_suggestion(body) or is_dialog_suggestion(body)
 
 
-def is_block_suggestion(payload: Dict[str, Any]) -> bool:
+def is_block_suggestion(body: Dict[str, Any]) -> bool:
     return (
-        payload is not None
-        and _is_expected_type(payload, "block_suggestion")
-        and "action_id" in payload
+        body is not None
+        and _is_expected_type(body, "block_suggestion")
+        and "action_id" in body
     )
 
 
-def is_dialog_suggestion(payload: Dict[str, Any]) -> bool:
+def is_dialog_suggestion(body: Dict[str, Any]) -> bool:
     return (
-        payload is not None
-        and _is_expected_type(payload, "dialog_suggestion")
-        and "callback_id" in payload
+        body is not None
+        and _is_expected_type(body, "dialog_suggestion")
+        and "callback_id" in body
     )
 
 
@@ -142,29 +142,29 @@ def is_dialog_suggestion(payload: Dict[str, Any]) -> bool:
 # -------------------
 
 
-def to_shortcut(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    if is_shortcut(payload):
-        return payload
+def to_shortcut(body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if is_shortcut(body):
+        return body
     return None
 
 
-def is_shortcut(payload: Dict[str, Any]) -> bool:
-    return is_global_shortcut(payload) or is_message_shortcut(payload)
+def is_shortcut(body: Dict[str, Any]) -> bool:
+    return is_global_shortcut(body) or is_message_shortcut(body)
 
 
-def is_global_shortcut(payload: Dict[str, Any]) -> bool:
+def is_global_shortcut(body: Dict[str, Any]) -> bool:
     return (
-        payload is not None
-        and _is_expected_type(payload, "shortcut")
-        and "callback_id" in payload
+        body is not None
+        and _is_expected_type(body, "shortcut")
+        and "callback_id" in body
     )
 
 
-def is_message_shortcut(payload: Dict[str, Any]) -> bool:
+def is_message_shortcut(body: Dict[str, Any]) -> bool:
     return (
-        payload is not None
-        and _is_expected_type(payload, "message_action")
-        and "callback_id" in payload
+        body is not None
+        and _is_expected_type(body, "message_action")
+        and "callback_id" in body
     )
 
 
@@ -173,31 +173,31 @@ def is_message_shortcut(payload: Dict[str, Any]) -> bool:
 # -------------------
 
 
-def to_view(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    if is_view(payload):
-        return payload["view"]
+def to_view(body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if is_view(body):
+        return body["view"]
     return None
 
 
-def is_view(payload: Dict[str, Any]) -> bool:
-    return is_view_submission(payload) or is_view_closed(payload)
+def is_view(body: Dict[str, Any]) -> bool:
+    return is_view_submission(body) or is_view_closed(body)
 
 
-def is_view_submission(payload: Dict[str, Any]) -> bool:
+def is_view_submission(body: Dict[str, Any]) -> bool:
     return (
-        payload is not None
-        and _is_expected_type(payload, "view_submission")
-        and "view" in payload
-        and "callback_id" in payload["view"]
+        body is not None
+        and _is_expected_type(body, "view_submission")
+        and "view" in body
+        and "callback_id" in body["view"]
     )
 
 
-def is_view_closed(payload: Dict[str, Any]) -> bool:
+def is_view_closed(body: Dict[str, Any]) -> bool:
     return (
-        payload is not None
-        and _is_expected_type(payload, "view_closed")
-        and "view" in payload
-        and "callback_id" in payload["view"]
+        body is not None
+        and _is_expected_type(body, "view_closed")
+        and "view" in body
+        and "callback_id" in body["view"]
     )
 
 
@@ -206,5 +206,5 @@ def is_view_closed(payload: Dict[str, Any]) -> bool:
 # ------------------------------------------
 
 
-def _is_expected_type(payload: dict, expected: str) -> bool:
-    return payload is not None and "type" in payload and payload["type"] == expected
+def _is_expected_type(body: dict, expected: str) -> bool:
+    return body is not None and "type" in body and body["type"] == expected

--- a/tests/adapter_tests/test_async_fastapi.py
+++ b/tests/adapter_tests/test_async_fastapi.py
@@ -52,7 +52,7 @@ class TestFastAPI:
 
         app.event("app_mention")(event_handler)
 
-        payload = {
+        input = {
             "token": "verification_token",
             "team_id": "T111",
             "enterprise_id": "E111",
@@ -72,7 +72,7 @@ class TestFastAPI:
             "event_time": 1595926230,
             "authed_users": ["W111"],
         }
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         api = FastAPI()
         app_handler = AsyncSlackRequestHandler(app)
@@ -96,7 +96,7 @@ class TestFastAPI:
 
         app.shortcut("test-shortcut")(shortcut_handler)
 
-        payload = {
+        input = {
             "type": "shortcut",
             "token": "verification_token",
             "action_ts": "111.111",
@@ -111,7 +111,7 @@ class TestFastAPI:
             "trigger_id": "111.111.xxxxxx",
         }
 
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         api = FastAPI()
         app_handler = AsyncSlackRequestHandler(app)
@@ -135,7 +135,7 @@ class TestFastAPI:
 
         app.command("/hello-world")(command_handler)
 
-        payload = (
+        input = (
             "token=verification_token"
             "&team_id=T111"
             "&team_domain=test-domain"
@@ -150,7 +150,7 @@ class TestFastAPI:
             "&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT111%2F111%2Fxxxxx"
             "&trigger_id=111.111.xxx"
         )
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         api = FastAPI()
         app_handler = AsyncSlackRequestHandler(app)

--- a/tests/adapter_tests/test_async_starlette.py
+++ b/tests/adapter_tests/test_async_starlette.py
@@ -53,7 +53,7 @@ class TestAsyncStarlette:
 
         app.event("app_mention")(event_handler)
 
-        payload = {
+        input = {
             "token": "verification_token",
             "team_id": "T111",
             "enterprise_id": "E111",
@@ -73,7 +73,7 @@ class TestAsyncStarlette:
             "event_time": 1595926230,
             "authed_users": ["W111"],
         }
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         async def endpoint(req: Request):
             return await app_handler.handle(req)
@@ -99,7 +99,7 @@ class TestAsyncStarlette:
 
         app.shortcut("test-shortcut")(shortcut_handler)
 
-        payload = {
+        input = {
             "type": "shortcut",
             "token": "verification_token",
             "action_ts": "111.111",
@@ -114,7 +114,7 @@ class TestAsyncStarlette:
             "trigger_id": "111.111.xxxxxx",
         }
 
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         async def endpoint(req: Request):
             return await app_handler.handle(req)
@@ -140,7 +140,7 @@ class TestAsyncStarlette:
 
         app.command("/hello-world")(command_handler)
 
-        payload = (
+        input = (
             "token=verification_token"
             "&team_id=T111"
             "&team_domain=test-domain"
@@ -155,7 +155,7 @@ class TestAsyncStarlette:
             "&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT111%2F111%2Fxxxxx"
             "&trigger_id=111.111.xxx"
         )
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         async def endpoint(req: Request):
             return await app_handler.handle(req)

--- a/tests/adapter_tests/test_aws_lambda.py
+++ b/tests/adapter_tests/test_aws_lambda.py
@@ -59,7 +59,7 @@ class TestAWSLambda:
 
         app.event("app_mention")(event_handler)
 
-        payload = {
+        input = {
             "token": "verification_token",
             "team_id": "T111",
             "enterprise_id": "E111",
@@ -79,7 +79,7 @@ class TestAWSLambda:
             "event_time": 1595926230,
             "authed_users": ["W111"],
         }
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
         event = {
             "body": body,
             "queryStringParameters": {},
@@ -100,7 +100,7 @@ class TestAWSLambda:
 
         app.shortcut("test-shortcut")(shortcut_handler)
 
-        payload = {
+        input = {
             "type": "shortcut",
             "token": "verification_token",
             "action_ts": "111.111",
@@ -115,7 +115,7 @@ class TestAWSLambda:
             "trigger_id": "111.111.xxxxxx",
         }
 
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
         event = {
             "body": body,
             "queryStringParameters": {},
@@ -136,7 +136,7 @@ class TestAWSLambda:
 
         app.command("/hello-world")(command_handler)
 
-        payload = (
+        input = (
             "token=verification_token"
             "&team_id=T111"
             "&team_domain=test-domain"
@@ -151,7 +151,7 @@ class TestAWSLambda:
             "&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT111%2F111%2Fxxxxx"
             "&trigger_id=111.111.xxx"
         )
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
         event = {
             "body": body,
             "queryStringParameters": {},

--- a/tests/adapter_tests/test_cherrypy.py
+++ b/tests/adapter_tests/test_cherrypy.py
@@ -73,7 +73,7 @@ class TestCherryPy(helper.CPWebCase):
         ]
 
     def test_events(self):
-        payload = {
+        input = {
             "token": "verification_token",
             "team_id": "T111",
             "enterprise_id": "E111",
@@ -93,7 +93,7 @@ class TestCherryPy(helper.CPWebCase):
             "event_time": 1595926230,
             "authed_users": ["W111"],
         }
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
         cherrypy.request.process_request_body = True
         self.getPage(
             "/slack/events",
@@ -105,7 +105,7 @@ class TestCherryPy(helper.CPWebCase):
         self.assertBody("")
 
     def test_shortcuts(self):
-        payload = {
+        input = {
             "type": "shortcut",
             "token": "verification_token",
             "action_ts": "111.111",
@@ -120,7 +120,7 @@ class TestCherryPy(helper.CPWebCase):
             "trigger_id": "111.111.xxxxxx",
         }
 
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
         cherrypy.request.process_request_body = True
         self.getPage(
             "/slack/events",
@@ -132,7 +132,7 @@ class TestCherryPy(helper.CPWebCase):
         self.assertBody("")
 
     def test_commands(self):
-        payload = (
+        input = (
             "token=verification_token"
             "&team_id=T111"
             "&team_domain=test-domain"
@@ -147,7 +147,7 @@ class TestCherryPy(helper.CPWebCase):
             "&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT111%2F111%2Fxxxxx"
             "&trigger_id=111.111.xxx"
         )
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
         cherrypy.request.process_request_body = True
         self.getPage(
             "/slack/events",

--- a/tests/adapter_tests/test_fastapi.py
+++ b/tests/adapter_tests/test_fastapi.py
@@ -52,7 +52,7 @@ class TestFastAPI:
 
         app.event("app_mention")(event_handler)
 
-        payload = {
+        input = {
             "token": "verification_token",
             "team_id": "T111",
             "enterprise_id": "E111",
@@ -72,7 +72,7 @@ class TestFastAPI:
             "event_time": 1595926230,
             "authed_users": ["W111"],
         }
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         api = FastAPI()
         app_handler = SlackRequestHandler(app)
@@ -96,7 +96,7 @@ class TestFastAPI:
 
         app.shortcut("test-shortcut")(shortcut_handler)
 
-        payload = {
+        input = {
             "type": "shortcut",
             "token": "verification_token",
             "action_ts": "111.111",
@@ -111,7 +111,7 @@ class TestFastAPI:
             "trigger_id": "111.111.xxxxxx",
         }
 
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         api = FastAPI()
         app_handler = SlackRequestHandler(app)
@@ -135,7 +135,7 @@ class TestFastAPI:
 
         app.command("/hello-world")(command_handler)
 
-        payload = (
+        input = (
             "token=verification_token"
             "&team_id=T111"
             "&team_domain=test-domain"
@@ -150,7 +150,7 @@ class TestFastAPI:
             "&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT111%2F111%2Fxxxxx"
             "&trigger_id=111.111.xxx"
         )
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         api = FastAPI()
         app_handler = SlackRequestHandler(app)

--- a/tests/adapter_tests/test_flask.py
+++ b/tests/adapter_tests/test_flask.py
@@ -49,7 +49,7 @@ class TestFlask:
 
         app.event("app_mention")(event_handler)
 
-        payload = {
+        input = {
             "token": "verification_token",
             "team_id": "T111",
             "enterprise_id": "E111",
@@ -69,7 +69,7 @@ class TestFlask:
             "event_time": 1595926230,
             "authed_users": ["W111"],
         }
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         flask_app = Flask(__name__)
 
@@ -92,7 +92,7 @@ class TestFlask:
 
         app.shortcut("test-shortcut")(shortcut_handler)
 
-        payload = {
+        input = {
             "type": "shortcut",
             "token": "verification_token",
             "action_ts": "111.111",
@@ -107,7 +107,7 @@ class TestFlask:
             "trigger_id": "111.111.xxxxxx",
         }
 
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         flask_app = Flask(__name__)
 
@@ -130,7 +130,7 @@ class TestFlask:
 
         app.command("/hello-world")(command_handler)
 
-        payload = (
+        input = (
             "token=verification_token"
             "&team_id=T111"
             "&team_domain=test-domain"
@@ -145,7 +145,7 @@ class TestFlask:
             "&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT111%2F111%2Fxxxxx"
             "&trigger_id=111.111.xxx"
         )
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         flask_app = Flask(__name__)
 

--- a/tests/adapter_tests/test_starlette.py
+++ b/tests/adapter_tests/test_starlette.py
@@ -55,7 +55,7 @@ class TestStarlette:
 
         app_handler = SlackRequestHandler(app)
 
-        payload = {
+        input = {
             "token": "verification_token",
             "team_id": "T111",
             "enterprise_id": "E111",
@@ -75,7 +75,7 @@ class TestStarlette:
             "event_time": 1595926230,
             "authed_users": ["W111"],
         }
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         async def endpoint(req: Request):
             return await app_handler.handle(req)
@@ -101,7 +101,7 @@ class TestStarlette:
 
         app_handler = SlackRequestHandler(app)
 
-        payload = {
+        input = {
             "type": "shortcut",
             "token": "verification_token",
             "action_ts": "111.111",
@@ -116,7 +116,7 @@ class TestStarlette:
             "trigger_id": "111.111.xxxxxx",
         }
 
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         async def endpoint(req: Request):
             return await app_handler.handle(req)
@@ -142,7 +142,7 @@ class TestStarlette:
 
         app_handler = SlackRequestHandler(app)
 
-        payload = (
+        input = (
             "token=verification_token"
             "&team_id=T111"
             "&team_domain=test-domain"
@@ -157,7 +157,7 @@ class TestStarlette:
             "&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT111%2F111%2Fxxxxx"
             "&trigger_id=111.111.xxx"
         )
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(input)
 
         async def endpoint(req: Request):
             return await app_handler.handle(req)

--- a/tests/async_scenario_tests/test_attachment_actions.py
+++ b/tests/async_scenario_tests/test_attachment_actions.py
@@ -140,7 +140,7 @@ class TestAsyncAttachmentActions:
 
 
 # https://api.slack.com/legacy/interactive-messages
-payload = {
+body = {
     "type": "interactive_message",
     "actions": [
         {
@@ -188,10 +188,11 @@ payload = {
     "trigger_id": "111.222.valid",
 }
 
-raw_body = f"payload={quote(json.dumps(payload))}"
+raw_body = f"payload={quote(json.dumps(body))}"
 
 
-async def simple_listener(ack, body, action):
-    assert body == action
+async def simple_listener(ack, body, payload, action):
+    assert body != payload
+    assert payload == action
     assert body["trigger_id"] == "111.222.valid"
     await ack()

--- a/tests/async_scenario_tests/test_block_actions.py
+++ b/tests/async_scenario_tests/test_block_actions.py
@@ -133,7 +133,7 @@ class TestAsyncBlockActions:
         assert self.mock_received_requests["/auth.test"] == 2
 
 
-payload = {
+body = {
     "type": "block_actions",
     "user": {
         "id": "W111",
@@ -170,11 +170,12 @@ payload = {
     ],
 }
 
-raw_body = f"payload={quote(json.dumps(payload))}"
+raw_body = f"payload={quote(json.dumps(body))}"
 
 
-async def simple_listener(ack, body, action):
+async def simple_listener(ack, body, payload, action):
     assert body["trigger_id"] == "111.222.valid"
-    assert body["actions"][0] == action
+    assert body["actions"][0] == payload
+    assert payload == action
     assert action["action_id"] == "a"
     await ack()

--- a/tests/async_scenario_tests/test_block_suggestion.py
+++ b/tests/async_scenario_tests/test_block_suggestion.py
@@ -173,7 +173,7 @@ class TestAsyncBlockSuggestion:
         assert self.mock_received_requests["/auth.test"] == 2
 
 
-payload = {
+body = {
     "type": "block_suggestion",
     "user": {
         "id": "W111",
@@ -246,12 +246,12 @@ payload = {
     },
 }
 
-raw_body = f"payload={quote(json.dumps(payload))}"
+raw_body = f"payload={quote(json.dumps(body))}"
 
-multi_payload = copy.deepcopy(payload)
-multi_payload["block_id"] = "mes_b"
-multi_payload["action_id"] = "mes_a"
-raw_multi_body = f"payload={quote(json.dumps(multi_payload))}"
+multi_body = copy.deepcopy(body)
+multi_body["block_id"] = "mes_b"
+multi_body["action_id"] = "mes_a"
+raw_multi_body = f"payload={quote(json.dumps(multi_body))}"
 
 response = {
     "options": [{"text": {"type": "plain_text", "text": "Maru"}, "value": "maru"}]
@@ -278,11 +278,13 @@ multi_response = {
 expected_multi_response_body = json.dumps(multi_response)
 
 
-async def show_options(ack, body, options):
+async def show_options(ack, body, payload, options):
     assert body == options
+    assert payload == options
     await ack(response)
 
 
-async def show_multi_options(ack, body, options):
+async def show_multi_options(ack, body, payload, options):
     assert body == options
+    assert payload == options
     await ack(multi_response)

--- a/tests/async_scenario_tests/test_dialogs.py
+++ b/tests/async_scenario_tests/test_dialogs.py
@@ -265,7 +265,7 @@ class TestAsyncAttachmentActions:
         assert self.mock_received_requests["/auth.test"] == 2
 
 
-suggestion_payload = {
+suggestion_body = {
     "type": "dialog_suggestion",
     "token": "verification_token",
     "action_ts": "1596603332.676855",
@@ -283,7 +283,7 @@ suggestion_payload = {
     "state": "Limo",
 }
 
-submission_payload = {
+submission_body = {
     "type": "dialog_submission",
     "token": "verification_token",
     "action_ts": "1596603334.328193",
@@ -305,7 +305,7 @@ submission_payload = {
     "state": "Limo",
 }
 
-cancellation_payload = {
+cancellation_body = {
     "type": "dialog_cancellation",
     "token": "verification_token",
     "action_ts": "1596603453.047897",
@@ -322,9 +322,9 @@ cancellation_payload = {
     "state": "Limo",
 }
 
-suggestion_raw_body = f"payload={quote(json.dumps(suggestion_payload))}"
-submission_raw_body = f"payload={quote(json.dumps(submission_payload))}"
-cancellation_raw_body = f"payload={quote(json.dumps(cancellation_payload))}"
+suggestion_raw_body = f"payload={quote(json.dumps(suggestion_body))}"
+submission_raw_body = f"payload={quote(json.dumps(submission_body))}"
+cancellation_raw_body = f"payload={quote(json.dumps(cancellation_body))}"
 
 
 async def handle_submission(ack):
@@ -343,11 +343,13 @@ options_response = {
 }
 
 
-async def handle_suggestion(ack, body, options):
+async def handle_suggestion(ack, body, payload, options):
     assert body == options
+    assert payload == options
     await ack(options_response)
 
 
-async def handle_cancellation(ack, body, action):
+async def handle_cancellation(ack, body, payload, action):
     assert body == action
+    assert payload == action
     await ack()

--- a/tests/async_scenario_tests/test_error_handler.py
+++ b/tests/async_scenario_tests/test_error_handler.py
@@ -52,7 +52,7 @@ class TestAsyncErrorHandler:
         }
 
     def build_valid_request(self) -> AsyncBoltRequest:
-        payload = {
+        body = {
             "type": "block_actions",
             "user": {"id": "W111",},
             "api_app_id": "A111",
@@ -72,7 +72,7 @@ class TestAsyncErrorHandler:
                 }
             ],
         }
-        raw_body = f"payload={quote(json.dumps(payload))}"
+        raw_body = f"payload={quote(json.dumps(body))}"
         timestamp = str(int(time()))
         return AsyncBoltRequest(
             body=raw_body, headers=self.build_headers(timestamp, raw_body)

--- a/tests/async_scenario_tests/test_events.py
+++ b/tests/async_scenario_tests/test_events.py
@@ -48,7 +48,7 @@ class TestAsyncEvents:
         }
 
     def build_valid_app_mention_request(self) -> AsyncBoltRequest:
-        timestamp, body = str(int(time())), json.dumps(app_mention_payload)
+        timestamp, body = str(int(time())), json.dumps(app_mention_body)
         return AsyncBoltRequest(body=body, headers=self.build_headers(timestamp, body))
 
     @pytest.mark.asyncio
@@ -114,7 +114,7 @@ class TestAsyncEvents:
         assert self.mock_received_requests["/chat.postMessage"] == times
 
 
-app_mention_payload = {
+app_mention_body = {
     "token": "verification_token",
     "team_id": "T111",
     "enterprise_id": "E111",
@@ -136,17 +136,19 @@ app_mention_payload = {
 }
 
 
-async def random_sleeper(payload, say, event):
-    assert payload == app_mention_payload
-    assert payload["event"] == event
+async def random_sleeper(body, say, payload, event):
+    assert body == app_mention_body
+    assert body["event"] == payload
+    assert payload == event
     seconds = random() + 2  # 2-3 seconds
     await asyncio.sleep(seconds)
     await say(f"Sending this message after sleeping for {seconds} seconds")
 
 
-async def whats_up(payload, say, event):
-    assert payload == app_mention_payload
-    assert payload["event"] == event
+async def whats_up(body, say, payload, event):
+    assert body == app_mention_body
+    assert body["event"] == payload
+    assert payload == event
     await say("What's up?")
 
 

--- a/tests/async_scenario_tests/test_lazy.py
+++ b/tests/async_scenario_tests/test_lazy.py
@@ -52,7 +52,7 @@ class TestAsyncLazy:
         }
 
     def build_valid_request(self) -> AsyncBoltRequest:
-        payload = {
+        body = {
             "type": "block_actions",
             "user": {"id": "W111",},
             "api_app_id": "A111",
@@ -72,7 +72,7 @@ class TestAsyncLazy:
                 }
             ],
         }
-        raw_body = f"payload={quote(json.dumps(payload))}"
+        raw_body = f"payload={quote(json.dumps(body))}"
         timestamp = str(int(time()))
         return AsyncBoltRequest(
             body=raw_body, headers=self.build_headers(timestamp, raw_body)

--- a/tests/async_scenario_tests/test_message.py
+++ b/tests/async_scenario_tests/test_message.py
@@ -48,11 +48,11 @@ class TestAsyncMessage:
         }
 
     def build_request(self) -> AsyncBoltRequest:
-        timestamp, body = str(int(time())), json.dumps(message_payload)
+        timestamp, body = str(int(time())), json.dumps(message_body)
         return AsyncBoltRequest(body=body, headers=self.build_headers(timestamp, body))
 
     def build_request2(self) -> AsyncBoltRequest:
-        timestamp, body = str(int(time())), json.dumps(message_payload2)
+        timestamp, body = str(int(time())), json.dumps(message_body2)
         return AsyncBoltRequest(body=body, headers=self.build_headers(timestamp, body))
 
     @pytest.mark.asyncio
@@ -126,7 +126,7 @@ class TestAsyncMessage:
         assert self.mock_received_requests["/auth.test"] == 1
 
 
-message_payload = {
+message_body = {
     "token": "verification_token",
     "team_id": "T111",
     "enterprise_id": "E111",
@@ -161,12 +161,12 @@ message_payload = {
 }
 
 
-async def whats_up(payload, say):
-    assert payload == message_payload
+async def whats_up(body, say):
+    assert body == message_body
     await say("What's up?")
 
 
-message_payload2 = {
+message_body2 = {
     "token": "verification_token",
     "team_id": "T111",
     "enterprise_id": "E111",

--- a/tests/async_scenario_tests/test_middleware.py
+++ b/tests/async_scenario_tests/test_middleware.py
@@ -35,7 +35,7 @@ class TestAsyncMiddleware:
             restore_os_env(old_os_env)
 
     def build_request(self) -> AsyncBoltRequest:
-        payload = {
+        body = {
             "type": "shortcut",
             "token": "verification_token",
             "action_ts": "111.111",
@@ -49,7 +49,7 @@ class TestAsyncMiddleware:
             "callback_id": "test-shortcut",
             "trigger_id": "111.111.xxxxxx",
         }
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(body)
         return AsyncBoltRequest(
             body=body,
             headers={

--- a/tests/async_scenario_tests/test_shortcut.py
+++ b/tests/async_scenario_tests/test_shortcut.py
@@ -175,7 +175,7 @@ class TestAsyncShortcut:
         assert self.mock_received_requests["/auth.test"] == 3
 
 
-global_shortcut_payload = {
+global_shortcut_body = {
     "type": "shortcut",
     "token": "verification_token",
     "action_ts": "111.111",
@@ -190,7 +190,7 @@ global_shortcut_payload = {
     "trigger_id": "111.111.xxxxxx",
 }
 
-message_shortcut_payload = {
+message_shortcut_body = {
     "type": "message_action",
     "token": "verification_token",
     "action_ts": "1583637157.207593",
@@ -231,10 +231,11 @@ message_shortcut_payload = {
     "response_url": "https://hooks.slack.com/app/T111/111/xxx",
 }
 
-global_shortcut_raw_body = f"payload={quote(json.dumps(global_shortcut_payload))}"
-message_shortcut_raw_body = f"payload={quote(json.dumps(message_shortcut_payload))}"
+global_shortcut_raw_body = f"payload={quote(json.dumps(global_shortcut_body))}"
+message_shortcut_raw_body = f"payload={quote(json.dumps(message_shortcut_body))}"
 
 
-async def simple_listener(ack, body, shortcut):
+async def simple_listener(ack, body, payload, shortcut):
     assert body == shortcut
+    assert payload == shortcut
     await ack()

--- a/tests/async_scenario_tests/test_slash_command.py
+++ b/tests/async_scenario_tests/test_slash_command.py
@@ -47,7 +47,7 @@ class TestAsyncSlashCommand:
         }
 
     def build_valid_request(self) -> AsyncBoltRequest:
-        timestamp, body = str(int(time())), json.dumps(slash_command_payload)
+        timestamp, body = str(int(time())), json.dumps(slash_command_body)
         return AsyncBoltRequest(body=body, headers=self.build_headers(timestamp, body))
 
     @pytest.mark.asyncio
@@ -93,7 +93,7 @@ class TestAsyncSlashCommand:
         assert self.mock_received_requests["/auth.test"] == 2
 
 
-slash_command_payload = (
+slash_command_body = (
     "token=verification_token"
     "&team_id=T111"
     "&team_domain=test-domain"
@@ -110,6 +110,7 @@ slash_command_payload = (
 )
 
 
-async def commander(ack, body, command):
+async def commander(ack, body, payload, command):
     assert body == command
+    assert payload == command
     await ack()

--- a/tests/async_scenario_tests/test_view_closed.py
+++ b/tests/async_scenario_tests/test_view_closed.py
@@ -132,7 +132,7 @@ class TestAsyncViewClosed:
         assert self.mock_received_requests["/auth.test"] == 2
 
 
-payload = {
+body = {
     "type": "view_closed",
     "team": {
         "id": "T111",
@@ -180,10 +180,11 @@ payload = {
     "response_urls": [],
 }
 
-raw_body = f"payload={quote(json.dumps(payload))}"
+raw_body = f"payload={quote(json.dumps(body))}"
 
 
-async def simple_listener(ack, body, view):
+async def simple_listener(ack, body, payload, view):
     assert body["view"] == view
+    assert payload == view
     assert view["private_metadata"] == "This is for you!"
     await ack()

--- a/tests/async_scenario_tests/test_view_submission.py
+++ b/tests/async_scenario_tests/test_view_submission.py
@@ -119,7 +119,7 @@ class TestAsyncViewSubmission:
         assert self.mock_received_requests["/auth.test"] == 2
 
 
-payload = {
+body = {
     "type": "view_submission",
     "team": {
         "id": "T111",
@@ -170,11 +170,12 @@ payload = {
     "response_urls": [],
 }
 
-raw_body = f"payload={quote(json.dumps(payload))}"
+raw_body = f"payload={quote(json.dumps(body))}"
 
 
-async def simple_listener(ack, body, view):
+async def simple_listener(ack, body, payload, view):
     assert body["trigger_id"] == "111.222.valid"
-    assert body["view"] == view
+    assert body["view"] == payload
+    assert payload == view
     assert view["private_metadata"] == "This is for you!"
     await ack()

--- a/tests/scenario_tests/test_attachment_actions.py
+++ b/tests/scenario_tests/test_attachment_actions.py
@@ -114,7 +114,7 @@ class TestAttachmentActions:
 
 
 # https://api.slack.com/legacy/interactive-messages
-payload = {
+body = {
     "type": "interactive_message",
     "actions": [
         {
@@ -162,10 +162,11 @@ payload = {
     "trigger_id": "111.222.valid",
 }
 
-raw_body = f"payload={quote(json.dumps(payload))}"
+raw_body = f"payload={quote(json.dumps(body))}"
 
 
-def simple_listener(ack, body, action):
-    assert body == action
+def simple_listener(ack, body, payload, action):
+    assert body != payload
+    assert payload == action
     assert body["trigger_id"] == "111.222.valid"
     ack()

--- a/tests/scenario_tests/test_block_actions.py
+++ b/tests/scenario_tests/test_block_actions.py
@@ -107,7 +107,7 @@ class TestBlockActions:
         assert self.mock_received_requests["/auth.test"] == 2
 
 
-payload = {
+body = {
     "type": "block_actions",
     "user": {
         "id": "W111",
@@ -144,11 +144,12 @@ payload = {
     ],
 }
 
-raw_body = f"payload={quote(json.dumps(payload))}"
+raw_body = f"payload={quote(json.dumps(body))}"
 
 
-def simple_listener(ack, body, action):
+def simple_listener(ack, body, payload, action):
     assert body["trigger_id"] == "111.222.valid"
-    assert body["actions"][0] == action
+    assert body["actions"][0] == payload
+    assert payload == action
     assert action["action_id"] == "a"
     ack()

--- a/tests/scenario_tests/test_block_suggestion.py
+++ b/tests/scenario_tests/test_block_suggestion.py
@@ -158,7 +158,7 @@ class TestBlockSuggestion:
         assert self.mock_received_requests["/auth.test"] == 2
 
 
-payload = {
+body = {
     "type": "block_suggestion",
     "user": {
         "id": "W111",
@@ -231,12 +231,12 @@ payload = {
     },
 }
 
-raw_body = f"payload={quote(json.dumps(payload))}"
+raw_body = f"payload={quote(json.dumps(body))}"
 
-multi_payload = copy.deepcopy(payload)
-multi_payload["block_id"] = "mes_b"
-multi_payload["action_id"] = "mes_a"
-raw_multi_body = f"payload={quote(json.dumps(multi_payload))}"
+multi_body = copy.deepcopy(body)
+multi_body["block_id"] = "mes_b"
+multi_body["action_id"] = "mes_a"
+raw_multi_body = f"payload={quote(json.dumps(multi_body))}"
 
 response = {
     "options": [{"text": {"type": "plain_text", "text": "Maru"}, "value": "maru"}]
@@ -263,11 +263,13 @@ multi_response = {
 expected_multi_response_body = json.dumps(multi_response)
 
 
-def show_options(ack, body, options):
+def show_options(ack, body, payload, options):
     assert body == options
+    assert payload == options
     ack(response)
 
 
-def show_multi_options(ack, body, options):
+def show_multi_options(ack, body, payload, options):
     assert body == options
+    assert payload == options
     ack(multi_response)

--- a/tests/scenario_tests/test_dialogs.py
+++ b/tests/scenario_tests/test_dialogs.py
@@ -248,7 +248,7 @@ class TestAttachmentActions:
         assert self.mock_received_requests["/auth.test"] == 2
 
 
-suggestion_payload = {
+suggestion_body = {
     "type": "dialog_suggestion",
     "token": "verification_token",
     "action_ts": "1596603332.676855",
@@ -266,7 +266,7 @@ suggestion_payload = {
     "state": "Limo",
 }
 
-submission_payload = {
+submission_body = {
     "type": "dialog_submission",
     "token": "verification_token",
     "action_ts": "1596603334.328193",
@@ -288,7 +288,7 @@ submission_payload = {
     "state": "Limo",
 }
 
-cancellation_payload = {
+cancellation_body = {
     "type": "dialog_cancellation",
     "token": "verification_token",
     "action_ts": "1596603453.047897",
@@ -305,9 +305,9 @@ cancellation_payload = {
     "state": "Limo",
 }
 
-suggestion_raw_body = f"payload={quote(json.dumps(suggestion_payload))}"
-submission_raw_body = f"payload={quote(json.dumps(submission_payload))}"
-cancellation_raw_body = f"payload={quote(json.dumps(cancellation_payload))}"
+suggestion_raw_body = f"payload={quote(json.dumps(suggestion_body))}"
+submission_raw_body = f"payload={quote(json.dumps(submission_body))}"
+cancellation_raw_body = f"payload={quote(json.dumps(cancellation_body))}"
 
 
 def handle_submission(ack):
@@ -326,11 +326,13 @@ options_response = {
 }
 
 
-def handle_suggestion(ack, body, options):
+def handle_suggestion(ack, body, payload, options):
     assert body == options
+    assert payload == options
     ack(options_response)
 
 
-def handle_cancellation(ack, body, action):
+def handle_cancellation(ack, body, payload, action):
     assert body == action
+    assert payload == action
     ack()

--- a/tests/scenario_tests/test_error_handler.py
+++ b/tests/scenario_tests/test_error_handler.py
@@ -46,7 +46,7 @@ class TestErrorHandler:
         }
 
     def build_valid_request(self) -> BoltRequest:
-        payload = {
+        body = {
             "type": "block_actions",
             "user": {"id": "W111",},
             "api_app_id": "A111",
@@ -66,7 +66,7 @@ class TestErrorHandler:
                 }
             ],
         }
-        raw_body = f"payload={quote(json.dumps(payload))}"
+        raw_body = f"payload={quote(json.dumps(body))}"
         timestamp = str(int(time()))
         return BoltRequest(
             body=raw_body, headers=self.build_headers(timestamp, raw_body)

--- a/tests/scenario_tests/test_events.py
+++ b/tests/scenario_tests/test_events.py
@@ -39,7 +39,7 @@ class TestEvents:
             "x-slack-request-timestamp": [timestamp],
         }
 
-    valid_event_payload = {
+    valid_event_body = {
         "token": "verification_token",
         "team_id": "T111",
         "enterprise_id": "E111",
@@ -68,12 +68,13 @@ class TestEvents:
         app = App(client=self.web_client, signing_secret=self.signing_secret)
 
         @app.event("app_mention")
-        def handle_app_mention(payload, say, event):
-            assert payload == self.valid_event_payload
-            assert payload["event"] == event
+        def handle_app_mention(body, say, payload, event):
+            assert body == self.valid_event_body
+            assert body["event"] == payload
+            assert payload == event
             say("What's up?")
 
-        timestamp, body = str(int(time())), json.dumps(self.valid_event_payload)
+        timestamp, body = str(int(time())), json.dumps(self.valid_event_body)
         request: BoltRequest = BoltRequest(
             body=body, headers=self.build_headers(timestamp, body)
         )
@@ -91,11 +92,12 @@ class TestEvents:
             pass
 
         @app.event("app_mention", middleware=[skip_middleware])
-        def handle_app_mention(payload, logger, event):
-            assert payload["event"] == event
+        def handle_app_mention(body, logger, payload, event):
+            assert body["event"] == payload
+            assert payload == event
             logger.info(payload)
 
-        timestamp, body = str(int(time())), json.dumps(self.valid_event_payload)
+        timestamp, body = str(int(time())), json.dumps(self.valid_event_body)
         request: BoltRequest = BoltRequest(
             body=body, headers=self.build_headers(timestamp, body)
         )

--- a/tests/scenario_tests/test_lazy.py
+++ b/tests/scenario_tests/test_lazy.py
@@ -46,7 +46,7 @@ class TestErrorHandler:
         }
 
     def build_valid_request(self) -> BoltRequest:
-        payload = {
+        body = {
             "type": "block_actions",
             "user": {"id": "W111",},
             "api_app_id": "A111",
@@ -66,7 +66,7 @@ class TestErrorHandler:
                 }
             ],
         }
-        raw_body = f"payload={quote(json.dumps(payload))}"
+        raw_body = f"payload={quote(json.dumps(body))}"
         timestamp = str(int(time.time()))
         return BoltRequest(
             body=raw_body, headers=self.build_headers(timestamp, raw_body)

--- a/tests/scenario_tests/test_message.py
+++ b/tests/scenario_tests/test_message.py
@@ -42,11 +42,11 @@ class TestMessage:
         }
 
     def build_request(self) -> BoltRequest:
-        timestamp, body = str(int(time.time())), json.dumps(message_payload)
+        timestamp, body = str(int(time.time())), json.dumps(message_body)
         return BoltRequest(body=body, headers=self.build_headers(timestamp, body))
 
     def build_request2(self) -> BoltRequest:
-        timestamp, body = str(int(time.time())), json.dumps(message_payload2)
+        timestamp, body = str(int(time.time())), json.dumps(message_body2)
         return BoltRequest(body=body, headers=self.build_headers(timestamp, body))
 
     def test_string_keyword(self):
@@ -114,7 +114,7 @@ class TestMessage:
         assert self.mock_received_requests["/auth.test"] == 1
 
 
-message_payload = {
+message_body = {
     "token": "verification_token",
     "team_id": "T111",
     "enterprise_id": "E111",
@@ -149,12 +149,13 @@ message_payload = {
 }
 
 
-def whats_up(payload, say):
-    assert payload == message_payload
+def whats_up(body, payload, message, say):
+    assert body == message_body
+    assert payload == message
     say("What's up?")
 
 
-message_payload2 = {
+message_body2 = {
     "token": "verification_token",
     "team_id": "T111",
     "enterprise_id": "E111",
@@ -177,8 +178,9 @@ message_payload2 = {
 }
 
 
-def verify_matches(context, say, body, message):
+def verify_matches(context, say, body, payload, message):
     assert context["matches"] == ("103", "you")
     assert context.matches == ("103", "you")
     assert body["event"] == message
+    assert payload == message
     say("Thanks!")

--- a/tests/scenario_tests/test_middleware.py
+++ b/tests/scenario_tests/test_middleware.py
@@ -30,7 +30,7 @@ class TestMiddleware:
         restore_os_env(self.old_os_env)
 
     def build_request(self) -> BoltRequest:
-        payload = {
+        body = {
             "type": "shortcut",
             "token": "verification_token",
             "action_ts": "111.111",
@@ -44,7 +44,7 @@ class TestMiddleware:
             "callback_id": "test-shortcut",
             "trigger_id": "111.111.xxxxxx",
         }
-        timestamp, body = str(int(time())), json.dumps(payload)
+        timestamp, body = str(int(time())), json.dumps(body)
         return BoltRequest(
             body=body,
             headers={

--- a/tests/scenario_tests/test_shortcut.py
+++ b/tests/scenario_tests/test_shortcut.py
@@ -160,7 +160,7 @@ class TestShortcut:
         assert self.mock_received_requests["/auth.test"] == 3
 
 
-global_shortcut_payload = {
+global_shortcut_body = {
     "type": "shortcut",
     "token": "verification_token",
     "action_ts": "111.111",
@@ -175,7 +175,7 @@ global_shortcut_payload = {
     "trigger_id": "111.111.xxxxxx",
 }
 
-message_shortcut_payload = {
+message_shortcut_body = {
     "type": "message_action",
     "token": "verification_token",
     "action_ts": "1583637157.207593",
@@ -216,10 +216,11 @@ message_shortcut_payload = {
     "response_url": "https://hooks.slack.com/app/T111/111/xxx",
 }
 
-global_shortcut_raw_body = f"payload={quote(json.dumps(global_shortcut_payload))}"
-message_shortcut_raw_body = f"payload={quote(json.dumps(message_shortcut_payload))}"
+global_shortcut_raw_body = f"payload={quote(json.dumps(global_shortcut_body))}"
+message_shortcut_raw_body = f"payload={quote(json.dumps(message_shortcut_body))}"
 
 
-def simple_listener(ack, body, shortcut):
+def simple_listener(ack, body, payload, shortcut):
     assert body == shortcut
+    assert payload == shortcut
     ack()

--- a/tests/scenario_tests/test_slash_command.py
+++ b/tests/scenario_tests/test_slash_command.py
@@ -41,7 +41,7 @@ class TestSlashCommand:
         }
 
     def build_valid_request(self) -> BoltRequest:
-        timestamp, body = str(int(time())), json.dumps(slash_command_payload)
+        timestamp, body = str(int(time())), json.dumps(slash_command_body)
         return BoltRequest(body=body, headers=self.build_headers(timestamp, body))
 
     def test_mock_server_is_running(self):
@@ -83,7 +83,7 @@ class TestSlashCommand:
         assert self.mock_received_requests["/auth.test"] == 2
 
 
-slash_command_payload = (
+slash_command_body = (
     "token=verification_token"
     "&team_id=T111"
     "&team_domain=test-domain"
@@ -100,6 +100,7 @@ slash_command_payload = (
 )
 
 
-def commander(ack, body, command):
+def commander(ack, body, payload, command):
     assert body == command
+    assert payload == command
     ack()

--- a/tests/scenario_tests/test_view_closed.py
+++ b/tests/scenario_tests/test_view_closed.py
@@ -119,7 +119,7 @@ class TestViewClosed:
         assert self.mock_received_requests["/auth.test"] == 2
 
 
-payload = {
+body = {
     "type": "view_closed",
     "team": {
         "id": "T111",
@@ -167,10 +167,11 @@ payload = {
     "response_urls": [],
 }
 
-raw_body = f"payload={quote(json.dumps(payload))}"
+raw_body = f"payload={quote(json.dumps(body))}"
 
 
-def simple_listener(ack, body, view):
-    assert body["view"] == view
+def simple_listener(ack, body, payload, view):
+    assert body["view"] == payload
+    assert payload == view
     assert view["private_metadata"] == "This is for you!"
     ack()

--- a/tests/scenario_tests/test_view_submission.py
+++ b/tests/scenario_tests/test_view_submission.py
@@ -107,7 +107,7 @@ class TestViewSubmission:
         assert self.mock_received_requests["/auth.test"] == 2
 
 
-payload = {
+body = {
     "type": "view_submission",
     "team": {
         "id": "T111",
@@ -158,11 +158,12 @@ payload = {
     "response_urls": [],
 }
 
-raw_body = f"payload={quote(json.dumps(payload))}"
+raw_body = f"payload={quote(json.dumps(body))}"
 
 
-def simple_listener(ack, body, view):
+def simple_listener(ack, body, payload, view):
     assert body["trigger_id"] == "111.222.valid"
-    assert body["view"] == view
+    assert body["view"] == payload
+    assert payload == view
     assert view["private_metadata"] == "This is for you!"
     ack()


### PR DESCRIPTION
This pull request fixes #61 by correcting the definitions of `body` and `payload` in middleware/listener args.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
