### PR TITLE
Fix #64 by correcting say() implementation

### DIFF
--- a/samples/events_app.py
+++ b/samples/events_app.py
@@ -27,6 +27,11 @@ def event_test(body, say, logger):
     say("What's up?")
 
 
+@app.event("reaction_added")
+def say_something_to_reaction(say):
+    say("OK!")
+
+
 @app.message("test")
 def test_message(logger, body):
     logger.info(body)

--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -104,6 +104,9 @@ def extract_channel_id(payload: Dict[str, Any]) -> Optional[str]:
         return payload.get("channel_id")
     if "event" in payload:
         return extract_channel_id(payload["event"])
+    if "item" in payload:
+        # reaction_added: body["event"]["item"]
+        return extract_channel_id(payload["item"])
     return None
 
 

--- a/tests/slack_bolt/request/test_internals.py
+++ b/tests/slack_bolt/request/test_internals.py
@@ -1,0 +1,67 @@
+from slack_bolt.request.internals import (
+    extract_channel_id,
+    extract_user_id,
+    extract_team_id,
+    extract_enterprise_id,
+)
+
+
+class TestRequestInternals:
+    def setup_method(self):
+        pass
+
+    def teardown_method(self):
+        pass
+
+    # based on https://github.com/slackapi/bolt-js/blob/f8c25ffb5cd91827510bbc689e97556d2d5ad017/src/App.spec.ts#L1123
+    requests = [
+        {
+            "event": {"channel": "C111", "user": "U111"},
+            "team_id": "T111",
+            "enterprise_id": "E111",
+        },
+        {
+            "event": {"item": {"channel": "C111"}, "user": "U111", "item_user": "U222"},
+            "team_id": "T111",
+            "enterprise_id": "E111",
+        },
+        {
+            "command": "/hello",
+            "channel_id": "C111",
+            "team_id": "T111",
+            "enterprise_id": "E111",
+            "user_id": "U111",
+        },
+        {
+            "actions": [{}],
+            "channel": {"id": "C111"},
+            "user": {"id": "U111"},
+            "team": {"id": "T111", "enterprise_id": "E111"},
+        },
+        {
+            "type": "dialog_submission",
+            "channel": {"id": "C111"},
+            "user": {"id": "U111"},
+            "team": {"id": "T111", "enterprise_id": "E111"},
+        },
+    ]
+
+    def test_channel_id_extraction(self):
+        for req in self.requests:
+            channel_id = extract_channel_id(req)
+            assert channel_id == "C111"
+
+    def test_user_id_extraction(self):
+        for req in self.requests:
+            user_id = extract_user_id(req)
+            assert user_id == "U111"
+
+    def test_team_id_extraction(self):
+        for req in self.requests:
+            team_id = extract_team_id(req)
+            assert team_id == "T111"
+
+    def test_enterprise_id_extraction(self):
+        for req in self.requests:
+            team_id = extract_enterprise_id(req)
+            assert team_id == "E111"


### PR DESCRIPTION
This pull request fixes #64 by correcting the extraction of channel ID in the request parser.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
