### PR TITLE
Add full support for Ack/AsyncAck's keyword args

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -40,7 +40,7 @@ from slack_bolt.middleware.url_verification import UrlVerification
 from slack_bolt.oauth import OAuthFlow
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
-from slack_bolt.util.utils import create_web_client, _copy_object
+from slack_bolt.util.utils import create_web_client, create_copy
 
 
 class App:
@@ -432,7 +432,7 @@ class App:
 
     @staticmethod
     def _build_lazy_request(request: BoltRequest, lazy_func_name: str) -> BoltRequest:
-        copied_request = _copy_object(request)
+        copied_request = create_copy(request)
         copied_request.method = "NONE"
         copied_request.lazy_only = True
         copied_request.lazy_function_name = lazy_func_name

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -52,7 +52,7 @@ from slack_bolt.oauth.async_oauth_flow import AsyncOAuthFlow
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 from slack_bolt.util.async_utils import create_async_web_client
-from slack_bolt.util.utils import _copy_object
+from slack_bolt.util.utils import create_copy
 
 
 class AsyncApp:
@@ -464,7 +464,7 @@ class AsyncApp:
     def _build_lazy_request(
         request: AsyncBoltRequest, lazy_func_name: str
     ) -> AsyncBoltRequest:
-        copied_request = _copy_object(request)
+        copied_request = create_copy(request)
         copied_request.method = "NONE"
         copied_request.lazy_only = True
         copied_request.lazy_function_name = lazy_func_name

--- a/slack_bolt/context/ack/ack.py
+++ b/slack_bolt/context/ack/ack.py
@@ -1,7 +1,8 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 
 from slack_sdk.models.attachments import Attachment
 from slack_sdk.models.blocks import Block, Option, OptionGroup
+from slack_sdk.models.views import View
 
 from slack_bolt.context.ack.internals import _set_response
 from slack_bolt.response.response import BoltResponse
@@ -18,14 +19,24 @@ class Ack:
         text: Union[str, dict] = "",  # text: str or whole_response: dict
         blocks: Optional[List[Union[dict, Block]]] = None,
         attachments: Optional[List[Union[dict, Attachment]]] = None,
+        response_type: Optional[str] = None,  # in_channel / ephemeral
+        # block_suggestion / dialog_suggestion
         options: Optional[List[Union[dict, Option]]] = None,
         option_groups: Optional[List[Union[dict, OptionGroup]]] = None,
+        # view_submission
+        response_action: Optional[str] = None,  # errors / update / push / clear
+        errors: Optional[Dict[str, str]] = None,
+        view: Optional[Union[dict, View]] = None,
     ) -> BoltResponse:
         return _set_response(
             self,
             text_or_whole_response=text,
             blocks=blocks,
             attachments=attachments,
+            response_type=response_type,
             options=options,
             option_groups=option_groups,
+            response_action=response_action,
+            errors=errors,
+            view=view,
         )

--- a/slack_bolt/context/ack/async_ack.py
+++ b/slack_bolt/context/ack/async_ack.py
@@ -1,7 +1,8 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 
 from slack_sdk.models.attachments import Attachment
 from slack_sdk.models.blocks import Block, Option, OptionGroup
+from slack_sdk.models.views import View
 
 from slack_bolt.context.ack.internals import _set_response
 from slack_bolt.response.response import BoltResponse
@@ -18,14 +19,24 @@ class AsyncAck:
         text: Union[str, dict] = "",  # text: str or whole_response: dict
         blocks: Optional[List[Union[dict, Block]]] = None,
         attachments: Optional[List[Union[dict, Attachment]]] = None,
+        response_type: Optional[str] = None,  # in_channel / ephemeral
+        # block_suggestion / dialog_suggestion
         options: Optional[List[Union[dict, Option]]] = None,
         option_groups: Optional[List[Union[dict, OptionGroup]]] = None,
