### PR TITLE
Fix #111 "step" arg in listeners for workflow_step_execute events

### DIFF
--- a/slack_bolt/util/payload_utils.py
+++ b/slack_bolt/util/payload_utils.py
@@ -32,7 +32,7 @@ def is_event(body: Dict[str, Any]) -> bool:
 def is_workflow_step_execute(body: Dict[str, Any]) -> bool:
     return (
         is_event(body)
-        and body["event"]["type"] == "workflow_step_edit"
+        and body["event"]["type"] == "workflow_step_execute"
         and "workflow_step" in body["event"]
     )
 

--- a/slack_bolt/util/payload_utils.py
+++ b/slack_bolt/util/payload_utils.py
@@ -222,6 +222,9 @@ def to_step(body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     # edit
     if is_workflow_step_edit(body):
         return body["workflow_step"]
+    # save
+    if is_workflow_step_save(body):
+        return body["workflow_step"]
     # execute
     if is_workflow_step_execute(body):
         return body["event"]["workflow_step"]

--- a/tests/scenario_tests/test_workflow_steps.py
+++ b/tests/scenario_tests/test_workflow_steps.py
@@ -1,4 +1,5 @@
 import json
+import time as time_module
 from time import time
 from urllib.parse import quote
 
@@ -85,6 +86,8 @@ class TestWorkflowSteps:
         response = self.app.dispatch(request)
         assert response.status == 200
         assert self.mock_received_requests["/auth.test"] == 1
+        time_module.sleep(0.5)
+        assert self.mock_received_requests["/workflows.stepCompleted"] == 1
 
         self.app = App(client=self.web_client, signing_secret=self.signing_secret)
         self.app.step(

--- a/tests/scenario_tests/test_workflow_steps.py
+++ b/tests/scenario_tests/test_workflow_steps.py
@@ -325,7 +325,9 @@ def edit(ack: Ack, step, configure: Configure):
     )
 
 
-def save(ack: Ack, view: dict, update: Update):
+def save(ack: Ack, step: dict, view: dict, update: Update):
+    assert step is not None
+    assert view is not None
     state_values = view["state"]["values"]
     update(
         inputs={

--- a/tests/scenario_tests_async/test_workflow_steps.py
+++ b/tests/scenario_tests_async/test_workflow_steps.py
@@ -105,6 +105,8 @@ class TestAsyncEvents:
         response = await self.app.async_dispatch(request)
         assert response.status == 200
         assert self.mock_received_requests["/auth.test"] == 1
+        await asyncio.sleep(0.5)
+        assert self.mock_received_requests["/workflows.stepCompleted"] == 1
 
         self.app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret)
         self.app.step(

--- a/tests/scenario_tests_async/test_workflow_steps.py
+++ b/tests/scenario_tests_async/test_workflow_steps.py
@@ -344,7 +344,9 @@ async def edit(ack: AsyncAck, step, configure: AsyncConfigure):
     )
 
 
-async def save(ack: AsyncAck, view: dict, update: AsyncUpdate):
+async def save(ack: AsyncAck, step: dict, view: dict, update: AsyncUpdate):
+    assert step is not None
+    assert view is not None
     state_values = view["state"]["values"]
     await update(
         inputs={


### PR DESCRIPTION
This pull request fixes a bug affecting the extraction of `step` arguments for listener/middleware. As the unit tests didn't detect it due to a lack of sufficient assertions, I've updated the corresponding tests as well.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
