### PR TITLE
Fix #87 by correcting App internals

### DIFF
--- a/samples/events_app.py
+++ b/samples/events_app.py
@@ -32,6 +32,10 @@ def say_something_to_reaction(say):
     say("OK!")
 
 
+@app.event("message")
+def foo(body, logger):
+    logger.info(body)
+
 @app.message("test")
 def test_message(logger, body):
     logger.info(body)

--- a/samples/events_app.py
+++ b/samples/events_app.py
@@ -32,10 +32,6 @@ def say_something_to_reaction(say):
     say("OK!")
 
 
-@app.event("message")
-def foo(body, logger):
-    logger.info(body)
-
 @app.message("test")
 def test_message(logger, body):
     logger.info(body)

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -772,12 +772,12 @@ class SlackAppDevelopmentServer:
         self._port: int = port
         self._bolt_endpoint_path: str = path
         self._bolt_app: App = app
-        self._bolt_oauth_flow: OAuthFlow = oauth_flow
+        self._bolt_oauth_flow: Optional[OAuthFlow] = oauth_flow
 
         _port: int = self._port
         _bolt_endpoint_path: str = self._bolt_endpoint_path
         _bolt_app: App = self._bolt_app
-        _bolt_oauth_flow: OAuthFlow = self._bolt_oauth_flow
+        _bolt_oauth_flow: Optional[OAuthFlow] = self._bolt_oauth_flow
 
         class SlackAppHandler(SimpleHTTPRequestHandler):
             def do_GET(self):

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -323,16 +323,20 @@ class App:
                     except Exception as e:
                         # The default response status code is 500 in this case.
                         # You can customize this by passing your own error handler.
-                        if response is None:
-                            response = BoltResponse(status=500)
-                        response.status = 500
-                        if ack.response is not None:  # already acknowledged
-                            response = None
-
-                        self._listener_error_handler.handle(
-                            error=e, request=request, response=response,
-                        )
-                        ack.response = response
+                        if listener.auto_acknowledgement:
+                            self._listener_error_handler.handle(
+                                error=e, request=request, response=response,
+                            )
+                        else:
+                            if response is None:
+                                response = BoltResponse(status=500)
+                            response.status = 500
+                            if ack.response is not None:  # already acknowledged
+                                response = None
+                            self._listener_error_handler.handle(
+                                error=e, request=request, response=response,
+                            )
+                            ack.response = response
 
                 self._listener_executor.submit(run_ack_function_asynchronously)
 

--- a/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
@@ -73,7 +73,7 @@ class AsyncMultiTeamsAuthorization(AsyncAuthorization):
                 # TODO: bot -> user token
                 req.context["token"] = bot.bot_token
                 req.context["client"] = create_async_web_client(bot.bot_token)
-                return next()
+                return await next()
 
         except SlackApiError as e:
             self.logger.error(f"Failed to authorize with the given token ({e})")

--- a/slack_bolt/middleware/authorization/multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/multi_teams_authorization.py
@@ -6,7 +6,7 @@ from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 from slack_sdk.errors import SlackApiError
 from slack_sdk.oauth.installation_store import InstallationStore, Bot
-from . import Authorization
+from .authorization import Authorization
 from .internals import _build_error_response, _is_no_auth_required
 from ...util.utils import create_web_client
 

--- a/slack_bolt/middleware/authorization/single_team_authorization.py
+++ b/slack_bolt/middleware/authorization/single_team_authorization.py
@@ -1,7 +1,7 @@
 from typing import Callable, Optional
 
 from slack_bolt.logger import get_bolt_logger
-from slack_bolt.middleware.authorization import Authorization
+from .authorization import Authorization
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 from slack_sdk.errors import SlackApiError

--- a/tests/scenario_tests/test_events.py
+++ b/tests/scenario_tests/test_events.py
@@ -149,7 +149,7 @@ class TestEvents:
 
         @app.event("reaction_added")
         def handle_app_mention():
-            raise Exception("something wrong!")
+            raise Exception("Something wrong!")
 
         for _ in range(10):
             timestamp, body = (

--- a/tests/scenario_tests_async/test_events.py
+++ b/tests/scenario_tests_async/test_events.py
@@ -129,6 +129,16 @@ class TestAsyncEvents:
         await asyncio.sleep(1)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
+    @pytest.mark.asyncio
+    async def test_stable_auto_ack(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret,)
+        app.event("reaction_added")(always_failing)
+
+        for _ in range(10):
+            request = self.build_valid_reaction_added_request()
+            response = await app.async_dispatch(request)
+            assert response.status == 200
+
 
 app_mention_body = {
     "token": "verification_token",
@@ -189,3 +199,7 @@ async def whats_up(body, say, payload, event):
 async def skip_middleware(req, resp, next):
     # return next()
     pass
+
+
+async def always_failing():
+    raise Exception("Something wrong!")


### PR DESCRIPTION
This pull request fixes #87 for `App`. `AsyncApp` doesn't have this issue but I added a unit test verifying the behavior for it too.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/run_tests.sh` after making the changes.