+        # view_submission
+        response_action: Optional[str] = None,  # errors / update / push / clear
+        errors: Optional[Dict[str, str]] = None,
+        view: Optional[Union[dict, View]] = None,
     ) -> BoltResponse:
         return _set_response(
             self,
             text_or_whole_response=text,
             blocks=blocks,
             attachments=attachments,
+            response_type=response_type,
             options=options,
             option_groups=option_groups,
+            response_action=response_action,
+            errors=errors,
+            view=view,
         )

--- a/slack_bolt/context/ack/internals.py
+++ b/slack_bolt/context/ack/internals.py
@@ -1,11 +1,12 @@
-from typing import Optional, List, Union, Any
+from typing import Optional, List, Union, Any, Dict
 
 from slack_sdk.models.attachments import Attachment
 from slack_sdk.models.blocks import Block, Option, OptionGroup
+from slack_sdk.models.views import View
 
 from slack_bolt.error import BoltError
 from slack_bolt.response import BoltResponse
-from slack_bolt.util.utils import convert_to_dict_list
+from slack_bolt.util.utils import convert_to_dict_list, _to_dict
 
 
 def _set_response(
@@ -13,30 +14,59 @@ def _set_response(
     text_or_whole_response: Union[str, dict] = "",
     blocks: Optional[List[Union[dict, Block]]] = None,
     attachments: Optional[List[Union[dict, Attachment]]] = None,
+    response_type: Optional[str] = None,  # in_channel / ephemeral
+    # block_suggestion / dialog_suggestion
     options: Optional[List[Union[dict, Option]]] = None,
     option_groups: Optional[List[Union[dict, OptionGroup]]] = None,
+    # view_submission
+    response_action: Optional[str] = None,
+    errors: Optional[Dict[str, str]] = None,
+    view: Optional[Union[dict, View]] = None,
 ) -> BoltResponse:
     if isinstance(text_or_whole_response, str):
         text: str = text_or_whole_response
+        body = {"text": text}
+        if response_type:
+            body["response_type"] = response_type
         if attachments and len(attachments) > 0:
-            self.response = BoltResponse(
-                status=200,
-                body={"text": text, "attachments": convert_to_dict_list(attachments),},
+            body.update(
+                {"text": text, "attachments": convert_to_dict_list(attachments)}
             )
+            self.response = BoltResponse(status=200, body=body)
         elif blocks and len(blocks) > 0:
-            self.response = BoltResponse(
-                status=200, body={"text": text, "blocks": convert_to_dict_list(blocks),}
-            )
+            body.update({"text": text, "blocks": convert_to_dict_list(blocks)})
+            self.response = BoltResponse(status=200, body=body)
         elif options and len(options) > 0:
-            self.response = BoltResponse(
-                status=200, body={"options": convert_to_dict_list(options),}
-            )
+            body = {"options": convert_to_dict_list(options)}
+            self.response = BoltResponse(status=200, body=body)
         elif option_groups and len(option_groups) > 0:
-            self.response = BoltResponse(
-                status=200, body={"option_groups": convert_to_dict_list(option_groups),}
-            )
+            body = {"option_groups": convert_to_dict_list(option_groups)}
+            self.response = BoltResponse(status=200, body=body)
+        elif response_action:
+            # These patterns are in response to view_submission requests
+            if response_action == "errors":
+                if errors:
+                    self.response = BoltResponse(
+                        status=200,
+                        body={
+                            "response_action": response_action,
+                            "errors": _to_dict(errors),
+                        },
+                    )
+                else:
+                    raise ValueError(
+                        f"errors field is required for response_action: errors"
+                    )
+            else:
+                body = {"response_action": response_action}
+                if view:
+                    body["view"] = _to_dict(view)
+                self.response = BoltResponse(status=200, body=body)
         else:
-            self.response = BoltResponse(status=200, body=text)
+            if len(body) == 1 and "text" in body:
+                self.response = BoltResponse(status=200, body=body["text"])
+            else:
+                self.response = BoltResponse(status=200, body=body)
         return self.response
     elif isinstance(text_or_whole_response, dict):
         body = text_or_whole_response
@@ -48,6 +78,14 @@ def _set_response(
             body["options"] = convert_to_dict_list(body["options"])
         if "option_groups" in body:
             body["option_groups"] = convert_to_dict_list(body["option_groups"])
+        if "response_type" in body:
+            body["response_type"] = body["response_type"]
+        if "response_action" in body:
+            body["response_action"] = body["response_action"]
+        if "errors" in body:
+            body["errors"] = _to_dict(body["errors"])
+        if "view" in body:
+            body["view"] = _to_dict(body["view"])
 
         self.response = BoltResponse(status=200, body=body)
         return self.response

--- a/slack_bolt/context/ack/internals.py
+++ b/slack_bolt/context/ack/internals.py
@@ -6,7 +6,7 @@ from slack_sdk.models.views import View
 
 from slack_bolt.error import BoltError
 from slack_bolt.response import BoltResponse
-from slack_bolt.util.utils import convert_to_dict_list, _to_dict
+from slack_bolt.util.utils import convert_to_dict_list, convert_to_dict
 
 
 def _set_response(
@@ -50,7 +50,7 @@ def _set_response(
                         status=200,
                         body={
                             "response_action": response_action,
-                            "errors": _to_dict(errors),
+                            "errors": convert_to_dict(errors),
                         },
                     )
                 else:
@@ -60,7 +60,7 @@ def _set_response(
             else:
                 body = {"response_action": response_action}
                 if view:
-                    body["view"] = _to_dict(view)
+                    body["view"] = convert_to_dict(view)
                 self.response = BoltResponse(status=200, body=body)
         else:
             if len(body) == 1 and "text" in body:
@@ -83,9 +83,9 @@ def _set_response(
         if "response_action" in body:
             body["response_action"] = body["response_action"]
         if "errors" in body:
-            body["errors"] = _to_dict(body["errors"])
+            body["errors"] = convert_to_dict(body["errors"])
         if "view" in body:
-            body["view"] = _to_dict(body["view"])
+            body["view"] = convert_to_dict(body["view"])
 
         self.response = BoltResponse(status=200, body=body)
         return self.response

--- a/slack_bolt/context/ack/internals.py
+++ b/slack_bolt/context/ack/internals.py
@@ -78,14 +78,11 @@ def _set_response(
             body["options"] = convert_to_dict_list(body["options"])
         if "option_groups" in body:
             body["option_groups"] = convert_to_dict_list(body["option_groups"])
-        if "response_type" in body:
-            body["response_type"] = body["response_type"]
-        if "response_action" in body:
-            body["response_action"] = body["response_action"]
         if "errors" in body:
             body["errors"] = convert_to_dict(body["errors"])
         if "view" in body:
             body["view"] = convert_to_dict(body["view"])
+        # no modification for response_type, response_action here
 
         self.response = BoltResponse(status=200, body=body)
         return self.response

--- a/slack_bolt/util/utils.py
+++ b/slack_bolt/util/utils.py
@@ -14,10 +14,10 @@ def create_web_client(token: Optional[str] = None) -> WebClient:
 
 
 def convert_to_dict_list(objects: List[Union[Dict, JsonObject]]) -> List[Dict]:
-    return [_to_dict(elm) for elm in objects]
+    return [convert_to_dict(elm) for elm in objects]
 
 
-def _to_dict(obj: Union[Dict, JsonObject]) -> Dict:
+def convert_to_dict(obj: Union[Dict, JsonObject]) -> Dict:
     if isinstance(obj, dict):
         return obj
     if isinstance(obj, JsonObject) or hasattr(obj, "to_dict"):
@@ -25,7 +25,7 @@ def _to_dict(obj: Union[Dict, JsonObject]) -> Dict:
     raise BoltError(f"{obj} (type: {type(obj)}) is unsupported")
 
 
-def _copy_object(original: Any) -> Any:
+def create_copy(original: Any) -> Any:
     if sys.version_info.major == 3 and sys.version_info.minor <= 6:
         # NOTE: Unfortunately, copy.deepcopy doesn't work in Python 3.6.5.
         # --------------------

--- a/tests/slack_bolt/context/test_ack.py
+++ b/tests/slack_bolt/context/test_ack.py
@@ -1,3 +1,6 @@
+from slack_sdk.models.blocks import PlainTextObject, DividerBlock
+from slack_sdk.models.views import View
+
 from slack_bolt import Ack, BoltResponse
 
 
@@ -69,6 +72,32 @@ class TestAck:
             '"title": {"type": "plain_text", "text": "My App"}, '
             '"close": {"type": "plain_text", "text": "Cancel"}, '
             '"blocks": [{"type": "divider", "block_id": "b"}]'
+            "}"
+            "}",
+        )
+
+    def test_view_update_2(self):
+        ack = Ack()
+        response: BoltResponse = ack(
+            response_action="update",
+            view=View(
+                type="modal",
+                callback_id="view-id",
+                title=PlainTextObject(text="My App"),
+                close=PlainTextObject(text="Cancel"),
+                blocks=[DividerBlock(block_id="b")],
+            ),
+        )
+        assert (response.status, response.body) == (
+            200,
+            ""
+            '{"response_action": "update", '
+            '"view": {'
+            '"blocks": [{"block_id": "b", "type": "divider"}], '
+            '"callback_id": "view-id", '
+            '"close": {"text": "Cancel", "type": "plain_text"}, '
+            '"title": {"text": "My App", "type": "plain_text"}, '
+            '"type": "modal"'
             "}"
             "}",
         )

--- a/tests/slack_bolt/context/test_ack.py
+++ b/tests/slack_bolt/context/test_ack.py
@@ -1,0 +1,74 @@
+from slack_bolt import Ack, BoltResponse
+
+
+class TestAck:
+    def setup_method(self):
+        pass
+
+    def teardown_method(self):
+        pass
+
+    def test_text(self):
+        ack = Ack()
+        response: BoltResponse = ack(text="foo")
+        assert (response.status, response.body) == (200, "foo")
+
+    def test_blocks(self):
+        ack = Ack()
+        response: BoltResponse = ack(text="foo", blocks=[{"type": "divider"}])
+        assert (response.status, response.body) == (
+            200,
+            '{"text": "foo", "blocks": [{"type": "divider"}]}',
+        )
+
+    def test_response_type(self):
+        ack = Ack()
+        response: BoltResponse = ack(text="foo", response_type="in_channel")
+        assert (response.status, response.body) == (
+            200,
+            '{"text": "foo", "response_type": "in_channel"}',
+        )
+
+    def test_view_errors(self):
+        ack = Ack()
+        response: BoltResponse = ack(
+            response_action="errors",
+            errors={
+                "block_title": "Title is required",
+                "block_description": "Description must be longer than 10 characters",
+            },
+        )
+        assert (response.status, response.body) == (
+            200,
+            '{"response_action": "errors", '
+            '"errors": {'
+            '"block_title": "Title is required", '
+            '"block_description": "Description must be longer than 10 characters"'
+            "}"
+            "}",
+        )
+
+    def test_view_update(self):
+        ack = Ack()
+        response: BoltResponse = ack(
+            response_action="update",
+            view={
+                "type": "modal",
+                "callback_id": "view-id",
+                "title": {"type": "plain_text", "text": "My App",},
+                "close": {"type": "plain_text", "text": "Cancel",},
+                "blocks": [{"type": "divider", "block_id": "b"}],
+            },
+        )
+        assert (response.status, response.body) == (
+            200,
+            '{"response_action": "update", '
+            '"view": {'
+            '"type": "modal", '
+            '"callback_id": "view-id", '
+            '"title": {"type": "plain_text", "text": "My App"}, '
+            '"close": {"type": "plain_text", "text": "Cancel"}, '
+            '"blocks": [{"type": "divider", "block_id": "b"}]'
+            "}"
+            "}",
+        )

--- a/tests/slack_bolt_async/context/test_async_ack.py
+++ b/tests/slack_bolt_async/context/test_async_ack.py
@@ -1,4 +1,6 @@
 import pytest
+from slack_sdk.models.blocks import PlainTextObject, DividerBlock
+from slack_sdk.models.views import View
 
 from slack_bolt import BoltResponse
 from slack_bolt.context.ack.async_ack import AsyncAck
@@ -71,6 +73,33 @@ class TestAsyncAsyncAck:
             '"title": {"type": "plain_text", "text": "My App"}, '
             '"close": {"type": "plain_text", "text": "Cancel"}, '
             '"blocks": [{"type": "divider", "block_id": "b"}]'
+            "}"
+            "}",
+        )
+
+    @pytest.mark.asyncio
+    async def test_view_update_2(self):
+        ack = AsyncAck()
+        response: BoltResponse = await ack(
+            response_action="update",
+            view=View(
+                type="modal",
+                callback_id="view-id",
+                title=PlainTextObject(text="My App"),
+                close=PlainTextObject(text="Cancel"),
+                blocks=[DividerBlock(block_id="b")],
+            ),
+        )
+        assert (response.status, response.body) == (
+            200,
+            ""
+            '{"response_action": "update", '
+            '"view": {'
+            '"blocks": [{"block_id": "b", "type": "divider"}], '
+            '"callback_id": "view-id", '
+            '"close": {"text": "Cancel", "type": "plain_text"}, '
+            '"title": {"text": "My App", "type": "plain_text"}, '
+            '"type": "modal"'
             "}"
             "}",
         )

--- a/tests/slack_bolt_async/context/test_async_ack.py
+++ b/tests/slack_bolt_async/context/test_async_ack.py
@@ -1,0 +1,76 @@
+import pytest
+
+from slack_bolt import BoltResponse
+from slack_bolt.context.ack.async_ack import AsyncAck
+
+
+class TestAsyncAsyncAck:
+    @pytest.mark.asyncio
+    async def test_text(self):
+        ack = AsyncAck()
+        response: BoltResponse = await ack(text="foo")
+        assert (response.status, response.body) == (200, "foo")
+
+    @pytest.mark.asyncio
+    async def test_blocks(self):
+        ack = AsyncAck()
+        response: BoltResponse = await ack(text="foo", blocks=[{"type": "divider"}])
+        assert (response.status, response.body) == (
+            200,
+            '{"text": "foo", "blocks": [{"type": "divider"}]}',
+        )
+
+    @pytest.mark.asyncio
+    async def test_response_type(self):
+        ack = AsyncAck()
+        response: BoltResponse = await ack(text="foo", response_type="in_channel")
+        assert (response.status, response.body) == (
+            200,
+            '{"text": "foo", "response_type": "in_channel"}',
+        )
+
+    @pytest.mark.asyncio
+    async def test_view_errors(self):
+        ack = AsyncAck()
+        response: BoltResponse = await ack(
+            response_action="errors",
+            errors={
+                "block_title": "Title is required",
+                "block_description": "Description must be longer than 10 characters",
+            },
+        )
+        assert (response.status, response.body) == (
+            200,
+            '{"response_action": "errors", '
+            '"errors": {'
+            '"block_title": "Title is required", '
+            '"block_description": "Description must be longer than 10 characters"'
+            "}"
+            "}",
+        )
+
+    @pytest.mark.asyncio
+    async def test_view_update(self):
+        ack = AsyncAck()
+        response: BoltResponse = await ack(
+            response_action="update",
+            view={
+                "type": "modal",
+                "callbAsyncAck_id": "view-id",
+                "title": {"type": "plain_text", "text": "My App",},
+                "close": {"type": "plain_text", "text": "Cancel",},
+                "blocks": [{"type": "divider", "block_id": "b"}],
+            },
+        )
+        assert (response.status, response.body) == (
+            200,
+            '{"response_action": "update", '
+            '"view": {'
+            '"type": "modal", '
+            '"callbAsyncAck_id": "view-id", '
+            '"title": {"type": "plain_text", "text": "My App"}, '
+            '"close": {"type": "plain_text", "text": "Cancel"}, '
+            '"blocks": [{"type": "divider", "block_id": "b"}]'
+            "}"
+            "}",
+        )


### PR DESCRIPTION
Passing a dict value for any patterns has been already available but some keyword args had been unsupported.

```python
ack({
    "response_action": "errors"
    "errors": {"block_title": "title is required"}
})
```

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
