### PR TITLE
Make single team auth Bolt JS compatible

### DIFF
--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -85,7 +85,6 @@ class AsyncApp:
         # for the OAuth flow
         oauth_settings: Optional[AsyncOAuthSettings] = None,
         oauth_flow: Optional[AsyncOAuthFlow] = None,
-        authorization_test_enabled: bool = True,
         # No need to set (the value is used only in response to ssl_check requests)
         verification_token: Optional[str] = None,
     ):
@@ -101,8 +100,6 @@ class AsyncApp:
         :param oauth_settings: The settings related to Slack app installation flow (OAuth flow)
         :param oauth_flow: Manually instantiated slack_bolt.oauth.async_oauth_flow.AsyncOAuthFlow.
             This is always prioritized over oauth_settings.
-        :param authorization_test_enabled: Set False if you want to skip auth.test calls
-            for every single incoming request from Slack (default: True)
         :param verification_token: Deprecated verification mechanism.
             This can used only for ssl_check requests.
         """
@@ -133,8 +130,6 @@ class AsyncApp:
         else:
             # NOTE: the token here can be None
             self._async_client = create_async_web_client(token)
-
-        self._authorization_test_enabled = authorization_test_enabled
 
         self._async_installation_store: Optional[
             AsyncInstallationStore
@@ -188,18 +183,13 @@ class AsyncApp:
         )
         if self._async_oauth_flow is None:
             if self._token:
-                self._async_middleware_list.append(
-                    AsyncSingleTeamAuthorization(
-                        verification_enabled=self._authorization_test_enabled
-                    )
-                )
+                self._async_middleware_list.append(AsyncSingleTeamAuthorization())
             else:
                 raise BoltError(error_token_required())
         else:
             self._async_middleware_list.append(
                 AsyncMultiTeamsAuthorization(
-                    installation_store=self._async_installation_store,
-                    verification_enabled=self._authorization_test_enabled,
+                    installation_store=self._async_installation_store
                 )
             )
 

--- a/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
@@ -19,19 +19,12 @@ class AsyncMultiTeamsAuthorization(AsyncAuthorization):
     installation_store: AsyncInstallationStore
     verification_enabled: bool
 
-    def __init__(
-        self,
-        installation_store: AsyncInstallationStore,
-        verification_enabled: bool = True,
-    ):
+    def __init__(self, installation_store: AsyncInstallationStore):
         """Multi-workspace authorization.
 
         :param installation_store: The module offering find/save operations of installation data.
