### PR TITLE
Fix #73 by adding oauth_settings to App and its underlying

### DIFF
--- a/samples/oauth_app_settings.py
+++ b/samples/oauth_app_settings.py
@@ -6,20 +6,42 @@ sys.path.insert(1, "..")
 # ------------------------------------------------
 
 import logging
-from slack_bolt import App
+import os
+from slack_bolt import App, BoltResponse
+from slack_bolt.oauth.callback_options import CallbackOptions, SuccessArgs, FailureArgs
+from slack_bolt.oauth.oauth_settings import OAuthSettings
+
+from slack_sdk.oauth.installation_store import FileInstallationStore
+from slack_sdk.oauth.state_store import FileOAuthStateStore
 
 logging.basicConfig(level=logging.DEBUG)
-app = App()
 
+def success(args: SuccessArgs) -> BoltResponse:
+    return BoltResponse(status=200, body="Thanks!")
 
-@app.event("app_mention")
-def event_test(body, say, logger):
-    logger.info(body)
-    say("What's up?")
+def failure(args: FailureArgs) -> BoltResponse:
+    return BoltResponse(status=args.suggested_status_code, body=args.reason)
 
+app = App(
+    signing_secret=os.environ.get("SLACK_SIGNING_SECRET"),
+    installation_store=FileInstallationStore(),
+    oauth_settings=OAuthSettings(
+        client_id=os.environ.get("SLACK_CLIENT_ID"),
+        client_secret=os.environ.get("SLACK_CLIENT_SECRET"),
+        scopes=["app_mentions:read","channels:history","im:history","chat:write"],
+        user_scopes=[],
+        redirect_uri=None,
+        install_path="/slack/install",
+        redirect_uri_path="/slack/oauth_redirect",
+        state_store=FileOAuthStateStore(expiration_seconds=600),
+        callback_options=CallbackOptions(
+            success=success,
+            failure=failure
+        )
+    )
+)
 
 @app.command("/hello-bolt-python")
-# or app.command(re.compile(r"/hello-.+"))(test_command)
 def test_command(body, respond, client, ack, logger):
     logger.info(body)
     ack("Thanks!")
@@ -83,5 +105,4 @@ if __name__ == "__main__":
 # export SLACK_SIGNING_SECRET=***
 # export SLACK_CLIENT_ID=111.111
 # export SLACK_CLIENT_SECRET=***
-# export SLACK_SCOPES=app_mentions:read,channels:history,im:history,chat:write
 # python oauth_app.py

--- a/slack_bolt/adapter/aws_lambda/handler.py
+++ b/slack_bolt/adapter/aws_lambda/handler.py
@@ -17,7 +17,7 @@ class SlackRequestHandler:
         self.logger = get_bolt_app_logger(app.name, SlackRequestHandler)
         self.app.lazy_listener_runner = LambdaLazyListenerRunner(self.logger)
         if self.app.oauth_flow is not None:
-            self.app.oauth_flow.redirect_uri_page_renderer.install_path = "?"
+            self.app.oauth_flow.settings.redirect_uri_page_renderer.install_path = "?"
 
     @classmethod
     def clear_all_log_handlers(cls):

--- a/slack_bolt/adapter/aws_lambda/lambda_s3_oauth_flow.py
+++ b/slack_bolt/adapter/aws_lambda/lambda_s3_oauth_flow.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from logging import Logger
 from typing import Optional
 
@@ -10,6 +9,7 @@ from slack_sdk import WebClient
 from slack_sdk.oauth.installation_store.amazon_s3 import AmazonS3InstallationStore
 from slack_sdk.oauth.state_store.amazon_s3 import AmazonS3OAuthStateStore
 
+from slack_bolt.oauth.oauth_settings import OAuthSettings
 from slack_bolt.util.utils import create_web_client
 
 
@@ -19,73 +19,27 @@ class LambdaS3OAuthFlow(OAuthFlow):
         *,
         client: Optional[WebClient] = None,
         logger: Optional[Logger] = None,
+        settings: OAuthSettings,
         oauth_state_bucket_name: Optional[str] = None,  # required
         installation_bucket_name: Optional[str] = None,  # required
-        oauth_state_cookie_name: str = "slack-app-oauth-state",
-        oauth_state_expiration_seconds: int = 60 * 10,  # 10 minutes
-        client_id: Optional[str] = None,  # required
-        client_secret: Optional[str] = None,  # required
-        scopes: Optional[str] = None,  # required
-        user_scopes: Optional[str] = None,
-        redirect_uri: Optional[str] = None,
-        install_path: Optional[str] = None,  # required
-        redirect_uri_path: Optional[str] = None,  # required
-        success_url: Optional[str] = None,
-        failure_url: Optional[str] = None,
     ):
-        self._client = client
-        self._logger = logger
+        super(OAuthFlow, self).__init__(
+            client=client, logger=logger, settings=settings,
+        )
 
         self.s3_client = boto3.client("s3")
-
-        oauth_state_bucket_name = (
-            oauth_state_bucket_name
-            or os.environ["SLACK_STATE_S3_BUCKET_NAME"]  # required
-        )
-        installation_bucket_name = (
-            installation_bucket_name
-            or os.environ["SLACK_INSTALLATION_S3_BUCKET_NAME"]  # required
-        )
-
-        client_id = client_id or os.environ["SLACK_CLIENT_ID"]  # required
-        client_secret = client_secret or os.environ["SLACK_CLIENT_SECRET"]  # required
-        scopes = scopes or os.environ.get("SLACK_SCOPES", None)
-        user_scopes = user_scopes or os.environ.get("SLACK_USER_SCOPES", None)
-        redirect_uri = redirect_uri or os.environ.get("SLACK_REDIRECT_URI", None)
-        install_path = install_path or os.environ.get(
-            "SLACK_LAMBDA_PATH", "/slack/install"
-        )
-        redirect_uri_path = redirect_uri_path or os.environ.get(
-            "SLACK_LAMBDA_PATH", "/slack/oauth_redirect"
-        )
-
         self.oauth_state_store = AmazonS3OAuthStateStore(
             logger=self.logger,
             s3_client=self.s3_client,
             bucket_name=oauth_state_bucket_name,
-            expiration_seconds=oauth_state_expiration_seconds,
+            expiration_seconds=self.settings.state_expiration_seconds,
         )
         self.installation_store = AmazonS3InstallationStore(
             logger=self.logger,
             s3_client=self.s3_client,
             bucket_name=installation_bucket_name,
-            client_id=client_id,
+            client_id=self.settings.client_id,
         )
-        self.oauth_state_cookie_name = oauth_state_cookie_name
-        self.oauth_state_expiration_seconds = oauth_state_expiration_seconds
-
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self.scopes = scopes.split(",") if scopes else None
-        self.user_scopes = user_scopes.split(",") if user_scopes else None
-        self.redirect_uri = redirect_uri
-
-        self.install_path = install_path
-        self.redirect_uri_path = redirect_uri_path
-        self.success_url = success_url
-        self.failure_url = failure_url
-
-        self._init_internal_utils()
 
     @property
     def client(self) -> WebClient:

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -7,9 +7,8 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from http.server import SimpleHTTPRequestHandler, HTTPServer
 from typing import List, Union, Pattern, Callable, Dict, Optional
 
-from slack_sdk.oauth import OAuthStateUtils
-from slack_sdk.oauth.installation_store import InstallationStore, FileInstallationStore
-from slack_sdk.oauth.state_store import OAuthStateStore, FileOAuthStateStore
+from slack_sdk.oauth.installation_store import InstallationStore
+from slack_sdk.oauth.state_store import OAuthStateStore
 from slack_sdk.web import WebClient
 
 from slack_bolt.error import BoltError
@@ -38,6 +37,7 @@ from slack_bolt.middleware import (
 from slack_bolt.middleware.message_listener_matches import MessageListenerMatches
 from slack_bolt.middleware.url_verification import UrlVerification
 from slack_bolt.oauth import OAuthFlow
+from slack_bolt.oauth.oauth_settings import OAuthSettings
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 from slack_bolt.util.utils import create_web_client, create_copy
@@ -58,21 +58,11 @@ class App:
         client: Optional[WebClient] = None,
         # for multi-workspace apps
         installation_store: Optional[InstallationStore] = None,
-        oauth_state_store: Optional[OAuthStateStore] = None,
-        oauth_state_cookie_name: str = OAuthStateUtils.default_cookie_name,
-        oauth_state_expiration_seconds: int = OAuthStateUtils.default_expiration_seconds,
         # for the OAuth flow
+        oauth_state_store: Optional[OAuthStateStore] = None,
+        oauth_settings: Optional[OAuthSettings] = None,
         oauth_flow: Optional[OAuthFlow] = None,
         authorization_test_enabled: bool = True,
-        client_id: Optional[str] = None,
-        client_secret: Optional[str] = None,
-        scopes: Optional[List[str]] = None,
-        user_scopes: Optional[List[str]] = None,
-        redirect_uri: Optional[str] = None,
-        oauth_install_path: Optional[str] = None,
-        oauth_redirect_uri_path: Optional[str] = None,
-        oauth_success_url: Optional[str] = None,
-        oauth_failure_url: Optional[str] = None,
         # No need to set (the value is used only in response to ssl_check requests)
         verification_token: Optional[str] = None,
     ):
@@ -86,18 +76,6 @@ class App:
 
         self._name: str = name or inspect.stack()[1].filename.split(os.path.sep)[-1]
         self._signing_secret: str = signing_secret
