### PR TITLE
fix secondary code snippet width

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -315,6 +315,10 @@ a:hover {
   margin-top: 1em;
 }
 
+.content .section-wrapper .secondary-content div.highlighter-rouge {
+  width: 100%;
+}
+
 summary h4 {
   display: inline;
 }


### PR DESCRIPTION
Fixes secondary code snippets, whose width were only 50%

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
