### PR TITLE
Fix #65 by having block_actions as the default when type is missing in constraints

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -590,13 +590,13 @@ class App:
 
     def block_action(
         self,
-        action_id: Union[str, Pattern],
+        constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
     ):
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
-            primary_matcher = builtin_matchers.block_action(action_id)
+            primary_matcher = builtin_matchers.block_action(constraints)
             return self._register_listener(
                 list(functions), primary_matcher, matchers, middleware
             )

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -622,13 +622,13 @@ class AsyncApp:
 
     def block_action(
         self,
-        action_id: Union[str, Pattern],
+        constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
     ):
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
-            primary_matcher = builtin_matchers.block_action(action_id, True)
+            primary_matcher = builtin_matchers.block_action(constraints, True)
             return self._register_listener(
                 list(functions), primary_matcher, matchers, middleware
             )

--- a/tests/async_scenario_tests/test_block_actions.py
+++ b/tests/async_scenario_tests/test_block_actions.py
@@ -79,6 +79,36 @@ class TestAsyncBlockActions:
         assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
+    async def test_default_type(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret,)
+        app.action({"action_id": "a", "block_id": "b"})(simple_listener)
+
+        request = self.build_valid_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
+    @pytest.mark.asyncio
+    async def test_default_type_no_block_id(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret,)
+        app.action({"action_id": "a"})(simple_listener)
+
+        request = self.build_valid_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
+    @pytest.mark.asyncio
+    async def test_default_type_unmatched_block_id(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret,)
+        app.action({"action_id": "a", "block_id": "bbb"})(simple_listener)
+
+        request = self.build_valid_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        assert self.mock_received_requests["/auth.test"] == 1
+
+    @pytest.mark.asyncio
     async def test_process_before_response(self):
         app = AsyncApp(
             client=self.web_client,

--- a/tests/scenario_tests/test_block_actions.py
+++ b/tests/scenario_tests/test_block_actions.py
@@ -82,6 +82,33 @@ class TestBlockActions:
         assert response.status == 200
         assert self.mock_received_requests["/auth.test"] == 1
 
+    def test_default_type(self):
+        app = App(client=self.web_client, signing_secret=self.signing_secret)
+        app.action({"action_id": "a", "block_id": "b"})(simple_listener)
+
+        request = self.build_valid_request()
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
+    def test_default_type_no_block_id(self):
+        app = App(client=self.web_client, signing_secret=self.signing_secret)
+        app.action({"action_id": "a"})(simple_listener)
+
+        request = self.build_valid_request()
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
+    def test_default_type_and_unmatched_block_id(self):
+        app = App(client=self.web_client, signing_secret=self.signing_secret)
+        app.action({"action_id": "a", "block_id": "bbb"})(simple_listener)
+
+        request = self.build_valid_request()
+        response = app.dispatch(request)
+        assert response.status == 404
+        assert self.mock_received_requests["/auth.test"] == 1
+
     def test_failure(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
         request = self.build_valid_request()

--- a/tests/slack_bolt/listener_matcher/test_builtins.py
+++ b/tests/slack_bolt/listener_matcher/test_builtins.py
@@ -1,0 +1,97 @@
+import json
+import re
+from urllib.parse import quote
+
+from slack_bolt import BoltRequest, BoltResponse
+from slack_bolt.listener_matcher.builtins import block_action, action
+
+
+class TestBuiltins:
+    def setup_method(self):
+        pass
+
+    def teardown_method(self):
+        pass
+
+    def test_block_action(self):
+        body = {
+            "type": "block_actions",
+            "actions": [
+                {
+                    "type": "button",
+                    "action_id": "valid_action_id",
+                    "block_id": "b",
+                    "action_ts": "111.222",
+                    "value": "v",
+                }
+            ],
+        }
+        raw_body = f"payload={quote(json.dumps(body))}"
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        req = BoltRequest(body=raw_body, headers=headers)
+        resp = BoltResponse(status=404)
+
+        assert block_action("valid_action_id").matches(req, resp) is True
+        assert block_action("invalid_action_id").matches(req, resp) is False
+        assert block_action(re.compile("valid_.+")).matches(req, resp) is True
+        assert block_action(re.compile("invalid_.+")).matches(req, resp) is False
+
+        assert action("valid_action_id").matches(req, resp) is True
+        assert action("invalid_action_id").matches(req, resp) is False
+        assert action(re.compile("valid_.+")).matches(req, resp) is True
+        assert action(re.compile("invalid_.+")).matches(req, resp) is False
+
+        assert action({"action_id": "valid_action_id"}).matches(req, resp) is True
+        assert action({"action_id": "invalid_action_id"}).matches(req, resp) is False
+        assert action({"action_id": re.compile("valid_.+")}).matches(req, resp) is True
+        assert (
+            action({"action_id": re.compile("invalid_.+")}).matches(req, resp) is False
+        )
+
+        assert (
+            action({"action_id": "valid_action_id", "block_id": "b"}).matches(req, resp)
+            is True
+        )
+        assert (
+            action({"action_id": "invalid_action_id", "block_id": "b"}).matches(
+                req, resp
+            )
+            is False
+        )
+        assert (
+            action({"action_id": re.compile("valid_.+"), "block_id": "b"}).matches(
+                req, resp
+            )
+            is True
+        )
+        assert (
+            action({"action_id": re.compile("invalid_.+"), "block_id": "b"}).matches(
+                req, resp
+            )
+            is False
+        )
+
+        assert (
+            action({"action_id": "valid_action_id", "block_id": "bbb"}).matches(
+                req, resp
+            )
+            is False
+        )
+        assert (
+            action({"action_id": "invalid_action_id", "block_id": "bbb"}).matches(
+                req, resp
+            )
+            is False
+        )
+        assert (
+            action({"action_id": re.compile("valid_.+"), "block_id": "bbb"}).matches(
+                req, resp
+            )
+            is False
+        )
+        assert (
+            action({"action_id": re.compile("invalid_.+"), "block_id": "bbb"}).matches(
+                req, resp
+            )
+            is False
+        )


### PR DESCRIPTION
This pull request fixes #65 by allowing to omit having `"type": "block_actions"` in constraints for `app.action`. Also, it enables the framework to consider `block_id` as one of the conditions for listener executions.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