-
-        client_id = client_id or os.environ.get("SLACK_CLIENT_ID", None)
-        client_secret = client_secret or os.environ.get("SLACK_CLIENT_SECRET", None)
-        scopes = scopes or os.environ.get("SLACK_SCOPES", "").split(",")
-        user_scopes = user_scopes or os.environ.get("SLACK_USER_SCOPES", "").split(",")
-        redirect_uri = redirect_uri or os.environ.get("SLACK_REDIRECT_URI", None)
-        oauth_install_path = oauth_install_path or os.environ.get(
-            "SLACK_INSTALL_PATH", "/slack/install"
-        )
-        oauth_redirect_uri_path = oauth_redirect_uri_path or os.environ.get(
-            "SLACK_REDIRECT_URI_PATH", "/slack/oauth_redirect"
-        )
 
         self._verification_token: Optional[str] = verification_token or os.environ.get(
             "SLACK_VERIFICATION_TOKEN", None
@@ -121,62 +99,24 @@ class App:
         self._installation_store: Optional[InstallationStore] = installation_store
         self._oauth_state_store: Optional[OAuthStateStore] = oauth_state_store
 
-        self._oauth_state_cookie_name = oauth_state_cookie_name
-        self._oauth_state_expiration_seconds = oauth_state_expiration_seconds
-
         self._oauth_flow: Optional[OAuthFlow] = None
         self._authorization_test_enabled = authorization_test_enabled
         if oauth_flow:
             self._oauth_flow = oauth_flow
             if self._installation_store is None:
-                self._installation_store = self._oauth_flow.installation_store
-            if self._oauth_state_store is None:
-                self._oauth_state_store = self._oauth_flow.oauth_state_store
+                self._installation_store = self._oauth_flow.settings.installation_store
             if self._oauth_flow._client is None:
                 self._oauth_flow._client = self._client
-        else:
-            if client_id is not None and client_secret is not None:
-                # The OAuth flow support is enabled
-                if self._installation_store is None and self._oauth_state_store is None:
-                    # use the default ones
-                    self._installation_store = FileInstallationStore(
-                        client_id=client_id,
-                    )
-                    self._oauth_state_store = FileOAuthStateStore(
-                        expiration_seconds=self._oauth_state_expiration_seconds,
-                        client_id=client_id,
-                    )
+        elif oauth_settings is not None:
+            # The OAuth flow support is enabled
+            if self._installation_store:
+                oauth_settings.installation_store = self._installation_store
+            if oauth_state_store:
+                oauth_settings.state_store = oauth_state_store
 
-                if (
-                    self._installation_store is not None
-                    and self._oauth_state_store is None
-                ):
-                    raise ValueError(
-                        f"Configure an appropriate OAuthStateStore for {self._installation_store}"
-                    )
-
-                self._oauth_flow = OAuthFlow(
-                    client=create_web_client(),
-                    logger=self._framework_logger,
-                    # required storage implementations
-                    installation_store=self._installation_store,
-                    oauth_state_store=self._oauth_state_store,
-                    oauth_state_cookie_name=self._oauth_state_cookie_name,
-                    oauth_state_expiration_seconds=self._oauth_state_expiration_seconds,
-                    # used for oauth.v2.access calls
-                    client_id=client_id,
-                    client_secret=client_secret,
-                    # installation url parameters
-                    scopes=scopes,
-                    user_scopes=user_scopes,
-                    redirect_uri=redirect_uri,
-                    # path in this app
-                    install_path=oauth_install_path,
-                    redirect_uri_path=oauth_redirect_uri_path,
-                    # urls after callback
-                    success_url=oauth_success_url,
-                    failure_url=oauth_failure_url,
-                )
+            self._oauth_flow = OAuthFlow(
+                client=self.client, logger=self.logger, settings=oauth_settings
+            )
 
         if self._installation_store is not None and self._token is not None:
             self._token = None
@@ -247,10 +187,6 @@ class App:
     @property
     def installation_store(self) -> Optional[InstallationStore]:
         return self._installation_store
-
-    @property
-    def oauth_state_store(self) -> Optional[OAuthStateStore]:
-        return self._oauth_state_store
 
     @property
     def listener_error_handler(self) -> ListenerErrorHandler:

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -59,7 +59,6 @@ class App:
         # for multi-workspace apps
         installation_store: Optional[InstallationStore] = None,
         # for the OAuth flow
-        oauth_state_store: Optional[OAuthStateStore] = None,
         oauth_settings: Optional[OAuthSettings] = None,
         oauth_flow: Optional[OAuthFlow] = None,
         authorization_test_enabled: bool = True,
@@ -97,7 +96,6 @@ class App:
             self._client = create_web_client(token)  # NOTE: the token here can be None
 
         self._installation_store: Optional[InstallationStore] = installation_store
-        self._oauth_state_store: Optional[OAuthStateStore] = oauth_state_store
 
         self._oauth_flow: Optional[OAuthFlow] = None
         self._authorization_test_enabled = authorization_test_enabled
@@ -108,11 +106,9 @@ class App:
             if self._oauth_flow._client is None:
                 self._oauth_flow._client = self._client
         elif oauth_settings is not None:
-            # The OAuth flow support is enabled
             if self._installation_store:
+                # Consistently use a single installation_store
                 oauth_settings.installation_store = self._installation_store
-            if oauth_state_store:
-                oauth_settings.state_store = oauth_state_store
 
             self._oauth_flow = OAuthFlow(
                 client=self.client, logger=self.logger, settings=oauth_settings

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -69,7 +69,6 @@ class AsyncApp:
         # for multi-workspace apps
         installation_store: Optional[AsyncInstallationStore] = None,
         # for the OAuth flow
-        oauth_state_store: Optional[OAuthStateStore] = None,
         oauth_settings: Optional[AsyncOAuthSettings] = None,
         oauth_flow: Optional[AsyncOAuthFlow] = None,
         authorization_test_enabled: bool = True,
@@ -122,11 +121,9 @@ class AsyncApp:
             if self._async_oauth_flow._async_client is None:
                 self._async_oauth_flow._async_client = self._async_client
         elif oauth_settings is not None:
-            # The OAuth flow support is enabled
             if self._async_installation_store:
+                # Consistently use a single installation_store
                 oauth_settings.installation_store = self._async_installation_store
-            if oauth_state_store:
-                oauth_settings.state_store = oauth_state_store
 
             self._async_oauth_flow = AsyncOAuthFlow(
                 client=self._async_client, logger=self.logger, settings=oauth_settings

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -6,13 +6,10 @@ import time
 from asyncio import Future
 from typing import Optional, List, Union, Callable, Pattern, Dict, Awaitable
 
-from slack_sdk.oauth import OAuthStateUtils
-from slack_sdk.oauth.installation_store import FileInstallationStore
+from slack_sdk.oauth import OAuthStateStore
 from slack_sdk.oauth.installation_store.async_installation_store import (
     AsyncInstallationStore,
 )
-from slack_sdk.oauth.state_store import FileOAuthStateStore
-from slack_sdk.oauth.state_store.async_state_store import AsyncOAuthStateStore
 from slack_sdk.web.async_client import AsyncWebClient
 
 from slack_bolt.context.ack.async_ack import AsyncAck
@@ -49,6 +46,7 @@ from slack_bolt.middleware.authorization.async_single_team_authorization import 
     AsyncSingleTeamAuthorization,
 )
 from slack_bolt.oauth.async_oauth_flow import AsyncOAuthFlow
+from slack_bolt.oauth.async_oauth_settings import AsyncOAuthSettings
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 from slack_bolt.util.async_utils import create_async_web_client
@@ -70,20 +68,11 @@ class AsyncApp:
         client: Optional[AsyncWebClient] = None,
         # for multi-workspace apps
         installation_store: Optional[AsyncInstallationStore] = None,
-        oauth_state_store: Optional[AsyncOAuthStateStore] = None,
-        oauth_state_cookie_name: str = OAuthStateUtils.default_cookie_name,
-        oauth_state_expiration_seconds: int = OAuthStateUtils.default_expiration_seconds,
         # for the OAuth flow
+        oauth_state_store: Optional[OAuthStateStore] = None,
+        oauth_settings: Optional[AsyncOAuthSettings] = None,
         oauth_flow: Optional[AsyncOAuthFlow] = None,
-        client_id: Optional[str] = None,
-        client_secret: Optional[str] = None,
-        scopes: Optional[List[str]] = None,
-        user_scopes: Optional[List[str]] = None,
-        redirect_uri: Optional[str] = None,
-        oauth_install_path: Optional[str] = None,
-        oauth_redirect_uri_path: Optional[str] = None,
-        oauth_success_url: Optional[str] = None,
-        oauth_failure_url: Optional[str] = None,
+        authorization_test_enabled: bool = True,
         # No need to set (the value is used only in response to ssl_check requests)
         verification_token: Optional[str] = None,
     ):
@@ -97,19 +86,6 @@ class AsyncApp:
 
         self._name: str = name or inspect.stack()[1].filename.split(os.path.sep)[-1]
         self._signing_secret: str = signing_secret
-
-        client_id = client_id or os.environ.get("SLACK_CLIENT_ID", None)
-        client_secret = client_secret or os.environ.get("SLACK_CLIENT_SECRET", None)
-        scopes = scopes or os.environ.get("SLACK_SCOPES", "").split(",")
-        user_scopes = user_scopes or os.environ.get("SLACK_USER_SCOPES", "").split(",")
-        redirect_uri = redirect_uri or os.environ.get("SLACK_REDIRECT_URI", None)
-        oauth_install_path = oauth_install_path or os.environ.get(
-            "SLACK_INSTALL_PATH", "/slack/install"
-        )
-        oauth_redirect_uri_path = oauth_redirect_uri_path or os.environ.get(
-            "SLACK_REDIRECT_URI_PATH", "/slack/oauth_redirect"
-        )
-
         self._verification_token: Optional[str] = verification_token or os.environ.get(
             "SLACK_VERIFICATION_TOKEN", None
         )
@@ -130,73 +106,31 @@ class AsyncApp:
             # NOTE: the token here can be None
             self._async_client = create_async_web_client(token)
 
+        self._authorization_test_enabled = authorization_test_enabled
+
         self._async_installation_store: Optional[
             AsyncInstallationStore
         ] = installation_store
-        self._async_oauth_state_store: Optional[
-            AsyncOAuthStateStore
-        ] = oauth_state_store
-
-        self._oauth_state_cookie_name = oauth_state_cookie_name
-        self._oauth_state_expiration_seconds = oauth_state_expiration_seconds
 
         self._async_oauth_flow: Optional[AsyncOAuthFlow] = None
         if oauth_flow:
             self._async_oauth_flow = oauth_flow
             if self._async_installation_store is None:
                 self._async_installation_store = (
-                    self._async_oauth_flow.installation_store
+                    self._async_oauth_flow.settings.installation_store
                 )
-            if self._async_oauth_state_store is None:
-                self._async_oauth_state_store = self._async_oauth_flow.oauth_state_store
             if self._async_oauth_flow._async_client is None:
                 self._async_oauth_flow._async_client = self._async_client
-        else:
-            if client_id is not None and client_secret is not None:
-                # The OAuth flow support is enabled
-                if (
-                    self._async_installation_store is None
-                    and self._async_oauth_state_store is None
-                ):
-                    # use the default ones
-                    self._async_installation_store = FileInstallationStore(
-                        client_id=client_id,
-                    )
-                    self._async_oauth_state_store = FileOAuthStateStore(
-                        expiration_seconds=self._oauth_state_expiration_seconds,
-                        client_id=client_id,
-                    )
+        elif oauth_settings is not None:
+            # The OAuth flow support is enabled
+            if self._async_installation_store:
+                oauth_settings.installation_store = self._async_installation_store
+            if oauth_state_store:
+                oauth_settings.state_store = oauth_state_store
 
-                if (
-                    self._async_installation_store is not None
-                    and self._async_oauth_state_store is None
-                ):
-                    raise ValueError(
-                        f"Configure an appropriate OAuthStateStore for {self._async_installation_store}"
-                    )
-
-                self._async_oauth_flow = AsyncOAuthFlow(
-                    client=create_async_web_client(),
-                    logger=self._framework_logger,
-                    # required storage implementations
-                    installation_store=self._async_installation_store,
-                    oauth_state_store=self._async_oauth_state_store,
-                    oauth_state_cookie_name=self._oauth_state_cookie_name,
-                    oauth_state_expiration_seconds=self._oauth_state_expiration_seconds,
-                    # used for oauth.v2.access calls
-                    client_id=client_id,
-                    client_secret=client_secret,
-                    # installation url parameters
-                    scopes=scopes,
-                    user_scopes=user_scopes,
-                    redirect_uri=redirect_uri,
-                    # path in this app
-                    install_path=oauth_install_path,
-                    redirect_uri_path=oauth_redirect_uri_path,
-                    # urls after callback
-                    success_url=oauth_success_url,
-                    failure_url=oauth_failure_url,
-                )
+            self._async_oauth_flow = AsyncOAuthFlow(
+                client=self._async_client, logger=self.logger, settings=oauth_settings
+            )
 
         if self._async_installation_store is not None and self._token is not None:
             self._token = None
@@ -235,7 +169,10 @@ class AsyncApp:
                 )
         else:
             self._async_middleware_list.append(
-                AsyncMultiTeamsAuthorization(self._async_installation_store)
+                AsyncMultiTeamsAuthorization(
+                    installation_store=self._async_installation_store,
+                    verification_enabled=self._authorization_test_enabled,
+                )
             )
 
         self._async_middleware_list.append(AsyncIgnoringSelfEvents())
