### PR TITLE
Make Bolt Python more customizable from global middleware

### DIFF
--- a/slack_bolt/kwargs_injection/async_utils.py
+++ b/slack_bolt/kwargs_injection/async_utils.py
@@ -58,6 +58,9 @@ def build_async_required_kwargs(
         or all_available_args["message"]
         or request.body
     )
+    for k, v in request.context.items():
+        if k not in all_available_args:
+            all_available_args[k] = v
 
     kwargs: Dict[str, Any] = {
         k: v for k, v in all_available_args.items() if k in required_arg_names

--- a/slack_bolt/kwargs_injection/utils.py
+++ b/slack_bolt/kwargs_injection/utils.py
@@ -58,6 +58,9 @@ def build_required_kwargs(
         or all_available_args["message"]
         or request.body
     )
+    for k, v in request.context.items():
+        if k not in all_available_args:
+            all_available_args[k] = v
 
     kwargs: Dict[str, Any] = {
         k: v for k, v in all_available_args.items() if k in required_arg_names

--- a/slack_bolt/listener/asyncio_runner.py
+++ b/slack_bolt/listener/asyncio_runner.py
@@ -1,0 +1,178 @@
+import asyncio
+import time
+from asyncio import Future
+from logging import Logger
+from typing import Optional, Callable, Awaitable
+
+from slack_bolt.context.ack.async_ack import AsyncAck
+from slack_bolt.lazy_listener.async_runner import AsyncLazyListenerRunner
+from slack_bolt.listener.async_listener import AsyncListener
+from slack_bolt.listener.async_listener_error_handler import AsyncListenerErrorHandler
+from slack_bolt.logger.messages import (
+    debug_responding,
+    debug_running_lazy_listener,
+    warning_did_not_call_ack,
+)
+from slack_bolt.request.async_request import AsyncBoltRequest
+from slack_bolt.response import BoltResponse
+from slack_bolt.util.utils import create_copy
+
+
+class AsyncioListenerRunner:
+    logger: Logger
+    process_before_response: bool
+    listener_error_handler: AsyncListenerErrorHandler
+    lazy_listener_runner: AsyncLazyListenerRunner
+
+    def __init__(
+        self,
+        logger: Logger,
+        process_before_response: bool,
+        listener_error_handler: AsyncListenerErrorHandler,
+        lazy_listener_runner: AsyncLazyListenerRunner,
+    ):
+        self.logger = logger
+        self.process_before_response = process_before_response
+        self.listener_error_handler = listener_error_handler
+        self.lazy_listener_runner = lazy_listener_runner
+
+    async def run(
+        self,
+        request: AsyncBoltRequest,
+        response: BoltResponse,
+        listener_name: str,
+        listener: AsyncListener,
+    ) -> Optional[BoltResponse]:
+        ack = request.context.ack
+        starting_time = time.time()
+        if self.process_before_response:
+            if not request.lazy_only:
+                try:
+                    returned_value = await listener.run_ack_function(
+                        request=request, response=response
+                    )
+                    if isinstance(returned_value, BoltResponse):
+                        response = returned_value
+                    if ack.response is None and listener.auto_acknowledgement:
+                        await ack()  # automatic ack() call if the call is not yet done
+                except Exception as e:
+                    # The default response status code is 500 in this case.
+                    # You can customize this by passing your own error handler.
+                    if response is None:
+                        response = BoltResponse(status=500)
+                    response.status = 500
+                    await self.listener_error_handler.handle(
+                        error=e, request=request, response=response,
+                    )
+                    ack.response = response
+
+            for lazy_func in listener.lazy_functions:
+                if request.lazy_function_name:
+                    func_name = lazy_func.__name__
+                    if func_name == request.lazy_function_name:
+                        await self.lazy_listener_runner.run(
+                            function=lazy_func, request=request
+                        )
+                        # This HTTP response won't be sent to Slack API servers.
+                        return BoltResponse(status=200)
+                    else:
+                        continue
+                else:
+                    self._start_lazy_function(lazy_func, request)
+
+            if response is not None:
+                self._debug_log_completion(starting_time, response)
+                return response
+            elif ack.response is not None:
+                self._debug_log_completion(starting_time, ack.response)
+                return ack.response
+        else:
+            if listener.auto_acknowledgement:
+                # acknowledge immediately in case of Events API
+                await ack()
+
+            if not request.lazy_only:
+                # start the listener function asynchronously
+                # NOTE: intentionally
+                async def run_ack_function_asynchronously(
+                    ack: AsyncAck, request: AsyncBoltRequest, response: BoltResponse,
+                ):
+                    try:
+                        await listener.run_ack_function(
+                            request=request, response=response
+                        )
+                    except Exception as e:
+                        # The default response status code is 500 in this case.
+                        # You can customize this by passing your own error handler.
+                        if response is None:
+                            response = BoltResponse(status=500)
+                        response.status = 500
+                        if ack.response is not None:  # already acknowledged
+                            response = None
+
+                        await self.listener_error_handler.handle(
+                            error=e, request=request, response=response,
+                        )
+                        ack.response = response
+
+                _f: Future = asyncio.ensure_future(
+                    run_ack_function_asynchronously(ack, request, response)
+                )
+
+            for lazy_func in listener.lazy_functions:
+                if request.lazy_function_name:
+                    func_name = lazy_func.__name__
+                    if func_name == request.lazy_function_name:
+                        await self.lazy_listener_runner.run(
+                            function=lazy_func, request=request
+                        )
+                        # This HTTP response won't be sent to Slack API servers.
+                        return BoltResponse(status=200)
+                    else:
+                        continue
+                else:
+                    self._start_lazy_function(lazy_func, request)
+
+            # await for the completion of ack() in the async listener execution
+            while ack.response is None and time.time() - starting_time <= 3:
+                await asyncio.sleep(0.01)
+
+            if response is None and ack.response is None:
+                self.logger.warning(warning_did_not_call_ack(listener_name))
+                return None
+
+            if response is None and ack.response is not None:
+                response = ack.response
+                self._debug_log_completion(starting_time, response)
+                return response
+
+            if response is not None:
+                return response
+
+        # None for both means no ack() in the listener
+        return None
+
+    def _start_lazy_function(
+        self, lazy_func: Callable[..., Awaitable[None]], request: AsyncBoltRequest
+    ) -> None:
+        # Start a lazy function asynchronously
+        func_name: str = lazy_func.__name__
+        self.logger.debug(debug_running_lazy_listener(func_name))
+        copied_request = self._build_lazy_request(request, func_name)
+        self.lazy_listener_runner.start(function=lazy_func, request=copied_request)
+
+    @staticmethod
+    def _build_lazy_request(
+        request: AsyncBoltRequest, lazy_func_name: str
+    ) -> AsyncBoltRequest:
+        copied_request = create_copy(request)
+        copied_request.method = "NONE"
+        copied_request.lazy_only = True
+        copied_request.lazy_function_name = lazy_func_name
+        return copied_request
+
+    def _debug_log_completion(
+        self, starting_time: float, response: BoltResponse
+    ) -> None:
+        millis = int((time.time() - starting_time) * 1000)
+        self.logger.debug(debug_responding(response.status, response.body, millis))

--- a/slack_bolt/listener/thread_runner.py
+++ b/slack_bolt/listener/thread_runner.py
@@ -1,0 +1,175 @@
+import time
+from concurrent.futures.thread import ThreadPoolExecutor
+from logging import Logger
+from typing import Optional, Callable
+
+from slack_bolt.lazy_listener import LazyListenerRunner
+from slack_bolt.listener import Listener
+from slack_bolt.listener.listener_error_handler import ListenerErrorHandler
+from slack_bolt.logger.messages import (
+    debug_responding,
+    debug_running_lazy_listener,
+    warning_did_not_call_ack,
+)
+from slack_bolt.request import BoltRequest
+from slack_bolt.response import BoltResponse
+from slack_bolt.util.utils import create_copy
+
+
+class ThreadListenerRunner:
+    logger: Logger
+    process_before_response: bool
+    listener_error_handler: ListenerErrorHandler
+    listener_executor: ThreadPoolExecutor
+    lazy_listener_runner: LazyListenerRunner
+
+    def __init__(
+        self,
+        logger: Logger,
+        process_before_response: bool,
+        listener_error_handler: ListenerErrorHandler,
+        listener_executor: ThreadPoolExecutor,
+        lazy_listener_runner: LazyListenerRunner,
+    ):
+        self.logger = logger
+        self.process_before_response = process_before_response
+        self.listener_error_handler = listener_error_handler
+        self.listener_executor = listener_executor
+        self.lazy_listener_runner = lazy_listener_runner
+
+    def run(  # type: ignore
+        self,
+        request: BoltRequest,
+        response: BoltResponse,
+        listener_name: str,
+        listener: Listener,
+    ) -> Optional[BoltResponse]:
+        ack = request.context.ack
+        starting_time = time.time()
+        if self.process_before_response:
+            if not request.lazy_only:
+                try:
+                    returned_value = listener.run_ack_function(
+                        request=request, response=response
+                    )
+                    if isinstance(returned_value, BoltResponse):
+                        response = returned_value
+                    if ack.response is None and listener.auto_acknowledgement:
+                        ack()  # automatic ack() call if the call is not yet done
+                except Exception as e:
+                    # The default response status code is 500 in this case.
+                    # You can customize this by passing your own error handler.
+                    if response is None:
+                        response = BoltResponse(status=500)
+                    response.status = 500
+                    self.listener_error_handler.handle(
+                        error=e, request=request, response=response,
+                    )
+                    ack.response = response
+
+            for lazy_func in listener.lazy_functions:
+                if request.lazy_function_name:
+                    func_name = lazy_func.__name__
+                    if func_name == request.lazy_function_name:
+                        self.lazy_listener_runner.run(
+                            function=lazy_func, request=request
+                        )
+                        # This HTTP response won't be sent to Slack API servers.
+                        return BoltResponse(status=200)
+                    else:
+                        continue
+                else:
+                    self._start_lazy_function(lazy_func, request)
+
+            if response is not None:
+                self._debug_log_completion(starting_time, response)
+                return response
+            elif ack.response is not None:
+                self._debug_log_completion(starting_time, ack.response)
+                return ack.response
+        else:
+            if listener.auto_acknowledgement:
+                # acknowledge immediately in case of Events API
+                ack()
+
+            if not request.lazy_only:
+                # start the listener function asynchronously
+                def run_ack_function_asynchronously():
+                    nonlocal ack, request, response
+                    try:
+                        listener.run_ack_function(request=request, response=response)
+                    except Exception as e:
+                        # The default response status code is 500 in this case.
+                        # You can customize this by passing your own error handler.
+                        if listener.auto_acknowledgement:
+                            self.listener_error_handler.handle(
+                                error=e, request=request, response=response,
+                            )
+                        else:
+                            if response is None:
+                                response = BoltResponse(status=500)
+                            response.status = 500
+                            if ack.response is not None:  # already acknowledged
+                                response = None
+                            self.listener_error_handler.handle(
+                                error=e, request=request, response=response,
+                            )
+                            ack.response = response
+
+                self.listener_executor.submit(run_ack_function_asynchronously)
+
+            for lazy_func in listener.lazy_functions:
+                if request.lazy_function_name:
+                    func_name = lazy_func.__name__
+                    if func_name == request.lazy_function_name:
+                        self.lazy_listener_runner.run(
+                            function=lazy_func, request=request
+                        )
+                        # This HTTP response won't be sent to Slack API servers.
+                        return BoltResponse(status=200)
+                    else:
+                        continue
+                else:
+                    self._start_lazy_function(lazy_func, request)
+
+            # await for the completion of ack() in the async listener execution
+            while ack.response is None and time.time() - starting_time <= 3:
+                time.sleep(0.01)
+
+            if response is None and ack.response is None:
+                self.logger.warning(warning_did_not_call_ack(listener_name))
+                return None
+
+            if response is None and ack.response is not None:
+                response = ack.response
+                self._debug_log_completion(starting_time, response)
+                return response
+
+            if response is not None:
+                return response
+
+        # None for both means no ack() in the listener
+        return None
+
+    def _start_lazy_function(
+        self, lazy_func: Callable[..., None], request: BoltRequest
+    ) -> None:
+        # Start a lazy function asynchronously
+        func_name: str = lazy_func.__name__
+        self.logger.debug(debug_running_lazy_listener(func_name))
+        copied_request = self._build_lazy_request(request, func_name)
+        self.lazy_listener_runner.start(function=lazy_func, request=copied_request)
+
+    @staticmethod
+    def _build_lazy_request(request: BoltRequest, lazy_func_name: str) -> BoltRequest:
+        copied_request = create_copy(request)
+        copied_request.method = "NONE"
+        copied_request.lazy_only = True
+        copied_request.lazy_function_name = lazy_func_name
+        return copied_request
+
+    def _debug_log_completion(
+        self, starting_time: float, response: BoltResponse
+    ) -> None:
+        millis = int((time.time() - starting_time) * 1000)
+        self.logger.debug(debug_responding(response.status, response.body, millis))

--- a/slack_bolt/listener_matcher/builtins.py
+++ b/slack_bolt/listener_matcher/builtins.py
@@ -19,6 +19,7 @@ from ..util.payload_utils import (
     is_dialog_suggestion,
     is_shortcut,
     to_action,
+    is_workflow_step_save,
 )
 
 if sys.version_info.major == 3 and sys.version_info.minor <= 6:
@@ -110,6 +111,19 @@ def event(
     raise BoltError(
         f"event ({constraints}: {type(constraints)}) must be any of str, Pattern, and dict"
     )
+
+
+def workflow_step_execute(
+    asyncio: bool = False,
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+    def func(body: Dict[str, Any]) -> bool:
+        return (
+            is_event(body)
+            and _matches("workflow_step_execute", body["event"]["type"])
+            and "workflow_step" in body["event"]
+        )
+
+    return build_listener_matcher(func, asyncio)
 
 
 # -------------
@@ -341,6 +355,17 @@ def view_closed(
 ) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
     def func(body: Dict[str, Any]) -> bool:
         return is_view_closed(body) and _matches(
+            callback_id, body["view"]["callback_id"]
+        )
+
+    return build_listener_matcher(func, asyncio)
+
+
+def workflow_step_save(
+    callback_id: Union[str, Pattern], asyncio: bool = False,
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+    def func(body: Dict[str, Any]) -> bool:
+        return is_workflow_step_save(body) and _matches(
             callback_id, body["view"]["callback_id"]
         )
 

--- a/slack_bolt/middleware/ignoring_self_events/async_ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/async_ignoring_self_events.py
@@ -15,7 +15,7 @@ class AsyncIgnoringSelfEvents(IgnoringSelfEvents, AsyncMiddleware):
         next: Callable[[], Awaitable[BoltResponse]],
     ) -> BoltResponse:
         auth_result = req.context.authorization_result
-        if self._is_self_event(auth_result, req.context.user_id):
+        if self._is_self_event(auth_result, req.context.user_id, req.body):
             self._debug_log(req.body)
             return await req.context.ack()
         else:

--- a/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable
+from typing import Callable, Dict, Any
 
 from slack_bolt.authorization import AuthorizationResult
 from slack_bolt.logger import get_bolt_logger
@@ -17,7 +17,7 @@ class IgnoringSelfEvents(Middleware):
         self, *, req: BoltRequest, resp: BoltResponse, next: Callable[[], BoltResponse],
     ) -> BoltResponse:
         auth_result = req.context.authorization_result
-        if self._is_self_event(auth_result, req.context.user_id):
+        if self._is_self_event(auth_result, req.context.user_id, req.body):
             self._debug_log(req.body)
             return req.context.ack()
         else:
@@ -26,10 +26,16 @@ class IgnoringSelfEvents(Middleware):
     # -----------------------------------------
 
     @staticmethod
-    def _is_self_event(auth_result: AuthorizationResult, user_id: str):
-        return auth_result is not None and user_id == auth_result.bot_user_id
+    def _is_self_event(
+        auth_result: AuthorizationResult, user_id: str, body: Dict[str, Any]
+    ):
+        return (
+            auth_result is not None
+            and user_id == auth_result.bot_user_id
+            and body.get("event") is not None
+        )
 
     def _debug_log(self, body: dict):
         if self.logger.level <= logging.DEBUG:
-            event = body["event"]
+            event = body.get("event")
             self.logger.debug(f"Skipped self event: {event}")

--- a/slack_bolt/util/payload_utils.py
+++ b/slack_bolt/util/payload_utils.py
@@ -201,6 +201,10 @@ def is_view_closed(body: Dict[str, Any]) -> bool:
     )
 
 
+def is_workflow_step_save(body: Dict[str, Any]) -> bool:
+    return is_view_submission(body) and body["view"]["type"] == "workflow_step"
+
+
 # ------------------------------------------
 # Internal Utilities
 # ------------------------------------------

--- a/tests/slack_bolt/kwargs_injection/test_args.py
+++ b/tests/slack_bolt/kwargs_injection/test_args.py
@@ -40,3 +40,19 @@ class TestArgs:
         assert args.request is not None
         assert args.response is not None
         assert args.client is not None
+
+    def test_all_values_from_context(self):
+        req = BoltRequest(body="", headers={})
+        req.context["foo"] = "FOO"
+        req.context["bar"] = 123
+        required_args = ["foo", "bar", "ack"]
+        arg_params: dict = build_required_kwargs(
+            logger=logging.getLogger(__name__),
+            required_arg_names=required_args,
+            request=req,
+            response=BoltResponse(status=200),
+            next_func=next,
+        )
+        assert arg_params["foo"] == "FOO"
+        assert arg_params["bar"] == 123
+        assert arg_params["ack"] is not None

--- a/tests/slack_bolt_async/kwargs_injection/test_async_args.py
+++ b/tests/slack_bolt_async/kwargs_injection/test_async_args.py
@@ -42,3 +42,19 @@ class TestAsyncArgs:
         assert args.request is not None
         assert args.response is not None
         assert args.client is not None
+
+    def test_all_values_from_context(self):
+        req = AsyncBoltRequest(body="", headers={})
+        req.context["foo"] = "FOO"
+        req.context["bar"] = 123
+        required_args = ["foo", "bar", "ack"]
+        arg_params: dict = build_async_required_kwargs(
+            logger=logging.getLogger(__name__),
+            required_arg_names=required_args,
+            request=req,
+            response=BoltResponse(status=200),
+            next_func=next,
+        )
+        assert arg_params["foo"] == "FOO"
+        assert arg_params["bar"] == 123
+        assert arg_params["ack"] is not None


### PR DESCRIPTION
This pull request applies the following changes to make Bolt Python more customizable from global middleware.

* Extract the core part of listener execution from App
* Enable kwargs_injection to merge all fields in context into args

In the short term, this is beneficial for Steps from Apps support.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
