### PR TITLE
Add more fields to context for Bolt JS compatibility

### DIFF
--- a/slack_bolt/authorization/authorize_result.py
+++ b/slack_bolt/authorization/authorize_result.py
@@ -53,12 +53,22 @@ class AuthorizeResult(dict):
         user_token: Optional[str] = None,
         auth_test_response: SlackResponse,
     ) -> "AuthorizeResult":
+        bot_user_id: Optional[str] = (  # type:ignore
+            auth_test_response.get("user_id")
+            if auth_test_response.get("bot_id") is not None
+            else None
+        )
+        user_id: Optional[str] = (  # type:ignore
+            auth_test_response.get("user_id")
+            if auth_test_response.get("bot_id") is None
+            else None
+        )
         return AuthorizeResult(
             enterprise_id=auth_test_response.get("enterprise_id"),
             team_id=auth_test_response.get("team_id"),
-            bot_user_id=auth_test_response.get("user_id"),
             bot_id=auth_test_response.get("bot_id"),
-            user_id=auth_test_response.get("user_id"),
+            bot_user_id=bot_user_id,
+            user_id=user_id,
             bot_token=bot_token,
             user_token=user_token,
         )

--- a/slack_bolt/context/base_context.py
+++ b/slack_bolt/context/base_context.py
@@ -6,10 +6,6 @@ from slack_bolt.authorization import AuthorizeResult
 
 class BaseContext(dict):
     @property
-    def authorize_result(self) -> Optional[AuthorizeResult]:
-        return self.get("authorize_result")
-
-    @property
     def logger(self) -> Logger:
         return self["logger"]
 
@@ -41,3 +37,38 @@ class BaseContext(dict):
     def matches(self) -> Optional[Tuple]:
         """Returns all the matched parts in message listener's regexp"""
         return self.get("matches")
+
+    # --------------------------------
+
+    @property
+    def authorize_result(self) -> Optional[AuthorizeResult]:
+        return self.get("authorize_result")
+
+    @property
+    def bot_token(self) -> Optional[str]:
+        return self.get("bot_token")
+
+    @property
+    def bot_id(self) -> Optional[str]:
+        return self.get("bot_id")
+
+    @property
+    def bot_user_id(self) -> Optional[str]:
+        return self.get("bot_user_id")
+
+    @property
+    def user_token(self) -> Optional[str]:
+        return self.get("user_token")
+
+    def set_authorize_result(self, authorize_result: AuthorizeResult):
+        self["authorize_result"] = authorize_result
+        if authorize_result.bot_id is not None:
+            self["bot_id"] = authorize_result.bot_id
+        if authorize_result.bot_user_id is not None:
+            self["bot_user_id"] = authorize_result.bot_user_id
+        if authorize_result.bot_token is not None:
+            self["bot_token"] = authorize_result.bot_token
+        if authorize_result.user_id is not None:
+            self["user_id"] = authorize_result.user_id
+        if authorize_result.user_token is not None:
+            self["user_token"] = authorize_result.user_token

--- a/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
@@ -39,7 +39,7 @@ class AsyncMultiTeamsAuthorization(AsyncAuthorization):
                 user_id=req.context.user_id,
             )
             if auth_result:
-                req.context["authorize_result"] = auth_result
+                req.context.set_authorize_result(auth_result)
                 token = auth_result.bot_token or auth_result.user_token
                 req.context["token"] = token
                 req.context["client"] = create_async_web_client(token)

--- a/slack_bolt/middleware/authorization/async_single_team_authorization.py
+++ b/slack_bolt/middleware/authorization/async_single_team_authorization.py
@@ -13,7 +13,7 @@ from .internals import _to_authorize_result
 class AsyncSingleTeamAuthorization(AsyncAuthorization):
     def __init__(self):
         """Single-workspace authorization."""