-        :param verification_enabled:
-            Calls auth.test for every single incoming request from Slack if True (Default: True)
         """
         self.installation_store = installation_store
-        self.verification_enabled = verification_enabled
         self.logger = get_bolt_logger(AsyncMultiTeamsAuthorization)
 
     async def async_process(
@@ -50,36 +43,23 @@ class AsyncMultiTeamsAuthorization(AsyncAuthorization):
             if bot is None:
                 return _build_error_response()
 
-            if self.verification_enabled:
-                auth_result = await req.context.client.auth_test(token=bot.bot_token)
-                if auth_result:
-                    req.context["authorization_result"] = AuthorizationResult(
-                        enterprise_id=auth_result.get("enterprise_id", None),
-                        team_id=auth_result.get("team_id", None),
-                        bot_user_id=auth_result.get("user_id", None),
-                        bot_id=auth_result.get("bot_id", None),
-                        bot_token=bot.bot_token,
-                    )
-                    # TODO: bot -> user token
-                    req.context["token"] = bot.bot_token
-                    req.context["client"] = create_async_web_client(bot.bot_token)
-                    return await next()
-                else:
-                    # Just in case
-                    self.logger.error("auth.test API call result is unexpectedly None")
-                    return _build_error_response()
-            else:
+            auth_result = await req.context.client.auth_test(token=bot.bot_token)
+            if auth_result:
                 req.context["authorization_result"] = AuthorizationResult(
-                    enterprise_id=bot.enterprise_id,
-                    team_id=bot.team_id,
-                    bot_user_id=bot.bot_user_id,
-                    bot_id=bot.bot_id,
+                    enterprise_id=auth_result.get("enterprise_id", None),
+                    team_id=auth_result.get("team_id", None),
+                    bot_user_id=auth_result.get("user_id", None),
+                    bot_id=auth_result.get("bot_id", None),
                     bot_token=bot.bot_token,
                 )
                 # TODO: bot -> user token
                 req.context["token"] = bot.bot_token
                 req.context["client"] = create_async_web_client(bot.bot_token)
                 return await next()
+            else:
+                # Just in case
+                self.logger.error("auth.test API call result is unexpectedly None")
+                return _build_error_response()
 
         except SlackApiError as e:
             self.logger.error(f"Failed to authorize with the given token ({e})")

--- a/slack_bolt/middleware/authorization/async_single_team_authorization.py
+++ b/slack_bolt/middleware/authorization/async_single_team_authorization.py
@@ -11,13 +11,8 @@ from .internals import _to_authorization_result
 
 
 class AsyncSingleTeamAuthorization(AsyncAuthorization):
-    def __init__(self, *, verification_enabled: bool = True):
-        """Single-workspace authorization.
-
-        :param verification_enabled:
-            Calls auth.test for every single incoming request from Slack if True (Default: True)
-        """
-        self.verification_enabled = verification_enabled
+    def __init__(self):
+        """Single-workspace authorization."""
         self.auth_result: Optional[AsyncSlackResponse] = None
         self.logger = get_bolt_logger(AsyncSingleTeamAuthorization)
 
@@ -32,20 +27,12 @@ class AsyncSingleTeamAuthorization(AsyncAuthorization):
             return await next()
 
         try:
-            if not self.verification_enabled:
-                if self.auth_result is None:
-                    self.auth_result = await req.context.client.auth_test()
+            if self.auth_result is None:
+                self.auth_result = await req.context.client.auth_test()
+
+            if self.auth_result:
                 req.context["authorization_result"] = _to_authorization_result(
                     auth_test_result=self.auth_result,
-                    bot_token=req.context.client.token,
-                    request_user_id=req.context.user_id,
-                )
-                return await next()
-
-            auth_result = await req.context.client.auth_test()
-            if auth_result:
-                req.context["authorization_result"] = _to_authorization_result(
-                    auth_test_result=auth_result,
                     bot_token=req.context.client.token,
                     request_user_id=req.context.user_id,
                 )

--- a/slack_bolt/middleware/authorization/multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/multi_teams_authorization.py
@@ -15,17 +15,12 @@ class MultiTeamsAuthorization(Authorization):
     installation_store: InstallationStore
     verification_enabled: bool
 
-    def __init__(
-        self, installation_store: InstallationStore, verification_enabled: bool = True,
-    ):
+    def __init__(self, installation_store: InstallationStore):
         """Multi-workspace authorization.
 
         :param installation_store: The module offering find/save operations of installation data.
