### PR TITLE
Fix decorators' side effects to methods

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -327,11 +327,11 @@ class App:
     # -------------------------
     # middleware
 
-    def use(self, *args) -> None:
+    def use(self, *args) -> Optional[Callable]:
         """Refer to middleware method's docstring for details."""
         return self.middleware(*args)
 
-    def middleware(self, *args) -> None:
+    def middleware(self, *args) -> Optional[Callable]:
         """Registers a new middleware to this Bolt app.
 
         :param args: a list of middleware. Passing a single middleware is supported.
@@ -341,10 +341,16 @@ class App:
             middleware_or_callable = args[0]
             if isinstance(middleware_or_callable, Middleware):
                 self._middleware_list.append(middleware_or_callable)
-            else:
+            elif isinstance(middleware_or_callable, Callable):
                 self._middleware_list.append(
                     CustomMiddleware(app_name=self.name, func=middleware_or_callable)
                 )
+                return middleware_or_callable
+            else:
+                raise BoltError(
+                    f"Unexpected type for a middleware ({type(middleware_or_callable)})"
+                )
+        return None
 
     # -------------------------
     # Workflows: Steps from Apps
@@ -372,7 +378,9 @@ class App:
     # -------------------------
     # global error handler
 
-    def error(self, func: Callable[..., None]) -> None:
+    def error(
+        self, func: Callable[..., None]
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Updates the global error handler.
 
         :param func: The function that is supposed to be executed
@@ -382,6 +390,7 @@ class App:
         self._listener_runner.listener_error_handler = CustomListenerErrorHandler(
             logger=self._framework_logger, func=func,
         )
+        return func
 
     # -------------------------
     # events
@@ -391,7 +400,7 @@ class App:
         event: Union[str, Pattern, Dict[str, str]],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new event listener.
 
         :param event: The conditions to match against a request payload
@@ -414,7 +423,7 @@ class App:
         keyword: Union[str, Pattern],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new message event listener.
         Check the #event method's docstring for details.
         """
@@ -441,7 +450,7 @@ class App:
         command: Union[str, Pattern],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new slash command listener.
 
         :param command: The conditions to match against a request payload
@@ -467,7 +476,7 @@ class App:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new shortcut listener.
 
         :param constraints: The conditions to match against a request payload
@@ -490,7 +499,7 @@ class App:
         callback_id: Union[str, Pattern],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new global shortcut listener."""
 
         def __call__(*args, **kwargs):
@@ -507,7 +516,7 @@ class App:
         callback_id: Union[str, Pattern],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new message shortcut listener."""
 
         def __call__(*args, **kwargs):
@@ -527,7 +536,7 @@ class App:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new action listener.
 
         :param constraints: The conditions to match against a request payload
@@ -550,7 +559,7 @@ class App:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new block_actions listener."""
 
         def __call__(*args, **kwargs):
@@ -567,7 +576,7 @@ class App:
         callback_id: Union[str, Pattern],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new interactive_message listener."""
 
         def __call__(*args, **kwargs):
@@ -584,7 +593,7 @@ class App:
         callback_id: Union[str, Pattern],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new dialog_submission listener."""
 
         def __call__(*args, **kwargs):
@@ -601,7 +610,7 @@ class App:
         callback_id: Union[str, Pattern],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new dialog_cancellation listener."""
 
         def __call__(*args, **kwargs):
@@ -621,7 +630,7 @@ class App:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new view submission/closed event listener.
 
         :param constraints: The conditions to match against a request payload
@@ -644,7 +653,7 @@ class App:
         constraints: Union[str, Pattern],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new view_submission listener."""
 
         def __call__(*args, **kwargs):
@@ -661,7 +670,7 @@ class App:
         constraints: Union[str, Pattern],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new view_closed listener."""
 
         def __call__(*args, **kwargs):
@@ -681,7 +690,7 @@ class App:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new options listener.
 
         :param constraints: The conditions to match against a request payload
@@ -704,7 +713,7 @@ class App:
         action_id: Union[str, Pattern],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new block_suggestion listener."""
 
         def __call__(*args, **kwargs):
@@ -721,7 +730,7 @@ class App:
         callback_id: Union[str, Pattern],
         matchers: Optional[List[Callable[..., bool]]] = None,
         middleware: Optional[List[Union[Callable, Middleware]]] = None,
-    ) -> Callable[..., None]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new dialog_submission listener."""
 
         def __call__(*args, **kwargs):
@@ -758,9 +767,14 @@ class App:
         matchers: Optional[List[Callable[..., bool]]],
         middleware: Optional[List[Union[Callable, Middleware]]],
         auto_acknowledgement: bool = False,
-    ) -> None:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+        value_to_return = None
         if not isinstance(functions, list):
             functions = list(functions)
+        if len(functions) == 1:
+            # In the case where the function is registered using decorator,
+            # the registration should return the original function.
+            value_to_return = functions[0]
 
         listener_matchers = [
             CustomListenerMatcher(app_name=self.name, func=f) for f in (matchers or [])
@@ -785,6 +799,7 @@ class App:
                 auto_acknowledgement=auto_acknowledgement,
             )
         )
+        return value_to_return
 
 
 # -------------------------

