### PR TITLE
Fix #81 by supporting input validations in dialogs

### DIFF
--- a/samples/dialogs_app.py
+++ b/samples/dialogs_app.py
@@ -9,7 +9,7 @@ import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-from slack_bolt import App
+from slack_bolt import App, Ack
 
 app = App()
 
@@ -52,8 +52,21 @@ def test_command(body, client, ack, logger):
 
 
 @app.action({"type": "dialog_submission", "callback_id": "dialog-callback-id"})
-def dialog_submission(ack):
-    ack()
+def dialog_submission(ack: Ack, body: dict):
+    errors = []
+    submission = body["submission"]
+    if len(submission["loc_origin"]) <= 3:
+        errors = [
+            {
+                "name": "loc_origin",
+                "error": "Pickup Location must be longer than 3 characters"
+            }
+        ]
+    if len(errors) > 0:
+        # or ack({"errors": errors})
+        ack(errors=errors)
+    else:
+        ack()
 
 
 @app.options({"type": "dialog_suggestion", "callback_id": "dialog-callback-id"})

--- a/slack_bolt/context/ack/internals.py
+++ b/slack_bolt/context/ack/internals.py
@@ -20,7 +20,7 @@ def _set_response(
     option_groups: Optional[List[Union[dict, OptionGroup]]] = None,
     # view_submission
     response_action: Optional[str] = None,
-    errors: Optional[Dict[str, str]] = None,
+    errors: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None,
     view: Optional[Union[dict, View]] = None,
 ) -> BoltResponse:
     if isinstance(text_or_whole_response, str):

--- a/slack_bolt/context/ack/internals.py
+++ b/slack_bolt/context/ack/internals.py
@@ -62,6 +62,10 @@ def _set_response(
                 if view:
                     body["view"] = convert_to_dict(view)
                 self.response = BoltResponse(status=200, body=body)
+        elif errors:
+            # dialogs: errors without response_action
+            body = {"errors": convert_to_dict_list(errors)}
+            self.response = BoltResponse(status=200, body=body)
         else:
             if len(body) == 1 and "text" in body:
                 self.response = BoltResponse(status=200, body=body["text"])
@@ -79,7 +83,12 @@ def _set_response(
         if "option_groups" in body:
             body["option_groups"] = convert_to_dict_list(body["option_groups"])
         if "errors" in body:
-            body["errors"] = convert_to_dict(body["errors"])
+            if body.get("response_action", "") == "errors":
+                # modal
+                body["errors"] = convert_to_dict(body["errors"])
+            else:
+                # dialog
+                body["errors"] = convert_to_dict_list(body["errors"])
         if "view" in body:
             body["view"] = convert_to_dict(body["view"])
         # no modification for response_type, response_action here

--- a/tests/slack_bolt/context/test_ack.py
+++ b/tests/slack_bolt/context/test_ack.py
@@ -97,6 +97,21 @@ class TestAck:
             '{"text": "foo", "response_type": "in_channel"}',
         )
 
+    def test_dialog_errors(self):
+        expected_body = '{"errors": [{"name": "loc_origin", "error": "Pickup Location must be longer than 3 characters"}]}'
+        errors = [
+            {
+                "name": "loc_origin",
+                "error": "Pickup Location must be longer than 3 characters",
+            }
+        ]
+
+        ack = Ack()
+        response: BoltResponse = ack(errors=errors)
+        assert (response.status, response.body) == (200, expected_body)
+        response: BoltResponse = ack({"errors": errors})
+        assert (response.status, response.body) == (200, expected_body)
+
     def test_view_errors(self):
         ack = Ack()
         response: BoltResponse = ack(

--- a/tests/slack_bolt_async/context/test_async_ack.py
+++ b/tests/slack_bolt_async/context/test_async_ack.py
@@ -102,6 +102,22 @@ class TestAsyncAsyncAck:
         )
 
     @pytest.mark.asyncio
+    async def test_dialog_errors(self):
+        expected_body = '{"errors": [{"name": "loc_origin", "error": "Pickup Location must be longer than 3 characters"}]}'
+        errors = [
+            {
+                "name": "loc_origin",
+                "error": "Pickup Location must be longer than 3 characters",
+            }
+        ]
+
+        ack = AsyncAck()
+        response: BoltResponse = await ack(errors=errors)
+        assert (response.status, response.body) == (200, expected_body)
+        response: BoltResponse = await ack({"errors": errors})
+        assert (response.status, response.body) == (200, expected_body)
+
+    @pytest.mark.asyncio
     async def test_view_errors(self):
         ack = AsyncAck()
         response: BoltResponse = await ack(


### PR DESCRIPTION
This pull request fixes #81 

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
