### PR TITLE
Fix error in Updating and Pushing Views section's sample code

### DIFF
--- a/docs/_basic/opening_modals.md
+++ b/docs/_basic/opening_modals.md
@@ -21,7 +21,6 @@ Read more about modal composition in the <a href="https://api.slack.com/surfaces
 def open_modal(ack, body, client):
     # Acknowledge the command request
     ack();
-
     # Call views_open with the built-in client
     client.views_open(
         # Pass a valid trigger_id within 3 seconds of receiving it

--- a/docs/_basic/updating_pushing_modals.md
+++ b/docs/_basic/updating_pushing_modals.md
@@ -22,14 +22,15 @@ Learn more about updating and pushing views in our <a href="https://api.slack.co
 ```python
 # Listen for a button invocation with action_id `button_abc` (assume it's inside of a modal)
 @app.action("button_abc")
-def update_modal(ack, view, client):
+def update_modal(ack, body, client):
     # Acknowledge the button request
     ack()
+    # Call views_update with the built-in client
     client.views_update(
         # Pass the view_id
-        view_id=view["id"],
+        view_id=body["view"]["id"],
         # String that represents view state to protect against race conditions
-        hash=view["hash"],
+        hash=body["view"]["hash"],
         # View payload with updated blocks
         view={
             "type": "modal",


### PR DESCRIPTION
Documentation's **Updating and pushing views** sample incorrectly uses `view` as available argument.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