-        self.auth_result: Optional[AsyncSlackResponse] = None
+        self.auth_test_result: Optional[AsyncSlackResponse] = None
         self.logger = get_bolt_logger(AsyncSingleTeamAuthorization)
 
     async def async_process(
@@ -27,14 +27,16 @@ class AsyncSingleTeamAuthorization(AsyncAuthorization):
             return await next()
 
         try:
-            if self.auth_result is None:
-                self.auth_result = await req.context.client.auth_test()
+            if self.auth_test_result is None:
+                self.auth_test_result = await req.context.client.auth_test()
 
-            if self.auth_result:
-                req.context["authorize_result"] = _to_authorize_result(
-                    auth_test_result=self.auth_result,
-                    token=req.context.client.token,
-                    request_user_id=req.context.user_id,
+            if self.auth_test_result:
+                req.context.set_authorize_result(
+                    _to_authorize_result(
+                        auth_test_result=self.auth_test_result,
+                        token=req.context.client.token,
+                        request_user_id=req.context.user_id,
+                    )
                 )
                 return await next()
             else:

--- a/slack_bolt/middleware/authorization/multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/multi_teams_authorization.py
@@ -37,7 +37,7 @@ class MultiTeamsAuthorization(Authorization):
                 user_id=req.context.user_id,
             )
             if auth_result is not None:
-                req.context["authorize_result"] = auth_result
+                req.context.set_authorize_result(auth_result)
                 token = auth_result.bot_token or auth_result.user_token
                 req.context["token"] = token
                 req.context["client"] = create_web_client(token)

--- a/slack_bolt/middleware/authorization/single_team_authorization.py
+++ b/slack_bolt/middleware/authorization/single_team_authorization.py
@@ -33,10 +33,12 @@ class SingleTeamAuthorization(Authorization):
                 self.auth_test_result = req.context.client.auth_test()
 
             if self.auth_test_result:
-                req.context["authorize_result"] = _to_authorize_result(
-                    auth_test_result=self.auth_test_result,
-                    token=req.context.client.token,
-                    request_user_id=req.context.user_id,
+                req.context.set_authorize_result(
+                    _to_authorize_result(
+                        auth_test_result=self.auth_test_result,
+                        token=req.context.client.token,
+                        request_user_id=req.context.user_id,
+                    )
                 )
                 return next()
             else:

--- a/tests/scenario_tests/test_block_actions.py
+++ b/tests/scenario_tests/test_block_actions.py
@@ -5,7 +5,7 @@ from urllib.parse import quote
 from slack_sdk import WebClient
 from slack_sdk.signature import SignatureVerifier
 
-from slack_bolt import BoltRequest
+from slack_bolt import BoltRequest, BoltContext
 from slack_bolt.app import App
 from tests.mock_web_api_server import (
     setup_mock_web_api_server,
@@ -174,9 +174,15 @@ body = {
 raw_body = f"payload={quote(json.dumps(body))}"
 
 
-def simple_listener(ack, body, payload, action):
+def simple_listener(ack, body, payload, action, context: BoltContext):
     assert body["trigger_id"] == "111.222.valid"
     assert body["actions"][0] == payload
     assert payload == action
     assert action["action_id"] == "a"
+    assert context.bot_id == "BZYBOTHED"
+    assert context.bot_user_id == "W23456789"
+    assert context.bot_token == "xoxb-valid"
+    assert context.token == "xoxb-valid"
+    assert context.user_id == "W111"
+    assert context.user_token is None
     ack()

--- a/tests/scenario_tests_async/test_authorize.py
+++ b/tests/scenario_tests_async/test_authorize.py
@@ -17,22 +17,33 @@ from tests.mock_web_api_server import (
 from tests.utils import remove_os_env_temporarily, restore_os_env
 
 valid_token = "xoxb-valid"
+valid_user_token = "xoxp-valid"
 
 
 async def authorize(enterprise_id, team_id, user_id, client: AsyncWebClient):
     assert enterprise_id == "E111"
     assert team_id == "T111"
-    assert user_id == "W111"
+    assert user_id == "W99999"
     auth_test = await client.auth_test(token=valid_token)
     return AuthorizeResult.from_auth_test_response(
         auth_test_response=auth_test, bot_token=valid_token,
     )
 
 
+async def user_authorize(enterprise_id, team_id, user_id, client: AsyncWebClient):
+    assert enterprise_id == "E111"
+    assert team_id == "T111"
+    assert user_id == "W99999"
+    auth_test = await client.auth_test(token=valid_user_token)
+    return AuthorizeResult.from_auth_test_response(
+        auth_test_response=auth_test, user_token=valid_user_token,
+    )
+
+
 async def error_authorize(enterprise_id, team_id, user_id):
     assert enterprise_id == "E111"
     assert team_id == "T111"
-    assert user_id == "W111"
+    assert user_id == "W99999"
     return None
 
 
@@ -102,11 +113,41 @@ class TestAsyncAuthorize:
         assert response.body == ":x: Please install this app into the workspace :bow:"
         assert self.mock_received_requests.get("/auth.test") == None
 
+    @pytest.mark.asyncio
+    async def test_bot_context_attributes(self):
+        app = AsyncApp(
+            client=self.web_client,
+            authorize=authorize,
+            signing_secret=self.signing_secret,
+        )
+        app.action("a")(assert_bot_context_attributes)
+
+        request = self.build_valid_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert response.body == ""
+        assert self.mock_received_requests["/auth.test"] == 1
+
+    @pytest.mark.asyncio
+    async def test_user_context_attributes(self):
+        app = AsyncApp(
+            client=self.web_client,
+            authorize=user_authorize,
+            signing_secret=self.signing_secret,
+        )
+        app.action("a")(assert_user_context_attributes)
+
+        request = self.build_valid_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert response.body == ""
+        assert self.mock_received_requests["/auth.test"] == 1
+
 
 body = {
     "type": "block_actions",
     "user": {
-        "id": "W111",
+        "id": "W99999",
         "username": "primary-owner",
         "name": "primary-owner",
         "team_id": "T111",
@@ -148,4 +189,24 @@ async def simple_listener(ack, body, payload, action):
     assert body["actions"][0] == payload
     assert payload == action
     assert action["action_id"] == "a"
+    await ack()
+
+
+async def assert_bot_context_attributes(ack, context):
+    assert context["bot_id"] == "BZYBOTHED"
+    assert context["bot_user_id"] == "W23456789"
+    assert context["bot_token"] == "xoxb-valid"
+    assert context["token"] == "xoxb-valid"
+    assert context["user_id"] == "W99999"
+    assert context.get("user_token") is None
+    await ack()
+
+
+async def assert_user_context_attributes(ack, context):
+    assert context.get("bot_id") is None
+    assert context.get("bot_user_id") is None
+    assert context.get("bot_token") is None
+    assert context["token"] == "xoxp-valid"
+    assert context["user_id"] == "W99999"
+    assert context["user_token"] == "xoxp-valid"
     await ack()

--- a/tests/scenario_tests_async/test_block_actions.py
+++ b/tests/scenario_tests_async/test_block_actions.py
@@ -8,6 +8,7 @@ from slack_sdk.signature import SignatureVerifier
 from slack_sdk.web.async_client import AsyncWebClient
 
 from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.context.async_context import AsyncBoltContext
 from slack_bolt.request.async_request import AsyncBoltRequest
 from tests.mock_web_api_server import (
     setup_mock_web_api_server,
@@ -203,9 +204,15 @@ body = {
 raw_body = f"payload={quote(json.dumps(body))}"
 
 
-async def simple_listener(ack, body, payload, action):
+async def simple_listener(ack, body, payload, action, context: AsyncBoltContext):
     assert body["trigger_id"] == "111.222.valid"
     assert body["actions"][0] == payload
     assert payload == action
     assert action["action_id"] == "a"
+    assert context.bot_id == "BZYBOTHED"
+    assert context.bot_user_id == "W23456789"
+    assert context.bot_token == "xoxb-valid"
+    assert context.token == "xoxb-valid"
+    assert context.user_id == "W111"
+    assert context.user_token is None
     await ack()


### PR DESCRIPTION
Although all the authorization-related fields are accessible via `context["authorize_result"]`, some fields such as `bot_id`, `bot_user_id`, and `bot_token` (`token` already exists) are not available in a Bolt Python's Context object, unlike Bolt JS. This pull request adds those fields to context objects and adjusts the logic to correctly pick up `user_id` in context for both token and user token.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
