### PR TITLE
Fix #123 by adding a validation in constructors (App/AsyncApp)

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -42,6 +42,7 @@ from slack_bolt.logger.messages import (
     debug_running_listener,
     error_unexpected_listener_middleware,
     error_client_invalid_type,
+    error_authorize_conflicts,
 )
 from slack_bolt.middleware import (
     Middleware,
@@ -131,6 +132,8 @@ class App:
 
         self._authorize: Optional[Authorize] = None
         if authorize is not None:
+            if oauth_settings is not None or oauth_flow is not None:
+                raise BoltError(error_authorize_conflicts())
             self._authorize = CallableAuthorize(
                 logger=self._framework_logger, func=authorize
             )

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -32,6 +32,7 @@ from slack_bolt.logger.messages import (
     error_unexpected_listener_middleware,
     error_listener_function_must_be_coro_func,
     error_client_invalid_type_async,
+    error_authorize_conflicts,
 )
 from slack_bolt.lazy_listener.asyncio_runner import AsyncioLazyListenerRunner
 from slack_bolt.listener.async_listener import AsyncListener, AsyncCustomListener
@@ -138,6 +139,9 @@ class AsyncApp:
 
         self._async_authorize: Optional[AsyncAuthorize] = None
         if authorize is not None:
+            if oauth_settings is not None or oauth_flow is not None:
+                raise BoltError(error_authorize_conflicts())
+
             self._async_authorize = AsyncCallableAuthorize(
                 logger=self._framework_logger, func=authorize
             )

--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -45,6 +45,10 @@ def error_listener_function_must_be_coro_func(func_name: str) -> str:
     return f"The listener function ({func_name}) is not a coroutine function."
 
 
+def error_authorize_conflicts() -> str:
+    return "`authorize` in the top-level arguments is not allowed when you pass either `oauth_settings` or `oauth_flow`"
+
+
 # -------------------------------
 # Warning
 # -------------------------------

--- a/tests/scenario_tests/test_app.py
+++ b/tests/scenario_tests/test_app.py
@@ -4,6 +4,7 @@ from slack_sdk.oauth.installation_store import FileInstallationStore
 from slack_sdk.oauth.state_store import FileOAuthStateStore
 
 from slack_bolt import App
+from slack_bolt.authorization import AuthorizeResult
 from slack_bolt.error import BoltError
 from slack_bolt.oauth import OAuthFlow
 from slack_bolt.oauth.oauth_settings import OAuthSettings
@@ -92,3 +93,31 @@ class TestApp:
                 signing_secret="valid",
                 oauth_settings=OAuthSettings(client_id="111.222", client_secret=None),
             )
+
+    def test_authorize_conflicts(self):
+        oauth_settings = OAuthSettings(
+            client_id="111.222",
+            client_secret="valid",
+            installation_store=FileInstallationStore(),
+            state_store=FileOAuthStateStore(expiration_seconds=120),
+        )
+
+        # no error with this
+        App(signing_secret="valid", oauth_settings=oauth_settings)
+
+        def authorize() -> AuthorizeResult:
+            return AuthorizeResult(enterprise_id="E111", team_id="T111")
+
+        with pytest.raises(BoltError):
+            App(
+                signing_secret="valid",
+                authorize=authorize,
+                oauth_settings=oauth_settings,
+            )
+
+        oauth_flow = OAuthFlow(settings=oauth_settings)
+        # no error with this
+        App(signing_secret="valid", oauth_flow=oauth_flow)
+
+        with pytest.raises(BoltError):
+            App(signing_secret="valid", authorize=authorize, oauth_flow=oauth_flow)


### PR DESCRIPTION
This pull request fixes #123 - see the issue for details.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
