### PR TITLE
Fix #80 by making app.action/options more flexible

### DIFF
--- a/samples/dialogs_app.py
+++ b/samples/dialogs_app.py
@@ -51,8 +51,13 @@ def test_command(body, client, ack, logger):
     logger.info(res)
 
 
-@app.action({"type": "dialog_submission", "callback_id": "dialog-callback-id"})
-def dialog_submission(ack: Ack, body: dict):
+@app.action("dialog-callback-id")
+def dialog_submission_or_cancellation(ack: Ack, body: dict):
+    if body["type"] == "dialog_cancellation":
+        # This can be sent only when notify_on_cancel is True
+        ack()
+        return
+
     errors = []
     submission = body["submission"]
     if len(submission["loc_origin"]) <= 3:
@@ -69,7 +74,30 @@ def dialog_submission(ack: Ack, body: dict):
         ack()
 
 
-@app.options({"type": "dialog_suggestion", "callback_id": "dialog-callback-id"})
+# @app.action({"type": "dialog_submission", "callback_id": "dialog-callback-id"})
+# def dialog_submission_or_cancellation(ack: Ack, body: dict):
+#     errors = []
+#     submission = body["submission"]
+#     if len(submission["loc_origin"]) <= 3:
+#         errors = [
+#             {
+#                 "name": "loc_origin",
+#                 "error": "Pickup Location must be longer than 3 characters"
+#             }
+#         ]
+#     if len(errors) > 0:
+#         # or ack({"errors": errors})
+#         ack(errors=errors)
+#     else:
+#         ack()
+#
+# @app.action({"type": "dialog_cancellation", "callback_id": "dialog-callback-id"})
+# def dialog_cancellation(ack):
+#     ack()
+
+
+# @app.options({"type": "dialog_suggestion", "callback_id": "dialog-callback-id"})
+@app.options("dialog-callback-id")
 def dialog_suggestion(ack):
     ack(
         {
@@ -87,10 +115,6 @@ def dialog_suggestion(ack):
         }
     )
 
-
-@app.action({"type": "dialog_cancellation", "callback_id": "dialog-callback-id"})
-def dialog_cancellation(ack):
-    ack()
 
 
 if __name__ == "__main__":

--- a/tests/scenario_tests/test_attachment_actions.py
+++ b/tests/scenario_tests/test_attachment_actions.py
@@ -51,6 +51,15 @@ class TestAttachmentActions:
         resp = self.web_client.api_test()
         assert resp != None
 
+    def test_success_without_type(self):
+        app = App(client=self.web_client, signing_secret=self.signing_secret,)
+        app.action("pick_channel_for_fun")(simple_listener)
+
+        request = self.build_valid_request()
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
     def test_success(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
         app.action(
@@ -85,6 +94,18 @@ class TestAttachmentActions:
         response = app.dispatch(request)
         assert response.status == 200
         assert self.mock_received_requests["/auth.test"] == 1
+
+    def test_failure_without_type(self):
+        app = App(client=self.web_client, signing_secret=self.signing_secret,)
+        request = self.build_valid_request()
+        response = app.dispatch(request)
+        assert response.status == 404
+        assert self.mock_received_requests["/auth.test"] == 1
+
+        app.action("unknown")(simple_listener)
+        response = app.dispatch(request)
+        assert response.status == 404
+        assert self.mock_received_requests["/auth.test"] == 2
 
     def test_failure(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)

--- a/tests/scenario_tests_async/test_attachment_actions.py
+++ b/tests/scenario_tests_async/test_attachment_actions.py
@@ -59,6 +59,16 @@ class TestAsyncAttachmentActions:
         assert resp != None
 
     @pytest.mark.asyncio
+    async def test_success_without_type(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret,)
+        app.action("pick_channel_for_fun")(simple_listener)
+
+        request = self.build_valid_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
+    @pytest.mark.asyncio
     async def test_success(self):
         app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret,)
         app.action(
@@ -109,6 +119,19 @@ class TestAsyncAttachmentActions:
         response = await app.async_dispatch(request)
         assert response.status == 200
         assert self.mock_received_requests["/auth.test"] == 1
+
+    @pytest.mark.asyncio
+    async def test_failure_without_type(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret,)
+        request = self.build_valid_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        assert self.mock_received_requests["/auth.test"] == 1
+
+        app.action("unknown")(simple_listener)
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        assert self.mock_received_requests["/auth.test"] == 2
 
     @pytest.mark.asyncio
     async def test_failure(self):


### PR DESCRIPTION
This pull request fixes #80 for both `app.action` and `app.options` for better compatibility with Bolt for JS.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
