### PR TITLE
Fix #118 by adding allowlist of events in ignore self middleware

### DIFF
--- a/slack_bolt/adapter/aws_lambda/lambda_s3_oauth_flow.py
+++ b/slack_bolt/adapter/aws_lambda/lambda_s3_oauth_flow.py
@@ -62,8 +62,7 @@ class LambdaS3OAuthFlow(OAuthFlow):
         # the settings may already have pre-defined authorize.
         # In this case, the /slack/events endpoint doesn't work along with the OAuth flow.
         settings.authorize = InstallationStoreAuthorize(
-            logger=logger,
-            installation_store=settings.installation_store
+            logger=logger, installation_store=settings.installation_store
         )
 
         OAuthFlow.__init__(self, client=client, logger=logger, settings=settings)

--- a/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
@@ -25,14 +25,20 @@ class IgnoringSelfEvents(Middleware):
 
     # -----------------------------------------
 
-    @staticmethod
+    # Its an Events API event that isn't of type message,
+    # but the user ID might match our own app. Filter these out.
+    # However, some events still must be fired, because they can make sense.
+    events_that_should_be_kept = ["member_joined_channel", "member_left_channel"]
+
+    @classmethod
     def _is_self_event(
-        auth_result: AuthorizeResult, user_id: str, body: Dict[str, Any]
+        cls, auth_result: AuthorizeResult, user_id: str, body: Dict[str, Any]
     ):
         return (
             auth_result is not None
             and user_id == auth_result.bot_user_id
             and body.get("event") is not None
+            and body.get("event").get("type") not in cls.events_that_should_be_kept
         )
 
     def _debug_log(self, body: dict):

--- a/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
@@ -38,7 +38,7 @@ class IgnoringSelfEvents(Middleware):
             auth_result is not None
             and user_id == auth_result.bot_user_id
             and body.get("event") is not None
-            and body.get("event").get("type") not in cls.events_that_should_be_kept
+            and body.get("event", {}).get("type") not in cls.events_that_should_be_kept
         )
 
     def _debug_log(self, body: dict):


### PR DESCRIPTION
This pull request fixes #118 

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