--- a/tests/scenario_tests/test_app_decorators.py
+++ b/tests/scenario_tests/test_app_decorators.py
@@ -1,0 +1,106 @@
+from typing import Callable
+
+from slack_sdk import WebClient
+
+from slack_bolt import App, Ack, BoltResponse
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class NoopAck(Ack):
+    def __call__(self) -> BoltResponse:
+        pass
+
+
+class TestAppDecorators:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    web_client = WebClient(token=valid_token, base_url=mock_api_server_base_url)
+
+    def test_decorators(self):
+        try:
+            self.old_os_env = remove_os_env_temporarily()
+            setup_mock_web_api_server(self)
+
+            app = App(signing_secret=self.signing_secret, client=self.web_client)
+            ack = NoopAck()
+
+            @app.event("app_home_opened")
+            def handle_events(body: dict):
+                assert body is not None
+
+            handle_events({})
+            assert isinstance(handle_events, Callable)
+
+            @app.message("hi")
+            def handle_message_events(body: dict):
+                assert body is not None
+
+            handle_message_events({})
+            assert isinstance(handle_message_events, Callable)
+
+            @app.command("/hello")
+            def handle_commands(ack: Ack, body: dict):
+                assert body is not None
+                ack()
+
+            handle_commands(ack, {})
+            assert isinstance(handle_commands, Callable)
+
+            @app.shortcut("test-shortcut")
+            def handle_shortcuts(ack: Ack, body: dict):
+                assert body is not None
+                ack()
+
+            handle_shortcuts(ack, {})
+            assert isinstance(handle_shortcuts, Callable)
+
+            @app.action("some-action-id")
+            def handle_actions(ack: Ack, body: dict):
+                assert body is not None
+                ack()
+
+            handle_actions(ack, {})
+            assert isinstance(handle_actions, Callable)
+
+            @app.view("some-callback-id")
+            def handle_views(ack: Ack, body: dict):
+                assert body is not None
+                ack()
+
+            handle_views(ack, {})
+            assert isinstance(handle_views, Callable)
+
+            @app.options("some-id")
+            def handle_views(ack: Ack, body: dict):
+                assert body is not None
+                ack()
+
+            handle_views(ack, {})
+            assert isinstance(handle_views, Callable)
+
+            @app.error
+            def handle_errors(body: dict):
+                assert body is not None
+
+            handle_errors({})
+            assert isinstance(handle_errors, Callable)
+
+            @app.use
+            def middleware(body, next):
+                assert body is not None
+                next()
+
+            def next_func():
+                pass
+
+            middleware({}, next_func)
+            assert isinstance(middleware, Callable)
+
+        finally:
+            cleanup_mock_web_api_server(self)
+            restore_os_env(self.old_os_env)

--- a/tests/scenario_tests_async/test_app_decorators.py
+++ b/tests/scenario_tests_async/test_app_decorators.py
@@ -1,0 +1,110 @@
+from typing import Callable
+
+import pytest
+from slack_sdk.web.async_client import AsyncWebClient
+
+from slack_bolt import BoltResponse
+from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.context.ack.async_ack import AsyncAck
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class NoopAsyncAck(AsyncAck):
+    async def __call__(self) -> BoltResponse:
+        pass
+
+
+class TestAppDecorators:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    web_client = AsyncWebClient(token=valid_token, base_url=mock_api_server_base_url)
+
+    @pytest.mark.asyncio
+    async def test_decorators(self):
+        try:
+            self.old_os_env = remove_os_env_temporarily()
+            setup_mock_web_api_server(self)
+
+            app = AsyncApp(signing_secret=self.signing_secret, client=self.web_client)
+            ack = NoopAsyncAck()
+
+            @app.event("app_home_opened")
+            async def handle_events(body: dict):
+                assert body is not None
+
+            await handle_events({})
+            assert isinstance(handle_events, Callable)
+
+            @app.message("hi")
+            async def handle_message_events(body: dict):
+                assert body is not None
+
+            await handle_message_events({})
+            assert isinstance(handle_message_events, Callable)
+
+            @app.command("/hello")
+            async def handle_commands(ack: AsyncAck, body: dict):
+                assert body is not None
+                await ack()
+
+            await handle_commands(ack, {})
+            assert isinstance(handle_commands, Callable)
+
+            @app.shortcut("test-shortcut")
+            async def handle_shortcuts(ack: AsyncAck, body: dict):
+                assert body is not None
+                await ack()
+
+            await handle_shortcuts(ack, {})
+            assert isinstance(handle_shortcuts, Callable)
+
+            @app.action("some-action-id")
+            async def handle_actions(ack: AsyncAck, body: dict):
+                assert body is not None
+                await ack()
+
+            await handle_actions(ack, {})
+            assert isinstance(handle_actions, Callable)
+
+            @app.view("some-callback-id")
+            async def handle_views(ack: AsyncAck, body: dict):
+                assert body is not None
+                await ack()
+
+            await handle_views(ack, {})
+            assert isinstance(handle_views, Callable)
+
+            @app.options("some-id")
+            async def handle_views(ack: AsyncAck, body: dict):
+                assert body is not None
+                await ack()
+
+            await handle_views(ack, {})
+            assert isinstance(handle_views, Callable)
+
+            @app.error
+            async def handle_errors(body: dict):
+                assert body is not None
+
+            await handle_errors({})
+            assert isinstance(handle_errors, Callable)
+
+            @app.use
+            async def middleware(body, next):
+                assert body is not None
+                await next()
+
+            async def next_func():
+                pass
+
+            await middleware({}, next_func)
+            assert isinstance(middleware, Callable)
+
+        finally:
+            cleanup_mock_web_api_server(self)
+            restore_os_env(self.old_os_env)


### PR DESCRIPTION
This pull request fixes the issues where some decorators in `App`/`AsyncApp` cause side effects to methods. As long as developers use those methods only for Bolt apps. The issues affect only when developers need to directly use the method for other purposes.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
