### PR TITLE
Change type hints for bot related fields in AuthorizationResult to optional

### DIFF
--- a/slack_bolt/authorization/authorization_result.py
+++ b/slack_bolt/authorization/authorization_result.py
@@ -6,9 +6,9 @@ from slack_sdk.web import SlackResponse
 class AuthorizationResult(dict):
     enterprise_id: Optional[str]
     team_id: Optional[str]
-    bot_id: str
-    bot_user_id: str
-    bot_token: str
+    bot_id: Optional[str]
+    bot_user_id: Optional[str]
+    bot_token: Optional[str]
     user_id: Optional[str]
     user_token: Optional[str]
 
@@ -18,9 +18,9 @@ class AuthorizationResult(dict):
         enterprise_id: Optional[str],
         team_id: Optional[str],
         # bot
-        bot_user_id: str,
-        bot_id: str,
-        bot_token: str,
+        bot_user_id: Optional[str] = None,
+        bot_id: Optional[str] = None,
+        bot_token: Optional[str] = None,
         # user
         user_id: Optional[str] = None,
         user_token: Optional[str] = None,


### PR DESCRIPTION
Thanks for your suggestion @shaydewael !

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
