### PR TITLE
Add tests for Tornado adapter

### DIFF
--- a/tests/adapter_tests/test_tornado.py
+++ b/tests/adapter_tests/test_tornado.py
@@ -1,0 +1,167 @@
+import json
+from time import time
+from urllib.parse import quote
+
+import tornado
+from slack_sdk.signature import SignatureVerifier
+from slack_sdk.web import WebClient
+from tornado.httpclient import HTTPRequest, HTTPResponse
+from tornado.testing import AsyncHTTPTestCase
+from tornado.web import Application
+
+from slack_bolt.adapter.tornado import SlackEventsHandler
+from slack_bolt.app import App
+from slack_bolt.oauth.oauth_settings import OAuthSettings
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+signing_secret = "secret"
+valid_token = "xoxb-valid"
+mock_api_server_base_url = "http://localhost:8888"
+web_client = WebClient(token=valid_token, base_url=mock_api_server_base_url,)
+
+app = App(client=web_client, signing_secret=signing_secret)
+
+
+@app.event("app_mention")
+def event_handler():
+    pass
+
+
+@app.shortcut("test-shortcut")
+def shortcut_handler(ack):
+    ack()
+
+
+@app.command("/hello-world")
+def command_handler(ack):
+    ack()
+
+
+class TestTornado(AsyncHTTPTestCase):
+    signature_verifier = SignatureVerifier(signing_secret)
+
+    def setUp(self):
+        AsyncHTTPTestCase.setUp(self)
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
+
+    def tearDown(self):
+        AsyncHTTPTestCase.tearDown(self)
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
+
+    def get_app(self):
+        return Application([("/slack/events", SlackEventsHandler, dict(app=app))])
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body, timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        content_type = (
+            "application/json"
+            if body.startswith("{")
+            else "application/x-www-form-urlencoded"
+        )
+        return {
+            "content-type": content_type,
+            "x-slack-signature": self.generate_signature(body, timestamp),
+            "x-slack-request-timestamp": timestamp,
+        }
+
+    @tornado.testing.gen_test
+    async def test_events(self):
+        input = {
+            "token": "verification_token",
+            "team_id": "T111",
+            "enterprise_id": "E111",
+            "api_app_id": "A111",
+            "event": {
+                "client_msg_id": "9cbd4c5b-7ddf-4ede-b479-ad21fca66d63",
+                "type": "app_mention",
+                "text": "<@W111> Hi there!",
+                "user": "W222",
+                "ts": "1595926230.009600",
+                "team": "T111",
+                "channel": "C111",
+                "event_ts": "1595926230.009600",
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1595926230,
+            "authed_users": ["W111"],
+        }
+        timestamp, body = str(int(time())), json.dumps(input)
+
+        request = HTTPRequest(
+            url=self.get_url("/slack/events"),
+            method="POST",
+            body=body,
+            headers=self.build_headers(timestamp, body),
+        )
+        response: HTTPResponse = await self.http_client.fetch(request)
+        assert response.code == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
+    @tornado.testing.gen_test
+    async def test_shortcuts(self):
+        input = {
+            "type": "shortcut",
+            "token": "verification_token",
+            "action_ts": "111.111",
+            "team": {
+                "id": "T111",
+                "domain": "workspace-domain",
+                "enterprise_id": "E111",
+                "enterprise_name": "Org Name",
+            },
+            "user": {"id": "W111", "username": "primary-owner", "team_id": "T111"},
+            "callback_id": "test-shortcut",
+            "trigger_id": "111.111.xxxxxx",
+        }
+
+        timestamp, body = str(int(time())), f"payload={quote(json.dumps(input))}"
+
+        request = HTTPRequest(
+            url=self.get_url("/slack/events"),
+            method="POST",
+            body=body,
+            headers=self.build_headers(timestamp, body),
+        )
+        response: HTTPResponse = await self.http_client.fetch(request)
+        assert response.code == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
+    @tornado.testing.gen_test
+    async def test_commands(self):
+        input = (
+            "token=verification_token"
+            "&team_id=T111"
+            "&team_domain=test-domain"
+            "&channel_id=C111"
+            "&channel_name=random"
+            "&user_id=W111"
+            "&user_name=primary-owner"
+            "&command=%2Fhello-world"
+            "&text=Hi"
+            "&enterprise_id=E111"
+            "&enterprise_name=Org+Name"
+            "&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT111%2F111%2Fxxxxx"
+            "&trigger_id=111.111.xxx"
+        )
+        timestamp, body = str(int(time())), input
+
+        request = HTTPRequest(
+            url=self.get_url("/slack/events"),
+            method="POST",
+            body=body,
+            headers=self.build_headers(timestamp, body),
+        )
+        response: HTTPResponse = await self.http_client.fetch(request)
+        assert response.code == 200
+        assert self.mock_received_requests["/auth.test"] == 1

--- a/tests/adapter_tests/test_tornado_oauth.py
+++ b/tests/adapter_tests/test_tornado_oauth.py
@@ -1,0 +1,43 @@
+import pytest
+import tornado
+from tornado.httpclient import HTTPRequest, HTTPResponse
+from tornado.testing import AsyncHTTPTestCase
+from tornado.web import Application
+
+from slack_bolt.adapter.tornado import SlackOAuthHandler
+from slack_bolt.app import App
+from slack_bolt.oauth.oauth_settings import OAuthSettings
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+signing_secret = "secret"
+
+app = App(
+    signing_secret=signing_secret,
+    oauth_settings=OAuthSettings(
+        client_id="111.111", client_secret="xxx", scopes=["chat:write", "commands"],
+    ),
+)
+
+
+class TestTornado(AsyncHTTPTestCase):
+    def get_app(self):
+        return Application([("/slack/install", SlackOAuthHandler, dict(app=app))])
+
+    def setUp(self):
+        AsyncHTTPTestCase.setUp(self)
+        self.old_os_env = remove_os_env_temporarily()
+
+    def tearDown(self):
+        AsyncHTTPTestCase.tearDown(self)
+        restore_os_env(self.old_os_env)
+
+    @tornado.testing.gen_test
+    async def test_oauth(self):
+        request = HTTPRequest(
+            url=self.get_url("/slack/install"), method="GET", follow_redirects=False
+        )
+        try:
+            response: HTTPResponse = await self.http_client.fetch(request)
+            assert response.code == 302
+        except tornado.httpclient.HTTPClientError as e:
+            assert e.code == 302


### PR DESCRIPTION
This pull request adds tests for the Tornado adapter.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