@@ -264,10 +201,6 @@ class AsyncApp:
     @property
     def installation_store(self) -> Optional[AsyncInstallationStore]:
         return self._async_installation_store
-
-    @property
-    def oauth_state_store(self) -> Optional[AsyncOAuthStateStore]:
-        return self._async_oauth_state_store
 
     @property
     def listener_error_handler(self) -> AsyncListenerErrorHandler:

--- a/slack_bolt/oauth/async_callback_options.py
+++ b/slack_bolt/oauth/async_callback_options.py
@@ -1,0 +1,87 @@
+import logging
+from logging import Logger
+from typing import Optional, Callable, Awaitable
+
+from slack_sdk.oauth import RedirectUriPageRenderer, OAuthStateUtils
+from slack_sdk.oauth.installation_store import Installation
+from slack_bolt.oauth.internals import CallbackResponseBuilder
+
+from slack_bolt.request.async_request import AsyncBoltRequest
+from slack_bolt.response import BoltResponse
+
+
+class AsyncSuccessArgs:
+    def __init__(  # type: ignore
+        self,
+        *,
+        request: AsyncBoltRequest,
+        installation: Installation,
+        settings: "AsyncOAuthSettings",
+    ):
+        self.request = request
+        self.installation = installation
+        self.settings = settings
+
+
+class AsyncFailureArgs:
+    def __init__(  # type: ignore
+        self,
+        *,
+        request: AsyncBoltRequest,
+        reason: str,
+        error: Optional[Exception] = None,
+        suggested_status_code: int,
+        settings: "AsyncOAuthSettings",
+    ):
+        self.request = request
+        self.reason = reason
+        self.error = error
+        self.suggested_status_code = suggested_status_code
+        self.settings = settings
+
+
+class AsyncCallbackOptions:
+    success: Callable[[AsyncSuccessArgs], Awaitable[BoltResponse]]
+    failure: Callable[[AsyncFailureArgs], Awaitable[BoltResponse]]
+
+    def __init__(
+        self,
+        success: Callable[[AsyncSuccessArgs], Awaitable[BoltResponse]],
+        failure: Callable[[AsyncFailureArgs], Awaitable[BoltResponse]],
+    ):
+        self.success = success
+        self.failure = failure
+
+
+class DefaultAsyncCallbackOptions(AsyncCallbackOptions):
+    success: Callable[[AsyncSuccessArgs], Awaitable[BoltResponse]]
+    failure: Callable[[AsyncFailureArgs], Awaitable[BoltResponse]]
+
+    def __init__(
+        self,
+        *,
+        logger: Logger,
+        state_utils: OAuthStateUtils,
+        redirect_uri_page_renderer: RedirectUriPageRenderer,
+    ):
+        self._response_builder = CallbackResponseBuilder(
+            logger=logger or logging.getLogger(__name__),
+            state_utils=state_utils,
+            redirect_uri_page_renderer=redirect_uri_page_renderer,
+        )
+        self.success = self._success_handler
+        self.failure = self._failure_handler
+
+    # --------------------------
+    # Internal methods
+    # --------------------------
+
+    async def _success_handler(self, args: AsyncSuccessArgs) -> BoltResponse:
+        return self._response_builder._build_callback_success_response(
+            request=args.request, installation=args.installation,
+        )
+
+    async def _failure_handler(self, args: AsyncFailureArgs) -> BoltResponse:
+        return self._response_builder._build_callback_failure_response(
+            request=args.request, reason=args.reason, status=args.suggested_status_code,
+        )

--- a/slack_bolt/oauth/async_oauth_flow.py
+++ b/slack_bolt/oauth/async_oauth_flow.py
@@ -259,10 +259,14 @@ class AsyncOAuthFlow:
                 client_secret=self.settings.client_secret,
                 redirect_uri=self.settings.redirect_uri,  # can be None
             )
-            installed_enterprise: Dict[str, str] = oauth_response.get("enterprise") or {}
+            installed_enterprise: Dict[str, str] = oauth_response.get(
+                "enterprise"
+            ) or {}
             installed_team: Dict[str, str] = oauth_response.get("team") or {}
             installer: Dict[str, str] = oauth_response.get("authed_user") or {}
-            incoming_webhook: Dict[str, str] = oauth_response.get("incoming_webhook") or {}
+            incoming_webhook: Dict[str, str] = oauth_response.get(
+                "incoming_webhook"
+            ) or {}
 
             bot_token: Optional[str] = oauth_response.get("access_token", None)
             # NOTE: oauth.v2.access doesn't include bot_id in response

--- a/slack_bolt/oauth/async_oauth_flow.py
+++ b/slack_bolt/oauth/async_oauth_flow.py
@@ -1,23 +1,22 @@
 import logging
 import os
 from logging import Logger
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Callable, Awaitable
 
 from slack_bolt.error import BoltError
+from slack_bolt.oauth.async_callback_options import (
+    AsyncCallbackOptions,
+    DefaultAsyncCallbackOptions,
+    AsyncSuccessArgs,
+    AsyncFailureArgs,
+)
+from slack_bolt.oauth.async_oauth_settings import AsyncOAuthSettings
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 from slack_sdk.errors import SlackApiError
-from slack_sdk.oauth import (
-    AuthorizeUrlGenerator,
-    OAuthStateUtils,
-    RedirectUriPageRenderer,
-)
+from slack_sdk.oauth import OAuthStateUtils
 from slack_sdk.oauth.installation_store import Installation
-from slack_sdk.oauth.installation_store.async_installation_store import (
-    AsyncInstallationStore,
-)
 from slack_sdk.oauth.installation_store.sqlite3 import SQLite3InstallationStore
-from slack_sdk.oauth.state_store.async_state_store import AsyncOAuthStateStore
 from slack_sdk.oauth.state_store.sqlite3 import SQLite3OAuthStateStore
 from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.web.async_slack_response import AsyncSlackResponse
@@ -26,24 +25,14 @@ from slack_bolt.util.async_utils import create_async_web_client
 
 
 class AsyncOAuthFlow:
-    installation_store: AsyncInstallationStore
-    oauth_state_store: AsyncOAuthStateStore
-    oauth_state_cookie_name: str
-    oauth_state_expiration_seconds: int
-
+    settings: AsyncOAuthSettings
     client_id: str
-    client_secret: str
     redirect_uri: Optional[str]
-    scopes: Optional[List[str]]
-    user_scopes: Optional[List[str]]
-
     install_path: str
     redirect_uri_path: str
-    success_url: Optional[str]
-    failure_url: Optional[str]
-    oauth_state_utils: OAuthStateUtils
-    authorize_url_generator: AuthorizeUrlGenerator
-    redirect_uri_page_renderer: RedirectUriPageRenderer
+
+    success_handler: Callable[[AsyncSuccessArgs], Awaitable[BoltResponse]]
+    failure_handler: Callable[[AsyncFailureArgs], Awaitable[BoltResponse]]
 
     @property
     def client(self) -> AsyncWebClient:
@@ -62,59 +51,24 @@ class AsyncOAuthFlow:
         *,
         client: Optional[AsyncWebClient] = None,
         logger: Optional[Logger] = None,
-        installation_store: AsyncInstallationStore,
-        oauth_state_store: AsyncOAuthStateStore,
-        oauth_state_cookie_name: str = OAuthStateUtils.default_cookie_name,
-        oauth_state_expiration_seconds: int = OAuthStateUtils.default_expiration_seconds,
-        client_id: str,
-        client_secret: str,
-        scopes: Optional[List[str]] = None,
-        user_scopes: Optional[List[str]] = None,
-        redirect_uri: Optional[str] = None,
-        install_path: str = "/slack/install",
-        redirect_uri_path: str = "/slack/oauth_redirect",
-        success_url: Optional[str] = None,
-        failure_url: Optional[str] = None,
+        settings: AsyncOAuthSettings,
     ):
         self._async_client = client
         self._logger = logger
+        self.settings = settings
+        self.client_id = self.settings.client_id
+        self.redirect_uri = self.settings.redirect_uri
+        self.install_path = self.settings.install_path
+        self.redirect_uri_path = self.settings.redirect_uri_path
 
-        self.installation_store = installation_store
-        self.oauth_state_store = oauth_state_store
-        self.oauth_state_cookie_name = oauth_state_cookie_name
-        self.oauth_state_expiration_seconds = oauth_state_expiration_seconds
-
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self.redirect_uri = redirect_uri
-        self.scopes = scopes
-        self.user_scopes = user_scopes
-
-        self.install_path = install_path
-        self.redirect_uri_path = redirect_uri_path
-        self.success_url = success_url
-        self.failure_url = failure_url
-
-        self._init_internal_utils()
-
-    def _init_internal_utils(self):
-        self.oauth_state_utils = OAuthStateUtils(
-            cookie_name=self.oauth_state_cookie_name,
-            expiration_seconds=self.oauth_state_expiration_seconds,
-        )
-        self.authorize_url_generator = AuthorizeUrlGenerator(
-            client_id=self.client_id,
-            client_secret=self.client_secret,
-            redirect_uri=self.redirect_uri,
-            scopes=self.scopes,
-            user_scopes=self.user_scopes,
-        )
-        self.redirect_uri_page_renderer = RedirectUriPageRenderer(
-            install_path=self.install_path,
-            redirect_uri_path=self.redirect_uri_path,
-            success_url=self.success_url,
-            failure_url=self.failure_url,
-        )
+        if settings.callback_options is None:
+            settings.callback_options = DefaultAsyncCallbackOptions(
+                logger=logger,
+                state_utils=self.settings.state_utils,
+                redirect_uri_page_renderer=self.settings.redirect_uri_page_renderer,
+            )
+        self.success_handler = settings.callback_options.success
+        self.failure_handler = settings.callback_options.failure
 
     # -----------------------------
     # Factory Methods