-        :param verification_enabled:
-            Calls auth.test for every single incoming request from Slack if True (Default: True)
         """
         self.installation_store = installation_store
-        self.verification_enabled = verification_enabled
         self.logger = get_bolt_logger(MultiTeamsAuthorization)
 
     def process(
@@ -40,36 +35,23 @@ class MultiTeamsAuthorization(Authorization):
             if bot is None:
                 return _build_error_response()
 
-            if self.verification_enabled:
-                auth_result = req.context.client.auth_test(token=bot.bot_token)
-                if auth_result:
-                    req.context["authorization_result"] = AuthorizationResult(
-                        enterprise_id=auth_result.get("enterprise_id", None),
-                        team_id=auth_result.get("team_id", None),
-                        bot_user_id=auth_result.get("user_id", None),
-                        bot_id=auth_result.get("bot_id", None),
-                        bot_token=bot.bot_token,
-                    )
-                    # TODO: bot -> user token
-                    req.context["token"] = bot.bot_token
-                    req.context["client"] = create_web_client(bot.bot_token)
-                    return next()
-                else:
-                    # Just in case
-                    self.logger.error("auth.test API call result is unexpectedly None")
-                    return _build_error_response()
-            else:
+            auth_result = req.context.client.auth_test(token=bot.bot_token)
+            if auth_result:
                 req.context["authorization_result"] = AuthorizationResult(
-                    enterprise_id=bot.enterprise_id,
-                    team_id=bot.team_id,
-                    bot_user_id=bot.bot_user_id,
-                    bot_id=bot.bot_id,
+                    enterprise_id=auth_result.get("enterprise_id", None),
+                    team_id=auth_result.get("team_id", None),
+                    bot_user_id=auth_result.get("user_id", None),
+                    bot_id=auth_result.get("bot_id", None),
                     bot_token=bot.bot_token,
                 )
                 # TODO: bot -> user token
                 req.context["token"] = bot.bot_token
                 req.context["client"] = create_web_client(bot.bot_token)
                 return next()
+            else:
+                # Just in case
+                self.logger.error("auth.test API call result is unexpectedly None")
+                return _build_error_response()
 
         except SlackApiError as e:
             self.logger.error(f"Failed to authorize with the given token ({e})")

--- a/tests/scenario_tests/test_attachment_actions.py
+++ b/tests/scenario_tests/test_attachment_actions.py
@@ -105,7 +105,7 @@ class TestAttachmentActions:
         app.action("unknown")(simple_listener)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_failure(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -119,7 +119,7 @@ class TestAttachmentActions:
         )
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_failure_2(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -131,7 +131,7 @@ class TestAttachmentActions:
         app.attachment_action("unknown")(simple_listener)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 # https://api.slack.com/legacy/interactive-messages

--- a/tests/scenario_tests/test_block_actions.py
+++ b/tests/scenario_tests/test_block_actions.py
@@ -119,7 +119,7 @@ class TestBlockActions:
         app.action("aaa")(simple_listener)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_failure_2(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -131,7 +131,7 @@ class TestBlockActions:
         app.block_action("aaa")(simple_listener)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 body = {

--- a/tests/scenario_tests/test_block_suggestion.py
+++ b/tests/scenario_tests/test_block_suggestion.py
@@ -131,7 +131,7 @@ class TestBlockSuggestion:
         app.options("mes_a")(show_multi_options)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_failure_2(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -143,7 +143,7 @@ class TestBlockSuggestion:
         app.block_suggestion("mes_a")(show_multi_options)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_failure_multi(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -155,7 +155,7 @@ class TestBlockSuggestion:
         app.options("es_a")(show_options)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 body = {

--- a/tests/scenario_tests/test_dialogs.py
+++ b/tests/scenario_tests/test_dialogs.py
@@ -65,13 +65,13 @@ class TestAttachmentActions:
         response = app.dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
         request = self.build_valid_request(cancellation_raw_body)
         response = app.dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 3
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_success(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -96,13 +96,13 @@ class TestAttachmentActions:
         response = app.dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
         request = self.build_valid_request(cancellation_raw_body)
         response = app.dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 3
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_success_2(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -121,13 +121,13 @@ class TestAttachmentActions:
         response = app.dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
         request = self.build_valid_request(cancellation_raw_body)
         response = app.dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 3
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_process_before_response(self):
         app = App(
@@ -156,13 +156,13 @@ class TestAttachmentActions:
         response = app.dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
         request = self.build_valid_request(cancellation_raw_body)
         response = app.dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 3
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_process_before_response_2(self):
         app = App(
@@ -185,13 +185,13 @@ class TestAttachmentActions:
         response = app.dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
         request = self.build_valid_request(cancellation_raw_body)
         response = app.dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 3
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_suggestion_failure_without_type(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -203,7 +203,7 @@ class TestAttachmentActions:
         app.options("dialog-callback-iddddd")(handle_suggestion)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_suggestion_failure(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -215,7 +215,7 @@ class TestAttachmentActions:
         app.dialog_suggestion("dialog-callback-iddddd")(handle_suggestion)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_suggestion_failure_2(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -229,7 +229,7 @@ class TestAttachmentActions:
         )(handle_suggestion)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_submission_failure_without_type(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -241,7 +241,7 @@ class TestAttachmentActions:
         app.action("dialog-callback-iddddd")(handle_submission)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_submission_failure(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -253,7 +253,7 @@ class TestAttachmentActions:
         app.dialog_submission("dialog-callback-iddddd")(handle_submission)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_submission_failure_2(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -267,7 +267,7 @@ class TestAttachmentActions:
         )(handle_submission)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_cancellation_failure_without_type(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -279,7 +279,7 @@ class TestAttachmentActions:
         app.action("dialog-callback-iddddd")(handle_cancellation)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_cancellation_failure(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -291,7 +291,7 @@ class TestAttachmentActions:
         app.dialog_cancellation("dialog-callback-iddddd")(handle_cancellation)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_cancellation_failure_2(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -305,7 +305,7 @@ class TestAttachmentActions:
         )(handle_cancellation)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 suggestion_body = {

--- a/tests/scenario_tests/test_shortcut.py
+++ b/tests/scenario_tests/test_shortcut.py
@@ -62,7 +62,7 @@ class TestShortcut:
         request = self.build_valid_request(message_shortcut_raw_body)
         response = app.dispatch(request)
         assert response.status == 200
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_success_global(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -85,7 +85,7 @@ class TestShortcut:
         request = self.build_valid_request(message_shortcut_raw_body)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_success_message(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -101,7 +101,7 @@ class TestShortcut:
         request = self.build_valid_request(global_shortcut_raw_body)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_success_message_2(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -115,7 +115,7 @@ class TestShortcut:
         request = self.build_valid_request(global_shortcut_raw_body)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_process_before_response_global(self):
         app = App(
@@ -140,7 +140,7 @@ class TestShortcut:
         app.shortcut("another-one")(simple_listener)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_failure_2(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -152,12 +152,12 @@ class TestShortcut:
         app.global_shortcut("another-one")(simple_listener)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
         request = self.build_valid_request(message_shortcut_raw_body)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 3
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 global_shortcut_body = {

--- a/tests/scenario_tests/test_slash_command.py
+++ b/tests/scenario_tests/test_slash_command.py
@@ -80,7 +80,7 @@ class TestSlashCommand:
         app.command("/another-one")(commander)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 slash_command_body = (

--- a/tests/scenario_tests/test_view_closed.py
+++ b/tests/scenario_tests/test_view_closed.py
@@ -92,7 +92,7 @@ class TestViewClosed:
         app.view("view-idddd")(simple_listener)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_failure(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -104,7 +104,7 @@ class TestViewClosed:
         app.view({"type": "view_closed", "callback_id": "view-idddd"})(simple_listener)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_failure_2(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -116,7 +116,7 @@ class TestViewClosed:
         app.view_closed("view-idddd")(simple_listener)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 body = {

--- a/tests/scenario_tests/test_view_submission.py
+++ b/tests/scenario_tests/test_view_submission.py
@@ -92,7 +92,7 @@ class TestViewSubmission:
         app.view("view-idddd")(simple_listener)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     def test_failure_2(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -104,7 +104,7 @@ class TestViewSubmission:
         app.view_submission("view-idddd")(simple_listener)
         response = app.dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 body = {

--- a/tests/scenario_tests_async/test_attachment_actions.py
+++ b/tests/scenario_tests_async/test_attachment_actions.py
@@ -131,7 +131,7 @@ class TestAsyncAttachmentActions:
         app.action("unknown")(simple_listener)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_failure(self):
@@ -146,7 +146,7 @@ class TestAsyncAttachmentActions:
         )
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_failure_2(self):
@@ -159,7 +159,7 @@ class TestAsyncAttachmentActions:
         app.attachment_action("unknown")(simple_listener)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 # https://api.slack.com/legacy/interactive-messages

--- a/tests/scenario_tests_async/test_block_actions.py
+++ b/tests/scenario_tests_async/test_block_actions.py
@@ -147,7 +147,7 @@ class TestAsyncBlockActions:
         app.action("aaa")(simple_listener)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_failure_2(self):
@@ -160,7 +160,7 @@ class TestAsyncBlockActions:
         app.block_action("aaa")(simple_listener)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 body = {

--- a/tests/scenario_tests_async/test_block_suggestion.py
+++ b/tests/scenario_tests_async/test_block_suggestion.py
@@ -144,7 +144,7 @@ class TestAsyncBlockSuggestion:
         app.options("mes_a")(show_multi_options)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_failure_2(self):
@@ -157,7 +157,7 @@ class TestAsyncBlockSuggestion:
         app.block_suggestion("mes_a")(show_multi_options)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_failure_multi(self):
@@ -170,7 +170,7 @@ class TestAsyncBlockSuggestion:
         app.options("es_a")(show_options)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 body = {

--- a/tests/scenario_tests_async/test_dialogs.py
+++ b/tests/scenario_tests_async/test_dialogs.py
@@ -73,13 +73,13 @@ class TestAsyncAttachmentActions:
         response = await app.async_dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
         request = self.build_valid_request(cancellation_raw_body)
         response = await app.async_dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 3
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_success(self):
@@ -105,13 +105,13 @@ class TestAsyncAttachmentActions:
         response = await app.async_dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
         request = self.build_valid_request(cancellation_raw_body)
         response = await app.async_dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 3
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_success_2(self):
@@ -131,13 +131,13 @@ class TestAsyncAttachmentActions:
         response = await app.async_dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
         request = self.build_valid_request(cancellation_raw_body)
         response = await app.async_dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 3
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_process_before_response(self):
@@ -167,13 +167,13 @@ class TestAsyncAttachmentActions:
         response = await app.async_dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
         request = self.build_valid_request(cancellation_raw_body)
         response = await app.async_dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 3
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_process_before_response_2(self):
@@ -197,13 +197,13 @@ class TestAsyncAttachmentActions:
         response = await app.async_dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
         request = self.build_valid_request(cancellation_raw_body)
         response = await app.async_dispatch(request)
         assert response.status == 200
         assert response.body == ""
-        assert self.mock_received_requests["/auth.test"] == 3
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_suggestion_failure_without_type(self):
@@ -216,7 +216,7 @@ class TestAsyncAttachmentActions:
         app.options("dialog-callback-iddddd")(handle_suggestion)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_suggestion_failure(self):
@@ -229,7 +229,7 @@ class TestAsyncAttachmentActions:
         app.dialog_suggestion("dialog-callback-iddddd")(handle_suggestion)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_suggestion_failure_2(self):
@@ -244,7 +244,7 @@ class TestAsyncAttachmentActions:
         )(handle_suggestion)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_submission_failure_without_type(self):
@@ -257,7 +257,7 @@ class TestAsyncAttachmentActions:
         app.action("dialog-callback-iddddd")(handle_submission)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_submission_failure(self):
@@ -270,7 +270,7 @@ class TestAsyncAttachmentActions:
         app.dialog_submission("dialog-callback-iddddd")(handle_submission)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_submission_failure_2(self):
@@ -285,7 +285,7 @@ class TestAsyncAttachmentActions:
         )(handle_submission)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_cancellation_failure_without_type(self):
@@ -298,7 +298,7 @@ class TestAsyncAttachmentActions:
         app.action("dialog-callback-iddddd")(handle_cancellation)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_cancellation_failure(self):
@@ -311,7 +311,7 @@ class TestAsyncAttachmentActions:
         app.dialog_cancellation("dialog-callback-iddddd")(handle_cancellation)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_cancellation_failure_2(self):
@@ -326,7 +326,7 @@ class TestAsyncAttachmentActions:
         )(handle_cancellation)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 suggestion_body = {

--- a/tests/scenario_tests_async/test_shortcut.py
+++ b/tests/scenario_tests_async/test_shortcut.py
@@ -70,7 +70,7 @@ class TestAsyncShortcut:
         request = self.build_valid_request(message_shortcut_raw_body)
         response = await app.async_dispatch(request)
         assert response.status == 200
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_success_global(self):
@@ -95,7 +95,7 @@ class TestAsyncShortcut:
         request = self.build_valid_request(message_shortcut_raw_body)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_success_message(self):
@@ -112,7 +112,7 @@ class TestAsyncShortcut:
         request = self.build_valid_request(global_shortcut_raw_body)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_success_message_2(self):
@@ -127,7 +127,7 @@ class TestAsyncShortcut:
         request = self.build_valid_request(global_shortcut_raw_body)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_process_before_response_global(self):
@@ -154,7 +154,7 @@ class TestAsyncShortcut:
         app.shortcut("another-one")(simple_listener)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_failure_2(self):
@@ -167,12 +167,12 @@ class TestAsyncShortcut:
         app.global_shortcut("another-one")(simple_listener)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
         request = self.build_valid_request(message_shortcut_raw_body)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 3
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 global_shortcut_body = {

--- a/tests/scenario_tests_async/test_slash_command.py
+++ b/tests/scenario_tests_async/test_slash_command.py
@@ -90,7 +90,7 @@ class TestAsyncSlashCommand:
         app.command("/another-one")(commander)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 slash_command_body = (

--- a/tests/scenario_tests_async/test_view_closed.py
+++ b/tests/scenario_tests_async/test_view_closed.py
@@ -103,7 +103,7 @@ class TestAsyncViewClosed:
         app.view("view-idddd")(simple_listener)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_failure(self):
@@ -116,7 +116,7 @@ class TestAsyncViewClosed:
         app.view({"type": "view_closed", "callback_id": "view-idddd"})(simple_listener)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_failure_2(self):
@@ -129,7 +129,7 @@ class TestAsyncViewClosed:
         app.view_closed("view-idddd")(simple_listener)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 body = {

--- a/tests/scenario_tests_async/test_view_submission.py
+++ b/tests/scenario_tests_async/test_view_submission.py
@@ -103,7 +103,7 @@ class TestAsyncViewSubmission:
         app.view("view-idddd")(simple_listener)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
     @pytest.mark.asyncio
     async def test_failure_2(self):
@@ -116,7 +116,7 @@ class TestAsyncViewSubmission:
         app.view_submission("view-idddd")(simple_listener)
         response = await app.async_dispatch(request)
         assert response.status == 404
-        assert self.mock_received_requests["/auth.test"] == 2
+        assert self.mock_received_requests["/auth.test"] == 1
 
 
 body = {

--- a/tests/slack_bolt/app/test_dev_server.py
+++ b/tests/slack_bolt/app/test_dev_server.py
@@ -1,17 +1,31 @@
+from slack_sdk import WebClient
+
 from slack_bolt.app.app import SlackAppDevelopmentServer, App
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
 
 
 class TestDevServer:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    web_client = WebClient(token=valid_token, base_url=mock_api_server_base_url,)
+
     def setup_method(self):
-        pass
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
 
     def teardown_method(self):
-        pass
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
 
     def test_instance(self):
         server = SlackAppDevelopmentServer(
             port=3001,
             path="/slack/events",
-            app=App(signing_secret="valid", token="xoxb-valid",),
+            app=App(signing_secret=self.signing_secret, client=self.web_client),
         )
         assert server is not None

--- a/tests/slack_bolt/middleware/authorization/test_single_team_authorization.py
+++ b/tests/slack_bolt/middleware/authorization/test_single_team_authorization.py
@@ -22,10 +22,8 @@ class TestSingleTeamAuthorization:
     def teardown_method(self):
         cleanup_mock_web_api_server(self)
 
-    def test_normal_pattern(self):
-        authorization = SingleTeamAuthorization(
-            auth_test_result={}, verification_enabled=True,
-        )
+    def test_success_pattern(self):
+        authorization = SingleTeamAuthorization(auth_test_result={})
         req = BoltRequest(body="payload={}", headers={})
         req.context["client"] = WebClient(
             base_url=self.mock_api_server_base_url, token="xoxb-valid"
@@ -38,9 +36,7 @@ class TestSingleTeamAuthorization:
         assert resp.body == ""
 
     def test_failure_pattern(self):
-        authorization = SingleTeamAuthorization(
-            auth_test_result={}, verification_enabled=True,
-        )
+        authorization = SingleTeamAuthorization(auth_test_result={})
         req = BoltRequest(body="payload={}", headers={})
         req.context["client"] = WebClient(
             base_url=self.mock_api_server_base_url, token="dummy"
@@ -51,18 +47,3 @@ class TestSingleTeamAuthorization:
 
         assert resp.status == 200
         assert resp.body == ":x: Please install this app into the workspace :bow:"
-
-    def test_normal_pattern_disabled(self):
-        authorization = SingleTeamAuthorization(
-            auth_test_result={"ok": True}, verification_enabled=False,
-        )
-        req = BoltRequest(body="payload={}", headers={})
-        req.context["client"] = WebClient(
-            base_url=self.mock_api_server_base_url, token="xoxb-valid"
-        )
-        resp = BoltResponse(status=404)
-
-        resp = authorization.process(req=req, resp=resp, next=next)
-
-        assert resp.status == 200
-        assert resp.body == ""

--- a/tests/slack_bolt_async/middleware/authorization/test_single_team_authorization.py
+++ b/tests/slack_bolt_async/middleware/authorization/test_single_team_authorization.py
@@ -35,8 +35,8 @@ class TestSingleTeamAuthorization:
             restore_os_env(old_os_env)
 
     @pytest.mark.asyncio
-    async def test_normal_pattern(self):
-        authorization = AsyncSingleTeamAuthorization(verification_enabled=True,)
+    async def test_success_pattern(self):
+        authorization = AsyncSingleTeamAuthorization()
         req = AsyncBoltRequest(body="payload={}", headers={})
         req.context["client"] = AsyncWebClient(
             base_url=self.mock_api_server_base_url, token="xoxb-valid"
@@ -50,7 +50,7 @@ class TestSingleTeamAuthorization:
 
     @pytest.mark.asyncio
     async def test_failure_pattern(self):
-        authorization = AsyncSingleTeamAuthorization(verification_enabled=True,)
+        authorization = AsyncSingleTeamAuthorization()
         req = AsyncBoltRequest(body="payload={}", headers={})
         req.context["client"] = AsyncWebClient(
             base_url=self.mock_api_server_base_url, token="dummy"
@@ -61,17 +61,3 @@ class TestSingleTeamAuthorization:
 
         assert resp.status == 200
         assert resp.body == ":x: Please install this app into the workspace :bow:"
-
-    @pytest.mark.asyncio
-    async def test_normal_pattern_disabled(self):
-        authorization = AsyncSingleTeamAuthorization(verification_enabled=False,)
-        req = AsyncBoltRequest(body="payload={}", headers={})
-        req.context["client"] = AsyncWebClient(
-            base_url=self.mock_api_server_base_url, token="xoxb-valid"
-        )
-        resp = BoltResponse(status=404)
-
-        resp = await authorization.async_process(req=req, resp=resp, next=next)
-
-        assert resp.status == 200
-        assert resp.body == ""


### PR DESCRIPTION
This pull request modifies `SingleTeamAuthorization` middleware to be compatible with Bolt for JS. Now the `App` calls `auth.test` API method when booting a Bolt app and raises an exception if the call fails. 

Also, this pull request removes the `authorization_test_enabled` option and we will be rethinking a better way to provide the option for multiple workspace apps. Probably, one of the options developers can take advantage of would be to utilize `authorize` function described at #98 .

(Describe the goal of this PR. Mention any related Issue numbers)

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
