### PR TITLE
Fix a bug where LambdaS3OAuthFlow does not work when settings arg is given

### DIFF
--- a/slack_bolt/adapter/aws_lambda/lambda_s3_oauth_flow.py
+++ b/slack_bolt/adapter/aws_lambda/lambda_s3_oauth_flow.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import boto3
 
+from slack_bolt.authorization.authorize import InstallationStoreAuthorize
 from slack_bolt.oauth import OAuthFlow
 from slack_sdk import WebClient
 from slack_sdk.oauth.installation_store.amazon_s3 import AmazonS3InstallationStore
@@ -55,6 +56,16 @@ class LambdaS3OAuthFlow(OAuthFlow):
                 bucket_name=installation_bucket_name,
                 client_id=settings.client_id,
             )
+
+        # Set up authorize function to surely use this installation_store.
+        # When a developer use a settings initialized outside this constructor,
+        # the settings may already have pre-defined authorize.
+        # In this case, the /slack/events endpoint doesn't work along with the OAuth flow.
+        settings.authorize = InstallationStoreAuthorize(
+            logger=logger,
+            installation_store=settings.installation_store
+        )
+
         OAuthFlow.__init__(self, client=client, logger=logger, settings=settings)
 
     @property


### PR DESCRIPTION
This pull request fixes a bug where LambdaS3OAuthFlow does not work when settings arg is given.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
