### PR TITLE
Adds line wrapping to code samples

### DIFF
--- a/docs/_basic/listening_responding_options.md
+++ b/docs/_basic/listening_responding_options.md
@@ -21,11 +21,17 @@ To respond to options requests, you'll need to call `ack()` with a valid `option
 def show_options(ack):
     options = [
         {
-            "text": {"type": "plain_text", "text": "Option 1"},
+            "text": {
+                "type": "plain_text",
+                "text": "Option 1"
+            },
             "value": "1-1",
         },
         {
-            "text": {"type": "plain_text", "text": "Option 2"},
+            "text": {
+                "type": "plain_text",
+                "text": "Option 2"
+            },
             "value": "1-2",
         },
     ]

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -248,6 +248,7 @@ pre code pre {
   padding: 0;
   font-size: 0.9em;
   line-height: 2.2em;
+  white-space: pre-wrap;
 }
 
 pre code span {


### PR DESCRIPTION
Some of the long lines are hard to read in current documentation. This PR adds line wrapping to make it easier 😄 

### Current
![image](https://user-images.githubusercontent.com/3411005/94493825-83a6ab80-01a2-11eb-8165-886872be608b.png)

### PR
![image](https://user-images.githubusercontent.com/3411005/94493854-94572180-01a2-11eb-8d4e-8bf86b0c39df.png)

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