@@ -124,13 +78,23 @@ class AsyncOAuthFlow:
     def sqlite3(
         cls,
         database: str,
+        # OAuth flow parameters/credentials
+        authorization_url: Optional[str] = None,
         client_id: Optional[str] = None,  # required
         client_secret: Optional[str] = None,  # required
         scopes: Optional[List[str]] = None,
         user_scopes: Optional[List[str]] = None,
         redirect_uri: Optional[str] = None,
-        oauth_state_cookie_name: str = OAuthStateUtils.default_cookie_name,
-        oauth_state_expiration_seconds: int = OAuthStateUtils.default_expiration_seconds,
+        # Handler configuration
+        install_path: Optional[str] = None,
+        redirect_uri_path: Optional[str] = None,
+        callback_options: Optional[AsyncCallbackOptions] = None,
+        success_url: Optional[str] = None,
+        failure_url: Optional[str] = None,
+        # Installation Management
+        # state parameter related configurations
+        state_cookie_name: str = OAuthStateUtils.default_cookie_name,
+        state_expiration_seconds: int = OAuthStateUtils.default_expiration_seconds,
         logger: Optional[Logger] = None,
     ) -> "AsyncOAuthFlow":
 
@@ -140,23 +104,35 @@ class AsyncOAuthFlow:
         user_scopes = user_scopes or os.environ.get("SLACK_USER_SCOPES", "").split(",")
         redirect_uri = redirect_uri or os.environ.get("SLACK_REDIRECT_URI", None)
         return AsyncOAuthFlow(
-            client=create_async_web_client(),
+            client=AsyncWebClient(),
             logger=logger,
-            installation_store=SQLite3InstallationStore(
-                database=database, client_id=client_id, logger=logger,
+            settings=AsyncOAuthSettings(
+                # OAuth flow parameters/credentials
+                authorization_url=authorization_url,
+                client_id=client_id,
+                client_secret=client_secret,
+                scopes=scopes,
+                user_scopes=user_scopes,
+                redirect_uri=redirect_uri,
+                # Handler configuration
+                install_path=install_path,
+                redirect_uri_path=redirect_uri_path,
+                callback_options=callback_options,
+                success_url=success_url,
+                failure_url=failure_url,
+                # Installation Management
+                installation_store=SQLite3InstallationStore(
+                    database=database, client_id=client_id, logger=logger,
+                ),
+                # state parameter related configurations
+                state_store=SQLite3OAuthStateStore(
+                    database=database,
+                    expiration_seconds=state_expiration_seconds,
+                    logger=logger,
+                ),
+                state_cookie_name=state_cookie_name,
+                state_expiration_seconds=state_expiration_seconds,
             ),
-            oauth_state_store=SQLite3OAuthStateStore(
-                database=database,
-                expiration_seconds=oauth_state_expiration_seconds,
-                logger=logger,
-            ),
-            oauth_state_cookie_name=oauth_state_cookie_name,
-            oauth_state_expiration_seconds=oauth_state_expiration_seconds,
-            client_id=client_id,
-            client_secret=client_secret,
-            scopes=scopes,
-            user_scopes=user_scopes,
-            redirect_uri=redirect_uri,
         )
 
     # -----------------------------
@@ -171,7 +147,7 @@ class AsyncOAuthFlow:
     # Internal methods for Installation
 
     async def issue_new_state(self, request: BoltRequest) -> str:
-        return await self.oauth_state_store.async_issue()
+        return await self.settings.state_store.async_issue()
 
     async def build_authorize_url_redirection(
         self, request: BoltRequest, state: str
@@ -179,9 +155,9 @@ class AsyncOAuthFlow:
         return BoltResponse(
             status=302,
             headers={
-                "Location": [self.authorize_url_generator.generate(state)],
+                "Location": [self.settings.authorize_url_generator.generate(state)],
                 "Set-Cookie": [
-                    self.oauth_state_utils.build_set_cookie_for_new_state(state)
+                    self.settings.state_utils.build_set_cookie_for_new_state(state)
                 ],
             },
         )
@@ -195,46 +171,82 @@ class AsyncOAuthFlow:
         # failure due to end-user's cancellation or invalid redirection to slack.com
         error = request.query.get("error", [None])[0]
         if error is not None:
-            return await self.build_callback_failure_response(
-                request, reason=error, status=200
+            return await self.failure_handler(
+                AsyncFailureArgs(
+                    request=request,
+                    reason=error,
+                    suggested_status_code=200,
+                    settings=self.settings,
+                )
             )
 
         # state parameter verification
         state = request.query.get("state", [None])[0]
-        if not self.oauth_state_utils.is_valid_browser(state, request.headers):
-            return await self.build_callback_failure_response(
-                request, reason="invalid_browser", status=400
+        if not self.settings.state_utils.is_valid_browser(state, request.headers):
+            return await self.failure_handler(
+                AsyncFailureArgs(
+                    request=request,
+                    reason="invalid_browser",
+                    suggested_status_code=400,
+                    settings=self.settings,
+                )
             )
 
-        valid_state_consumed = await self.oauth_state_store.async_consume(state)
+        valid_state_consumed = await self.settings.state_store.async_consume(state)
         if not valid_state_consumed:
-            return await self.build_callback_failure_response(
-                request, reason="invalid_state", status=401
+            return await self.failure_handler(
+                AsyncFailureArgs(
+                    request=request,
+                    reason="invalid_state",
+                    suggested_status_code=401,
+                    settings=self.settings,
+                )
             )
 
         # run installation
         code = request.query.get("code", [None])[0]
         if code is None:
-            return await self.build_callback_failure_response(
-                request, reason="missing_code", status=401
+            return await self.failure_handler(
+                AsyncFailureArgs(
+                    request=request,
+                    reason="missing_code",
+                    suggested_status_code=401,
+                    settings=self.settings,
+                )
             )
+
         installation = await self.run_installation(code)
         if installation is None:
             # failed to run installation with the code
-            return await self.build_callback_failure_response(
-                request, reason="invalid_code", status=401
+            return await self.failure_handler(
+                AsyncFailureArgs(
+                    request=request,
+                    reason="invalid_code",
+                    suggested_status_code=401,
+                    settings=self.settings,
+                )
             )
 
         # persist the installation
         try:
             await self.store_installation(request, installation)
-        except BoltError as e:
-            return await self.build_callback_failure_response(
-                request, reason="storage_error", error=e
+        except BoltError as err:
+            return await self.failure_handler(
+                AsyncFailureArgs(
+                    request=request,
+                    reason="storage_error",
+                    error=err,
+                    suggested_status_code=500,
+                    settings=self.settings,
+                )
             )
 
         # display a successful completion page to the end-user
-        return await self.build_callback_success_response(request, installation)
+        return await self.success_handler(
+            AsyncSuccessArgs(
+                request=request, installation=installation, settings=self.settings,
+            )
+        )
 
     # ----------------------
     # Internal methods for Callback
@@ -243,16 +255,14 @@ class AsyncOAuthFlow:
         try:
             oauth_response: AsyncSlackResponse = await self.client.oauth_v2_access(
                 code=code,
-                client_id=self.client_id,
-                client_secret=self.client_secret,
-                redirect_uri=self.redirect_uri,  # can be None
+                client_id=self.settings.client_id,
+                client_secret=self.settings.client_secret,
+                redirect_uri=self.settings.redirect_uri,  # can be None
             )
-            installed_enterprise: Dict[str, str] = oauth_response.get("enterprise", {})
-            installed_team: Dict[str, str] = oauth_response.get("team", {})
-            installer: Dict[str, str] = oauth_response.get("authed_user", {})
-            incoming_webhook: Dict[str, str] = oauth_response.get(
-                "incoming_webhook", {}
-            )
+            installed_enterprise: Dict[str, str] = oauth_response.get("enterprise") or {}
+            installed_team: Dict[str, str] = oauth_response.get("team") or {}
+            installer: Dict[str, str] = oauth_response.get("authed_user") or {}
+            incoming_webhook: Dict[str, str] = oauth_response.get("incoming_webhook") or {}
 
             bot_token: Optional[str] = oauth_response.get("access_token", None)
             # NOTE: oauth.v2.access doesn't include bot_id in response
@@ -290,47 +300,4 @@ class AsyncOAuthFlow:
         self, request: BoltRequest, installation: Installation
     ):
         # may raise BoltError
-        await self.installation_store.async_save(installation)
-
-    async def build_callback_failure_response(
-        self,
-        request: BoltRequest,
-        reason: str,
-        status: int = 500,
-        error: Optional[Exception] = None,
-    ) -> BoltResponse:
-        debug_message = (
-            "Handling an OAuth callback failure "
-            f"(reason: {reason}, error: {error}, request: {request.query})"
-        )
-        self.logger.debug(debug_message)
-
-        html = self.redirect_uri_page_renderer.render_failure_page(reason)
-        return BoltResponse(
-            status=status,
-            headers={
-                "Content-Type": "text/html; charset=utf-8",
-                "Content-Length": len(html),
-                "Set-Cookie": self.oauth_state_utils.build_set_cookie_for_deletion(),
-            },
-            body=html,
-        )
-
-    async def build_callback_success_response(
-        self, request: BoltRequest, installation: Installation,
-    ) -> BoltResponse:
-        debug_message = f"Handling an OAuth callback success (request: {request.query})"
-        self.logger.debug(debug_message)
-
-        html = self.redirect_uri_page_renderer.render_success_page(
-            app_id=installation.app_id, team_id=installation.team_id,
-        )
-        return BoltResponse(
-            status=200,
-            headers={
-                "Content-Type": "text/html; charset=utf-8",
-                "Content-Length": len(html),
-                "Set-Cookie": self.oauth_state_utils.build_set_cookie_for_deletion(),
-            },
-            body=html,
-        )
+        await self.settings.installation_store.async_save(installation)

--- a/slack_bolt/oauth/async_oauth_settings.py
+++ b/slack_bolt/oauth/async_oauth_settings.py
@@ -1,0 +1,122 @@
+import os
+from typing import List, Optional
+
+from slack_sdk.oauth import (
+    OAuthStateUtils,
+    AuthorizeUrlGenerator,
+    RedirectUriPageRenderer,
+)
+from slack_sdk.oauth.installation_store import FileInstallationStore
+from slack_sdk.oauth.installation_store.async_installation_store import (
+    AsyncInstallationStore,
+)
+from slack_sdk.oauth.state_store import FileOAuthStateStore
+from slack_sdk.oauth.state_store.async_state_store import AsyncOAuthStateStore
+
+from slack_bolt.error import BoltError
+from slack_bolt.oauth.callback_options import CallbackOptions
+
+
+class AsyncOAuthSettings:
+    # OAuth flow parameters/credentials
+    client_id: str
+    client_secret: str
+    scopes: Optional[List[str]]
+    user_scopes: Optional[List[str]]
+    redirect_uri: Optional[str]
+    # Handler configuration
+    install_path: str
+    redirect_uri_path: str
+    callback_options: Optional[CallbackOptions] = None
+    success_url: Optional[str]
+    failure_url: Optional[str]
+    authorization_url: str  # default: https://slack.com/oauth/v2/authorize
+    # Installation Management
+    installation_store: AsyncInstallationStore
+    # state parameter related configurations
+    state_store: AsyncOAuthStateStore
+    state_cookie_name: str
+    state_expiration_seconds: int
+    # Customizable utilities
+    state_utils: OAuthStateUtils
+    authorize_url_generator: AuthorizeUrlGenerator
+    redirect_uri_page_renderer: RedirectUriPageRenderer
+
+    def __init__(
+        self,
+        *,
+        # OAuth flow parameters/credentials
+        client_id: str,
+        client_secret: str,
+        scopes: Optional[List[str]] = None,
+        user_scopes: Optional[List[str]] = None,
+        redirect_uri: Optional[str] = None,
+        # Handler configuration
+        install_path: str = "/slack/install",
+        redirect_uri_path: str = "/slack/oauth_redirect",
+        callback_options: Optional[CallbackOptions] = None,
+        success_url: Optional[str] = None,
+        failure_url: Optional[str] = None,
+        authorization_url: Optional[str] = None,
+        # Installation Management
+        installation_store: Optional[AsyncInstallationStore] = None,
+        # state parameter related configurations
+        state_store: Optional[AsyncOAuthStateStore] = None,
+        state_cookie_name: str = OAuthStateUtils.default_cookie_name,
+        state_expiration_seconds: int = OAuthStateUtils.default_expiration_seconds,
+    ):
+        # OAuth flow parameters/credentials
+        self.client_id = client_id or os.environ.get("SLACK_CLIENT_ID", None)
+        self.client_secret = client_secret or os.environ.get(
+            "SLACK_CLIENT_SECRET", None
+        )
+        if self.client_id is None or self.client_secret is None:
+            raise BoltError("Both client_id and client_secret are required")
+
+        self.scopes = scopes or os.environ.get("SLACK_SCOPES", "").split(",")
+        self.user_scopes = user_scopes or os.environ.get("SLACK_USER_SCOPES", "").split(
+            ","
+        )
+        self.redirect_uri = redirect_uri or os.environ.get("SLACK_REDIRECT_URI", None)
+        # Handler configuration
+        self.install_path = install_path or os.environ.get(
+            "SLACK_INSTALL_PATH", "/slack/install"
+        )
+        self.redirect_uri_path = redirect_uri_path or os.environ.get(
+            "SLACK_REDIRECT_URI_PATH", "/slack/oauth_redirect"
+        )
+        self.callback_options = callback_options
+        self.success_url = success_url
+        self.failure_url = failure_url
+        self.authorization_url = (
+            authorization_url or "https://slack.com/oauth/v2/authorize"
+        )
+        # Installation Management
+        self.installation_store = installation_store or FileInstallationStore(
+            client_id=client_id
+        )
+        # state parameter related configurations
+        self.state_store = state_store or FileOAuthStateStore(
+            expiration_seconds=state_expiration_seconds, client_id=client_id,
+        )
+        self.state_cookie_name = state_cookie_name
+        self.state_expiration_seconds = state_expiration_seconds
+
+        self.state_utils = OAuthStateUtils(
+            cookie_name=self.state_cookie_name,
+            expiration_seconds=self.state_expiration_seconds,
+        )
+        # TODO: add authorization_url support on the slack-sdk side
+        self.authorize_url_generator = AuthorizeUrlGenerator(
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            redirect_uri=self.redirect_uri,
+            scopes=self.scopes,
+            user_scopes=self.user_scopes,
+        )
+        self.redirect_uri_page_renderer = RedirectUriPageRenderer(
+            install_path=self.install_path,
+            redirect_uri_path=self.redirect_uri_path,
+            success_url=self.success_url,
+            failure_url=self.failure_url,
+        )

--- a/slack_bolt/oauth/callback_options.py
+++ b/slack_bolt/oauth/callback_options.py
@@ -1,0 +1,87 @@
+import logging
+from logging import Logger
+from typing import Optional, Callable
+
+from slack_sdk.oauth import RedirectUriPageRenderer, OAuthStateUtils
+from slack_sdk.oauth.installation_store import Installation
+
+from slack_bolt.oauth.internals import CallbackResponseBuilder
+from slack_bolt.request import BoltRequest
+from slack_bolt.response import BoltResponse
+
+
+class SuccessArgs:
+    def __init__(  # type: ignore
+        self,
+        *,
+        request: BoltRequest,
+        installation: Installation,
+        settings: "OAuthSettings",
+    ):
+        self.request = request
+        self.installation = installation
+        self.settings = settings
+
+
+class FailureArgs:
+    def __init__(  # type: ignore
+        self,
+        *,
+        request: BoltRequest,
+        reason: str,
+        error: Optional[Exception] = None,
+        suggested_status_code: int,
+        settings: "OAuthSettings",
+    ):
+        self.request = request
+        self.reason = reason
+        self.error = error
+        self.suggested_status_code = suggested_status_code
+        self.settings = settings
+
+
+class CallbackOptions:
+    success: Callable[[SuccessArgs], BoltResponse]
+    failure: Callable[[FailureArgs], BoltResponse]
+
+    def __init__(
+        self,
+        success: Callable[[SuccessArgs], BoltResponse],
+        failure: Callable[[FailureArgs], BoltResponse],
+    ):
+        self.success = success
+        self.failure = failure
+
+
+class DefaultCallbackOptions(CallbackOptions):
+    success: Callable[[SuccessArgs], BoltResponse]
+    failure: Callable[[FailureArgs], BoltResponse]
+
+    def __init__(
+        self,
+        *,
+        logger: Logger,
+        state_utils: OAuthStateUtils,
+        redirect_uri_page_renderer: RedirectUriPageRenderer,
+    ):
+        self._response_builder = CallbackResponseBuilder(
+            logger=logger or logging.getLogger(__name__),
+            state_utils=state_utils,
+            redirect_uri_page_renderer=redirect_uri_page_renderer,
+        )
+        self.success = self._success_handler
+        self.failure = self._failure_handler
+
+    # --------------------------
+    # Internal methods
+    # --------------------------
+
+    def _success_handler(self, args: SuccessArgs) -> BoltResponse:
+        return self._response_builder._build_callback_success_response(
+            request=args.request, installation=args.installation,
+        )
+
+    def _failure_handler(self, args: FailureArgs) -> BoltResponse:
+        return self._response_builder._build_callback_failure_response(
+            request=args.request, reason=args.reason, status=args.suggested_status_code,
+        )

--- a/slack_bolt/oauth/internals.py
+++ b/slack_bolt/oauth/internals.py
@@ -1,0 +1,66 @@
+from logging import Logger
+from typing import Optional, Union
+
+from slack_sdk.oauth import OAuthStateUtils, RedirectUriPageRenderer
+from slack_sdk.oauth.installation_store import Installation
+
+from slack_bolt.request import BoltRequest
+from slack_bolt.response import BoltResponse
+
+
+class CallbackResponseBuilder:
+    def __init__(
+        self,
+        *,
+        logger: Logger,
+        state_utils: OAuthStateUtils,
+        redirect_uri_page_renderer: RedirectUriPageRenderer,
+    ):
+        self._logger = logger
+        self._state_utils = state_utils
+        self._redirect_uri_page_renderer = redirect_uri_page_renderer
+
+    def _build_callback_success_response(  # type: ignore
+        self,
+        request: Union[BoltRequest, "AsyncBoltRequest"],
+        installation: Installation,
+    ) -> BoltResponse:
+        debug_message = f"Handling an OAuth callback success (request: {request.query})"
+        self._logger.debug(debug_message)
+
+        html = self._redirect_uri_page_renderer.render_success_page(
+            app_id=installation.app_id, team_id=installation.team_id,
+        )
+        return BoltResponse(
+            status=200,
+            headers={
+                "Content-Type": "text/html; charset=utf-8",
+                "Content-Length": len(html),
+                "Set-Cookie": self._state_utils.build_set_cookie_for_deletion(),
+            },
+            body=html,
+        )
+
+    def _build_callback_failure_response(  # type: ignore
+        self,
+        request: Union[BoltRequest, "AsyncBoltRequest"],
+        reason: str,
+        status: int = 500,
+        error: Optional[Exception] = None,
+    ) -> BoltResponse:
+        debug_message = (
+            "Handling an OAuth callback failure "
+            f"(reason: {reason}, error: {error}, request: {request.query})"
+        )
+        self._logger.debug(debug_message)
+
+        html = self._redirect_uri_page_renderer.render_failure_page(reason)
+        return BoltResponse(
+            status=status,
+            headers={
+                "Content-Type": "text/html; charset=utf-8",
+                "Content-Length": len(html),
+                "Set-Cookie": self._state_utils.build_set_cookie_for_deletion(),
+            },
+            body=html,
+        )

--- a/slack_bolt/oauth/oauth_flow.py
+++ b/slack_bolt/oauth/oauth_flow.py
@@ -259,10 +259,14 @@ class OAuthFlow:
                 client_secret=self.settings.client_secret,
                 redirect_uri=self.settings.redirect_uri,  # can be None
             )
-            installed_enterprise: Dict[str, str] = oauth_response.get("enterprise") or {}
+            installed_enterprise: Dict[str, str] = oauth_response.get(
+                "enterprise"
+            ) or {}
             installed_team: Dict[str, str] = oauth_response.get("team") or {}
             installer: Dict[str, str] = oauth_response.get("authed_user") or {}
-            incoming_webhook: Dict[str, str] = oauth_response.get("incoming_webhook") or {}
+            incoming_webhook: Dict[str, str] = oauth_response.get(
+                "incoming_webhook"
+            ) or {}
 
             bot_token: Optional[str] = oauth_response.get("access_token", None)
             # NOTE: oauth.v2.access doesn't include bot_id in response

--- a/slack_bolt/oauth/oauth_flow.py
+++ b/slack_bolt/oauth/oauth_flow.py
@@ -1,20 +1,23 @@
 import logging
 import os
 from logging import Logger
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Callable
 
 from slack_bolt.error import BoltError
+from slack_bolt.oauth.callback_options import (
+    FailureArgs,
+    SuccessArgs,
+    DefaultCallbackOptions,
+    CallbackOptions,
+)
+
+from slack_bolt.oauth.oauth_settings import OAuthSettings
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 from slack_sdk.errors import SlackApiError
-from slack_sdk.oauth import (
-    AuthorizeUrlGenerator,
-    OAuthStateUtils,
-    RedirectUriPageRenderer,
-)
-from slack_sdk.oauth.installation_store import InstallationStore, Installation
+from slack_sdk.oauth import OAuthStateUtils
+from slack_sdk.oauth.installation_store import Installation
 from slack_sdk.oauth.installation_store.sqlite3 import SQLite3InstallationStore
-from slack_sdk.oauth.state_store import OAuthStateStore
 from slack_sdk.oauth.state_store.sqlite3 import SQLite3OAuthStateStore
 from slack_sdk.web import WebClient, SlackResponse
 
@@ -22,24 +25,14 @@ from slack_bolt.util.utils import create_web_client
 
 
 class OAuthFlow:
-    installation_store: InstallationStore
-    oauth_state_store: OAuthStateStore
-    oauth_state_cookie_name: str
-    oauth_state_expiration_seconds: int
-
+    settings: OAuthSettings
     client_id: str
-    client_secret: str
     redirect_uri: Optional[str]
-    scopes: Optional[List[str]]
-    user_scopes: Optional[List[str]]
-
     install_path: str
     redirect_uri_path: str
-    success_url: Optional[str]
-    failure_url: Optional[str]
-    oauth_state_utils: OAuthStateUtils
-    authorize_url_generator: AuthorizeUrlGenerator
-    redirect_uri_page_renderer: RedirectUriPageRenderer
+
+    success_handler: Callable[[SuccessArgs], BoltResponse]
+    failure_handler: Callable[[FailureArgs], BoltResponse]
 
     @property
     def client(self) -> WebClient:
@@ -58,59 +51,24 @@ class OAuthFlow:
         *,
         client: Optional[WebClient] = None,
         logger: Optional[Logger] = None,
-        installation_store: InstallationStore,
-        oauth_state_store: OAuthStateStore,
-        oauth_state_cookie_name: str = OAuthStateUtils.default_cookie_name,
-        oauth_state_expiration_seconds: int = OAuthStateUtils.default_expiration_seconds,
-        client_id: str,
-        client_secret: str,
-        scopes: Optional[List[str]] = None,
-        user_scopes: Optional[List[str]] = None,
-        redirect_uri: Optional[str] = None,
-        install_path: str = "/slack/install",
-        redirect_uri_path: str = "/slack/oauth_redirect",
-        success_url: Optional[str] = None,
-        failure_url: Optional[str] = None,
+        settings: OAuthSettings,
     ):
         self._client = client
         self._logger = logger
+        self.settings = settings
+        self.client_id = self.settings.client_id
+        self.redirect_uri = self.settings.redirect_uri
+        self.install_path = self.settings.install_path
+        self.redirect_uri_path = self.settings.redirect_uri_path
 
-        self.installation_store = installation_store
-        self.oauth_state_store = oauth_state_store
-        self.oauth_state_cookie_name = oauth_state_cookie_name
-        self.oauth_state_expiration_seconds = oauth_state_expiration_seconds
-
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self.redirect_uri = redirect_uri
-        self.scopes = scopes
-        self.user_scopes = user_scopes
-
-        self.install_path = install_path
-        self.redirect_uri_path = redirect_uri_path
-        self.success_url = success_url
-        self.failure_url = failure_url
-
-        self._init_internal_utils()
-
-    def _init_internal_utils(self):
-        self.oauth_state_utils = OAuthStateUtils(
-            cookie_name=self.oauth_state_cookie_name,
-            expiration_seconds=self.oauth_state_expiration_seconds,
-        )
-        self.authorize_url_generator = AuthorizeUrlGenerator(
-            client_id=self.client_id,
-            client_secret=self.client_secret,
-            redirect_uri=self.redirect_uri,
-            scopes=self.scopes,
-            user_scopes=self.user_scopes,
-        )
-        self.redirect_uri_page_renderer = RedirectUriPageRenderer(
-            install_path=self.install_path,
-            redirect_uri_path=self.redirect_uri_path,
-            success_url=self.success_url,
-            failure_url=self.failure_url,
-        )
+        if settings.callback_options is None:
+            settings.callback_options = DefaultCallbackOptions(
+                logger=logger,
+                state_utils=self.settings.state_utils,
+                redirect_uri_page_renderer=self.settings.redirect_uri_page_renderer,
+            )
+        self.success_handler = settings.callback_options.success
+        self.failure_handler = settings.callback_options.failure
 
     # -----------------------------
     # Factory Methods
@@ -120,13 +78,23 @@ class OAuthFlow:
     def sqlite3(
         cls,
         database: str,
+        # OAuth flow parameters/credentials
         client_id: Optional[str] = None,  # required
         client_secret: Optional[str] = None,  # required
         scopes: Optional[List[str]] = None,
         user_scopes: Optional[List[str]] = None,
         redirect_uri: Optional[str] = None,
-        oauth_state_cookie_name: str = OAuthStateUtils.default_cookie_name,
-        oauth_state_expiration_seconds: int = OAuthStateUtils.default_expiration_seconds,
+        # Handler configuration
+        install_path: Optional[str] = None,
+        redirect_uri_path: Optional[str] = None,
+        callback_options: Optional[CallbackOptions] = None,
+        success_url: Optional[str] = None,
+        failure_url: Optional[str] = None,
+        authorization_url: Optional[str] = None,
+        # Installation Management
+        # state parameter related configurations
+        state_cookie_name: str = OAuthStateUtils.default_cookie_name,
+        state_expiration_seconds: int = OAuthStateUtils.default_expiration_seconds,
         logger: Optional[Logger] = None,
     ) -> "OAuthFlow":
 
@@ -138,21 +106,33 @@ class OAuthFlow:
         return OAuthFlow(
             client=WebClient(),
             logger=logger,
-            installation_store=SQLite3InstallationStore(
-                database=database, client_id=client_id, logger=logger,
+            settings=OAuthSettings(
+                # OAuth flow parameters/credentials
+                client_id=client_id,
+                client_secret=client_secret,
+                scopes=scopes,
+                user_scopes=user_scopes,
+                redirect_uri=redirect_uri,
+                # Handler configuration
+                install_path=install_path,
+                redirect_uri_path=redirect_uri_path,
+                callback_options=callback_options,
+                success_url=success_url,
+                failure_url=failure_url,
+                authorization_url=authorization_url,
+                # Installation Management
+                installation_store=SQLite3InstallationStore(
+                    database=database, client_id=client_id, logger=logger,
+                ),
+                # state parameter related configurations
+                state_store=SQLite3OAuthStateStore(
+                    database=database,
+                    expiration_seconds=state_expiration_seconds,
+                    logger=logger,
+                ),
+                state_cookie_name=state_cookie_name,
+                state_expiration_seconds=state_expiration_seconds,
             ),
-            oauth_state_store=SQLite3OAuthStateStore(
-                database=database,
-                expiration_seconds=oauth_state_expiration_seconds,
-                logger=logger,
-            ),
-            oauth_state_cookie_name=oauth_state_cookie_name,
-            oauth_state_expiration_seconds=oauth_state_expiration_seconds,
-            client_id=client_id,
-            client_secret=client_secret,
-            scopes=scopes,
-            user_scopes=user_scopes,
-            redirect_uri=redirect_uri,
         )
 
     # -----------------------------
@@ -167,7 +147,7 @@ class OAuthFlow:
     # Internal methods for Installation
 
     def issue_new_state(self, request: BoltRequest) -> str:
-        return self.oauth_state_store.issue()
+        return self.settings.state_store.issue()
 
     def build_authorize_url_redirection(
         self, request: BoltRequest, state: str
@@ -175,9 +155,9 @@ class OAuthFlow:
         return BoltResponse(
             status=302,
             headers={
-                "Location": [self.authorize_url_generator.generate(state)],
+                "Location": [self.settings.authorize_url_generator.generate(state)],
                 "Set-Cookie": [
-                    self.oauth_state_utils.build_set_cookie_for_new_state(state)
+                    self.settings.state_utils.build_set_cookie_for_new_state(state)
                 ],
             },
         )
@@ -191,46 +171,82 @@ class OAuthFlow:
         # failure due to end-user's cancellation or invalid redirection to slack.com
         error = request.query.get("error", [None])[0]
         if error is not None:
-            return self.build_callback_failure_response(
-                request, reason=error, status=200
+            return self.failure_handler(
+                FailureArgs(
+                    request=request,
+                    reason=error,
+                    suggested_status_code=200,
+                    settings=self.settings,
+                )
             )
 
         # state parameter verification
         state = request.query.get("state", [None])[0]
-        if not self.oauth_state_utils.is_valid_browser(state, request.headers):
-            return self.build_callback_failure_response(
-                request, reason="invalid_browser", status=400
+        if not self.settings.state_utils.is_valid_browser(state, request.headers):
+            return self.failure_handler(
+                FailureArgs(
+                    request=request,
+                    reason="invalid_browser",
+                    suggested_status_code=400,
+                    settings=self.settings,
+                )
             )
 
-        valid_state_consumed = self.oauth_state_store.consume(state)
+        valid_state_consumed = self.settings.state_store.consume(state)
         if not valid_state_consumed:
-            return self.build_callback_failure_response(
-                request, reason="invalid_state", status=401
+            return self.failure_handler(
+                FailureArgs(
+                    request=request,
+                    reason="invalid_state",
+                    suggested_status_code=401,
+                    settings=self.settings,
+                )
             )
 
         # run installation
         code = request.query.get("code", [None])[0]
         if code is None:
-            return self.build_callback_failure_response(
-                request, reason="missing_code", status=401
+            return self.failure_handler(
+                FailureArgs(
+                    request=request,
+                    reason="missing_code",
+                    suggested_status_code=401,
+                    settings=self.settings,
+                )
             )
+
         installation = self.run_installation(code)
         if installation is None:
             # failed to run installation with the code
-            return self.build_callback_failure_response(
-                request, reason="invalid_code", status=401
+            return self.failure_handler(
+                FailureArgs(
+                    request=request,
+                    reason="invalid_code",
+                    suggested_status_code=401,
+                    settings=self.settings,
+                )
             )
 
         # persist the installation
         try:
             self.store_installation(request, installation)
-        except BoltError as e:
-            return self.build_callback_failure_response(
-                request, reason="storage_error", error=e
+        except BoltError as err:
+            return self.failure_handler(
+                FailureArgs(
+                    request=request,
+                    reason="storage_error",
+                    error=err,
+                    suggested_status_code=500,
+                    settings=self.settings,
+                )
             )
 
         # display a successful completion page to the end-user
-        return self.build_callback_success_response(request, installation)
+        return self.success_handler(
+            SuccessArgs(
+                request=request, installation=installation, settings=self.settings,
+            )
+        )
 
     # ----------------------
     # Internal methods for Callback
@@ -239,16 +255,14 @@ class OAuthFlow:
         try:
             oauth_response: SlackResponse = self.client.oauth_v2_access(
                 code=code,
-                client_id=self.client_id,
-                client_secret=self.client_secret,
-                redirect_uri=self.redirect_uri,  # can be None
+                client_id=self.settings.client_id,
+                client_secret=self.settings.client_secret,
+                redirect_uri=self.settings.redirect_uri,  # can be None
             )
-            installed_enterprise: Dict[str, str] = oauth_response.get("enterprise", {})
-            installed_team: Dict[str, str] = oauth_response.get("team", {})
-            installer: Dict[str, str] = oauth_response.get("authed_user", {})
-            incoming_webhook: Dict[str, str] = oauth_response.get(
-                "incoming_webhook", {}
-            )
+            installed_enterprise: Dict[str, str] = oauth_response.get("enterprise") or {}
+            installed_team: Dict[str, str] = oauth_response.get("team") or {}
+            installer: Dict[str, str] = oauth_response.get("authed_user") or {}
+            incoming_webhook: Dict[str, str] = oauth_response.get("incoming_webhook") or {}
 
             bot_token: Optional[str] = oauth_response.get("access_token", None)
             # NOTE: oauth.v2.access doesn't include bot_id in response
@@ -284,47 +298,4 @@ class OAuthFlow:
 
     def store_installation(self, request: BoltRequest, installation: Installation):
         # may raise BoltError
-        self.installation_store.save(installation)
-
-    def build_callback_failure_response(
-        self,
-        request: BoltRequest,
-        reason: str,
-        status: int = 500,
-        error: Optional[Exception] = None,
-    ) -> BoltResponse:
-        debug_message = (
-            "Handling an OAuth callback failure "
-            f"(reason: {reason}, error: {error}, request: {request.query})"
-        )
-        self.logger.debug(debug_message)
-
-        html = self.redirect_uri_page_renderer.render_failure_page(reason)
-        return BoltResponse(
-            status=status,
-            headers={
-                "Content-Type": "text/html; charset=utf-8",
-                "Content-Length": len(html),
-                "Set-Cookie": self.oauth_state_utils.build_set_cookie_for_deletion(),
-            },
-            body=html,
-        )
-
-    def build_callback_success_response(
-        self, request: BoltRequest, installation: Installation,
-    ) -> BoltResponse:
-        debug_message = f"Handling an OAuth callback success (request: {request.query})"
-        self.logger.debug(debug_message)
-
-        html = self.redirect_uri_page_renderer.render_success_page(
-            app_id=installation.app_id, team_id=installation.team_id,
-        )
-        return BoltResponse(
-            status=200,
-            headers={
-                "Content-Type": "text/html; charset=utf-8",
-                "Content-Length": len(html),
-                "Set-Cookie": self.oauth_state_utils.build_set_cookie_for_deletion(),
-            },
-            body=html,
-        )
+        self.settings.installation_store.save(installation)

--- a/slack_bolt/oauth/oauth_settings.py
+++ b/slack_bolt/oauth/oauth_settings.py
@@ -1,0 +1,119 @@
+import os
+from typing import List, Optional
+
+from slack_sdk.oauth import (
+    OAuthStateStore,
+    InstallationStore,
+    OAuthStateUtils,
+    AuthorizeUrlGenerator,
+    RedirectUriPageRenderer,
+)
+from slack_sdk.oauth.installation_store import FileInstallationStore
+from slack_sdk.oauth.state_store import FileOAuthStateStore
+
+from slack_bolt.error import BoltError
+from slack_bolt.oauth.callback_options import CallbackOptions
+
+
+class OAuthSettings:
+    # OAuth flow parameters/credentials
+    client_id: str
+    client_secret: str
+    scopes: Optional[List[str]]
+    user_scopes: Optional[List[str]]
+    redirect_uri: Optional[str]
+    # Handler configuration
+    install_path: str
+    redirect_uri_path: str
+    callback_options: Optional[CallbackOptions] = None
+    success_url: Optional[str]
+    failure_url: Optional[str]
+    authorization_url: str  # default: https://slack.com/oauth/v2/authorize
+    # Installation Management
+    installation_store: InstallationStore
+    # state parameter related configurations
+    state_store: OAuthStateStore
+    state_cookie_name: str
+    state_expiration_seconds: int
+    # Customizable utilities
+    state_utils: OAuthStateUtils
+    authorize_url_generator: AuthorizeUrlGenerator
+    redirect_uri_page_renderer: RedirectUriPageRenderer
+
+    def __init__(
+        self,
+        *,
+        # OAuth flow parameters/credentials
+        client_id: str,
+        client_secret: str,
+        scopes: Optional[List[str]] = None,
+        user_scopes: Optional[List[str]] = None,
+        redirect_uri: Optional[str] = None,
+        # Handler configuration
+        install_path: str = "/slack/install",
+        redirect_uri_path: str = "/slack/oauth_redirect",
+        callback_options: Optional[CallbackOptions] = None,
+        success_url: Optional[str] = None,
+        failure_url: Optional[str] = None,
+        authorization_url: Optional[str] = None,
+        # Installation Management
+        installation_store: Optional[InstallationStore] = None,
+        # state parameter related configurations
+        state_store: Optional[OAuthStateStore] = None,
+        state_cookie_name: str = OAuthStateUtils.default_cookie_name,
+        state_expiration_seconds: int = OAuthStateUtils.default_expiration_seconds,
+    ):
+        self.client_id = client_id or os.environ.get("SLACK_CLIENT_ID", None)
+        self.client_secret = client_secret or os.environ.get(
+            "SLACK_CLIENT_SECRET", None
+        )
+        if self.client_id is None or self.client_secret is None:
+            raise BoltError("Both client_id and client_secret are required")
+
+        self.scopes = scopes or os.environ.get("SLACK_SCOPES", "").split(",")
+        self.user_scopes = user_scopes or os.environ.get("SLACK_USER_SCOPES", "").split(
+            ","
+        )
+        self.redirect_uri = redirect_uri or os.environ.get("SLACK_REDIRECT_URI", None)
+        # Handler configuration
+        self.install_path = install_path or os.environ.get(
+            "SLACK_INSTALL_PATH", "/slack/install"
+        )
+        self.redirect_uri_path = redirect_uri_path or os.environ.get(
+            "SLACK_REDIRECT_URI_PATH", "/slack/oauth_redirect"
+        )
+        self.callback_options = callback_options
+        self.success_url = success_url
+        self.failure_url = failure_url
+        self.authorization_url = (
+            authorization_url or "https://slack.com/oauth/v2/authorize"
+        )
+        # Installation Management
+        self.installation_store = installation_store or FileInstallationStore(
+            client_id=client_id
+        )
+        # state parameter related configurations
+        self.state_store = state_store or FileOAuthStateStore(
+            expiration_seconds=state_expiration_seconds, client_id=client_id,
+        )
+        self.state_cookie_name = state_cookie_name
+        self.state_expiration_seconds = state_expiration_seconds
+
+        self.state_utils = OAuthStateUtils(
+            cookie_name=self.state_cookie_name,
+            expiration_seconds=self.state_expiration_seconds,
+        )
+        # TODO: add authorization_url support on the slack-sdk side
+        self.authorize_url_generator = AuthorizeUrlGenerator(
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            redirect_uri=self.redirect_uri,
+            scopes=self.scopes,
+            user_scopes=self.user_scopes,
+        )
+        self.redirect_uri_page_renderer = RedirectUriPageRenderer(
+            install_path=self.install_path,
+            redirect_uri_path=self.redirect_uri_path,
+            success_url=self.success_url,
+            failure_url=self.failure_url,
+        )

--- a/tests/adapter_tests/test_async_fastapi.py
+++ b/tests/adapter_tests/test_async_fastapi.py
@@ -10,6 +10,7 @@ from starlette.testclient import TestClient
 
 from slack_bolt.adapter.fastapi.async_handler import AsyncSlackRequestHandler
 from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.oauth.async_oauth_settings import AsyncOAuthSettings
 from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
@@ -170,9 +171,11 @@ class TestFastAPI:
         app = AsyncApp(
             client=self.web_client,
             signing_secret=self.signing_secret,
-            client_id="111.111",
-            client_secret="xxx",
-            scopes=["chat:write", "commands"],
+            oauth_settings=AsyncOAuthSettings(
+                client_id="111.111",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+            ),
         )
         api = FastAPI()
         app_handler = AsyncSlackRequestHandler(app)

--- a/tests/adapter_tests/test_async_starlette.py
+++ b/tests/adapter_tests/test_async_starlette.py
@@ -11,6 +11,7 @@ from starlette.testclient import TestClient
 
 from slack_bolt.adapter.starlette.async_handler import AsyncSlackRequestHandler
 from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.oauth.async_oauth_settings import AsyncOAuthSettings
 from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
@@ -177,9 +178,11 @@ class TestAsyncStarlette:
         app = AsyncApp(
             client=self.web_client,
             signing_secret=self.signing_secret,
-            client_id="111.111",
-            client_secret="xxx",
-            scopes=["chat:write", "commands"],
+            oauth_settings=AsyncOAuthSettings(
+                client_id="111.111",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+            ),
         )
         app_handler = AsyncSlackRequestHandler(app)
 

--- a/tests/adapter_tests/test_aws_lambda.py
+++ b/tests/adapter_tests/test_aws_lambda.py
@@ -6,6 +6,7 @@ from slack_sdk.web import WebClient
 
 from slack_bolt.adapter.aws_lambda import SlackRequestHandler
 from slack_bolt.app import App
+from slack_bolt.oauth.oauth_settings import OAuthSettings
 from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
@@ -168,9 +169,11 @@ class TestAWSLambda:
         app = App(
             client=self.web_client,
             signing_secret=self.signing_secret,
-            client_id="111.111",
-            client_secret="xxx",
-            scopes=["chat:write", "commands"],
+            oauth_settings=OAuthSettings(
+                client_id="111.111",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+            ),
         )
 
         event = {

--- a/tests/adapter_tests/test_cherrypy_oauth.py
+++ b/tests/adapter_tests/test_cherrypy_oauth.py
@@ -5,10 +5,7 @@ from slack_sdk.web import WebClient
 
 from slack_bolt.adapter.cherrypy import SlackRequestHandler
 from slack_bolt.app import App
-from tests.mock_web_api_server import (
-    setup_mock_web_api_server,
-    cleanup_mock_web_api_server,
-)
+from slack_bolt.oauth.oauth_settings import OAuthSettings
 from tests.utils import remove_os_env_temporarily, restore_os_env
 
 
@@ -28,9 +25,11 @@ class TestCherryPy(helper.CPWebCase):
         app = App(
             client=web_client,
             signing_secret=signing_secret,
-            client_id="111.111",
-            client_secret="xxx",
-            scopes=["chat:write", "commands"],
+            oauth_settings=OAuthSettings(
+                client_id="111.111",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+            ),
         )
         handler = SlackRequestHandler(app)
 

--- a/tests/adapter_tests/test_fastapi.py
+++ b/tests/adapter_tests/test_fastapi.py
@@ -10,6 +10,7 @@ from starlette.testclient import TestClient
 
 from slack_bolt.adapter.fastapi import SlackRequestHandler
 from slack_bolt.app import App
+from slack_bolt.oauth.oauth_settings import OAuthSettings
 from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
@@ -170,9 +171,11 @@ class TestFastAPI:
         app = App(
             client=self.web_client,
             signing_secret=self.signing_secret,
-            client_id="111.111",
-            client_secret="xxx",
-            scopes=["chat:write", "commands"],
+            oauth_settings=OAuthSettings(
+                client_id="111.111",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+            ),
         )
         api = FastAPI()
         app_handler = SlackRequestHandler(app)

--- a/tests/adapter_tests/test_flask.py
+++ b/tests/adapter_tests/test_flask.py
@@ -7,6 +7,7 @@ from slack_sdk.web import WebClient
 
 from slack_bolt.adapter.flask import SlackRequestHandler
 from slack_bolt.app import App
+from slack_bolt.oauth.oauth_settings import OAuthSettings
 from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
@@ -164,9 +165,11 @@ class TestFlask:
         app = App(
             client=self.web_client,
             signing_secret=self.signing_secret,
-            client_id="111.111",
-            client_secret="xxx",
-            scopes=["chat:write", "commands"],
+            oauth_settings=OAuthSettings(
+                client_id="111.111",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+            ),
         )
         flask_app = Flask(__name__)
 

--- a/tests/adapter_tests/test_starlette.py
+++ b/tests/adapter_tests/test_starlette.py
@@ -11,6 +11,7 @@ from starlette.testclient import TestClient
 
 from slack_bolt.adapter.starlette import SlackRequestHandler
 from slack_bolt.app import App
+from slack_bolt.oauth.oauth_settings import OAuthSettings
 from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
@@ -177,9 +178,11 @@ class TestStarlette:
         app = App(
             client=self.web_client,
             signing_secret=self.signing_secret,
-            client_id="111.111",
-            client_secret="xxx",
-            scopes=["chat:write", "commands"],
+            oauth_settings=OAuthSettings(
+                client_id="111.111",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+            ),
         )
         app_handler = SlackRequestHandler(app)
 

--- a/tests/async_scenario_tests/test_app.py
+++ b/tests/async_scenario_tests/test_app.py
@@ -6,6 +6,8 @@ from slack_sdk.oauth.state_store import FileOAuthStateStore
 from slack_bolt.async_app import AsyncApp
 from slack_bolt.error import BoltError
 from slack_bolt.oauth.async_oauth_flow import AsyncOAuthFlow
+from slack_bolt.oauth.async_oauth_settings import AsyncOAuthSettings
+from slack_bolt.oauth.oauth_settings import OAuthSettings
 from tests.utils import remove_os_env_temporarily, restore_os_env
 
 
@@ -64,24 +66,35 @@ class TestAsyncApp:
 
     def test_valid_multi_auth(self):
         app = AsyncApp(
-            signing_secret="valid", client_id="111.222", client_secret="valid"
+            signing_secret="valid",
+            oauth_settings=AsyncOAuthSettings(
+                client_id="111.222", client_secret="valid"
+            ),
         )
         assert app != None
 
     def test_valid_multi_auth_oauth_flow(self):
         oauth_flow = AsyncOAuthFlow(
-            client_id="111.222",
-            client_secret="valid",
-            installation_store=FileInstallationStore(),
-            oauth_state_store=FileOAuthStateStore(expiration_seconds=120),
+            settings=AsyncOAuthSettings(
+                client_id="111.222",
+                client_secret="valid",
+                installation_store=FileInstallationStore(),
+                state_store=FileOAuthStateStore(expiration_seconds=120),
+            )
         )
         app = AsyncApp(signing_secret="valid", oauth_flow=oauth_flow)
         assert app != None
 
     def test_valid_multi_auth_client_id_absence(self):
         with pytest.raises(BoltError):
-            AsyncApp(signing_secret="valid", client_id=None, client_secret="valid")
+            AsyncApp(
+                signing_secret="valid",
+                oauth_settings=OAuthSettings(client_id=None, client_secret="valid"),
+            )
 
     def test_valid_multi_auth_secret_absence(self):
         with pytest.raises(BoltError):
-            AsyncApp(signing_secret="valid", client_id="111.222", client_secret=None)
+            AsyncApp(
+                signing_secret="valid",
+                oauth_settings=OAuthSettings(client_id="111.222", client_secret=None),
+            )

--- a/tests/scenario_tests/test_app.py
+++ b/tests/scenario_tests/test_app.py
@@ -5,6 +5,7 @@ from slack_sdk.oauth.state_store import FileOAuthStateStore
 from slack_bolt import App
 from slack_bolt.error import BoltError
 from slack_bolt.oauth import OAuthFlow
+from slack_bolt.oauth.oauth_settings import OAuthSettings
 from tests.utils import remove_os_env_temporarily, restore_os_env
 
 
@@ -48,23 +49,34 @@ class TestApp:
     # --------------------------
 
     def test_valid_multi_auth(self):
-        app = App(signing_secret="valid", client_id="111.222", client_secret="valid")
+        app = App(
+            signing_secret="valid",
+            oauth_settings=OAuthSettings(client_id="111.222", client_secret="valid"),
+        )
         assert app != None
 
     def test_valid_multi_auth_oauth_flow(self):
         oauth_flow = OAuthFlow(
-            client_id="111.222",
-            client_secret="valid",
-            installation_store=FileInstallationStore(),
-            oauth_state_store=FileOAuthStateStore(expiration_seconds=120),
+            settings=OAuthSettings(
+                client_id="111.222",
+                client_secret="valid",
+                installation_store=FileInstallationStore(),
+                state_store=FileOAuthStateStore(expiration_seconds=120),
+            )
         )
         app = App(signing_secret="valid", oauth_flow=oauth_flow)
         assert app != None
 
     def test_valid_multi_auth_client_id_absence(self):
         with pytest.raises(BoltError):
-            App(signing_secret="valid", client_id=None, client_secret="valid")
+            App(
+                signing_secret="valid",
+                oauth_settings=OAuthSettings(client_id=None, client_secret="valid"),
+            )
 
     def test_valid_multi_auth_secret_absence(self):
         with pytest.raises(BoltError):
-            App(signing_secret="valid", client_id="111.222", client_secret=None)
+            App(
+                signing_secret="valid",
+                oauth_settings=OAuthSettings(client_id="111.222", client_secret=None),
+            )

--- a/tests/slack_bolt/oauth/test_oauth_flow.py
+++ b/tests/slack_bolt/oauth/test_oauth_flow.py
@@ -4,8 +4,10 @@ from slack_sdk import WebClient
 from slack_sdk.oauth.installation_store import FileInstallationStore
 from slack_sdk.oauth.state_store import FileOAuthStateStore
 
-from slack_bolt import BoltRequest
+from slack_bolt import BoltRequest, BoltResponse
 from slack_bolt.oauth import OAuthFlow
+from slack_bolt.oauth.callback_options import CallbackOptions, SuccessArgs, FailureArgs
+from slack_bolt.oauth.oauth_settings import OAuthSettings
 from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     setup_mock_web_api_server,
@@ -26,21 +28,25 @@ class TestOAuthFlow:
 
     def test_instantiation(self):
         oauth_flow = OAuthFlow(
-            client_id="111.222",
-            client_secret="xxx",
-            scopes=["chat:write", "commands"],
-            installation_store=FileInstallationStore(),
-            oauth_state_store=FileOAuthStateStore(expiration_seconds=120),
+            settings=OAuthSettings(
+                client_id="111.222",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+                installation_store=FileInstallationStore(),
+                state_store=FileOAuthStateStore(expiration_seconds=120),
+            )
         )
         assert oauth_flow is not None
 
     def test_handle_installation(self):
         oauth_flow = OAuthFlow(
-            client_id="111.222",
-            client_secret="xxx",
-            scopes=["chat:write", "commands"],
-            installation_store=FileInstallationStore(),
-            oauth_state_store=FileOAuthStateStore(expiration_seconds=120),
+            settings=OAuthSettings(
+                client_id="111.222",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+                installation_store=FileInstallationStore(),
+                state_store=FileOAuthStateStore(expiration_seconds=120),
+            )
         )
         req = BoltRequest(body="")
         resp = oauth_flow.handle_installation(req)
@@ -59,19 +65,21 @@ class TestOAuthFlow:
     def test_handle_callback(self):
         oauth_flow = OAuthFlow(
             client=WebClient(base_url=self.mock_api_server_base_url),
-            client_id="111.222",
-            client_secret="xxx",
-            scopes=["chat:write", "commands"],
-            installation_store=FileInstallationStore(),
-            oauth_state_store=FileOAuthStateStore(expiration_seconds=120),
-            success_url="https://www.example.com/completion",
-            failure_url="https://www.example.com/failure",
+            settings=OAuthSettings(
+                client_id="111.222",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+                installation_store=FileInstallationStore(),
+                state_store=FileOAuthStateStore(expiration_seconds=120),
+                success_url="https://www.example.com/completion",
+                failure_url="https://www.example.com/failure",
+            ),
         )
         state = oauth_flow.issue_new_state(None)
         req = BoltRequest(
             body="",
             query=f"code=foo&state={state}",
-            headers={"cookie": [f"{oauth_flow.oauth_state_cookie_name}={state}"]},
+            headers={"cookie": [f"{oauth_flow.settings.state_cookie_name}={state}"]},
         )
         resp = oauth_flow.handle_callback(req)
         assert resp.status == 200
@@ -79,17 +87,60 @@ class TestOAuthFlow:
 
     def test_handle_callback_invalid_state(self):
         oauth_flow = OAuthFlow(
-            client_id="111.222",
-            client_secret="xxx",
-            scopes=["chat:write", "commands"],
-            installation_store=FileInstallationStore(),
-            oauth_state_store=FileOAuthStateStore(expiration_seconds=120),
+            settings=OAuthSettings(
+                client_id="111.222",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+                installation_store=FileInstallationStore(),
+                state_store=FileOAuthStateStore(expiration_seconds=120),
+            )
         )
         state = oauth_flow.issue_new_state(None)
         req = BoltRequest(
             body="",
             query=f"code=foo&state=invalid",
-            headers={"cookie": [f"{oauth_flow.oauth_state_cookie_name}={state}"]},
+            headers={"cookie": [f"{oauth_flow.settings.state_cookie_name}={state}"]},
         )
         resp = oauth_flow.handle_callback(req)
         assert resp.status == 400
+
+    def test_handle_callback_using_options(self):
+        def success(args: SuccessArgs) -> BoltResponse:
+            assert args.request is not None
+            return BoltResponse(status=200, body="customized")
+
+        def failure(args: FailureArgs) -> BoltResponse:
+            assert args.request is not None
+            assert args.reason is not None
+            return BoltResponse(status=502, body="customized")
+
+        oauth_flow = OAuthFlow(
+            client=WebClient(base_url=self.mock_api_server_base_url),
+            settings=OAuthSettings(
+                client_id="111.222",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+                installation_store=FileInstallationStore(),
+                state_store=FileOAuthStateStore(expiration_seconds=120),
+                callback_options=CallbackOptions(success=success, failure=failure),
+            ),
+        )
+        state = oauth_flow.issue_new_state(None)
+        req = BoltRequest(
+            body="",
+            query=f"code=foo&state={state}",
+            headers={"cookie": [f"{oauth_flow.settings.state_cookie_name}={state}"]},
+        )
+        resp = oauth_flow.handle_callback(req)
+        assert resp.status == 200
+        assert resp.body == "customized"
+
+        state = oauth_flow.issue_new_state(None)
+        req = BoltRequest(
+            body="",
+            query=f"code=foo&state=invalid",
+            headers={"cookie": [f"{oauth_flow.settings.state_cookie_name}={state}"]},
+        )
+        resp = oauth_flow.handle_callback(req)
+        assert resp.status == 502
+        assert resp.body == "customized"


### PR DESCRIPTION
This pull request fixes #73 by finalizing the OAuth flow support interface.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
