### PR TITLE
Fix #121 by changing the built-in middleware

### DIFF
--- a/slack_bolt/middleware/authorization/internals.py
+++ b/slack_bolt/middleware/authorization/internals.py
@@ -6,8 +6,16 @@ from slack_bolt.authorization import AuthorizeResult
 from slack_bolt.request.request import BoltRequest
 from slack_bolt.response import BoltResponse
 
+#
+# NOTE: this source file intentionally avoids having a reference to
+# AsyncBoltRequest, AsyncSlackResponse, and whatever Async-prefixed.
+#
+# The reason why we do so is to enable developers use sync version of Bolt
+# without installing aiohttp library (or any others we may use for async things)
+#
 
-def _is_url_verification(req: BoltRequest) -> bool:
+
+def _is_url_verification(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore
     return (
         req is not None
         and req.body is not None
@@ -15,13 +23,13 @@ def _is_url_verification(req: BoltRequest) -> bool:
     )
 
 
-def _is_ssl_check(req: BoltRequest) -> bool:
+def _is_ssl_check(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore
     return (
         req is not None and req.body is not None and req.body.get("type") == "ssl_check"
     )
 
 
-def _is_uninstallation_event(req: BoltRequest) -> bool:
+def _is_uninstallation_event(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore
     return (
         req is not None
         and req.body is not None
@@ -30,7 +38,7 @@ def _is_uninstallation_event(req: BoltRequest) -> bool:
     )
 
 
-def _is_tokens_revoked_event(req: BoltRequest) -> bool:
+def _is_tokens_revoked_event(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore
     return (
         req is not None
         and req.body is not None
@@ -39,11 +47,11 @@ def _is_tokens_revoked_event(req: BoltRequest) -> bool:
     )
 
 
-def _is_no_auth_required(req: BoltRequest) -> bool:
+def _is_no_auth_required(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore
     return _is_url_verification(req) or _is_ssl_check(req)
 
 
-def _is_no_auth_test_call_required(req: BoltRequest) -> bool:
+def _is_no_auth_test_call_required(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore
     return _is_uninstallation_event(req) or _is_tokens_revoked_event(req)
 
 

--- a/slack_bolt/middleware/authorization/internals.py
+++ b/slack_bolt/middleware/authorization/internals.py
@@ -21,8 +21,30 @@ def _is_ssl_check(req: BoltRequest) -> bool:
     )
 
 
+def _is_uninstallation_event(req: BoltRequest) -> bool:
+    return (
+        req is not None
+        and req.body is not None
+        and req.body.get("type") == "event_callback"
+        and req.body.get("event", {}).get("type") == "app_uninstalled"
+    )
+
+
+def _is_tokens_revoked_event(req: BoltRequest) -> bool:
+    return (
+        req is not None
+        and req.body is not None
+        and req.body.get("type") == "event_callback"
+        and req.body.get("event", {}).get("type") == "tokens_revoked"
+    )
+
+
 def _is_no_auth_required(req: BoltRequest) -> bool:
     return _is_url_verification(req) or _is_ssl_check(req)
+
+
+def _is_no_auth_test_call_required(req: BoltRequest) -> bool:
+    return _is_uninstallation_event(req) or _is_tokens_revoked_event(req)
 
 
 def _build_error_response() -> BoltResponse:

--- a/slack_bolt/middleware/authorization/single_team_authorization.py
+++ b/slack_bolt/middleware/authorization/single_team_authorization.py
@@ -10,7 +10,9 @@ from .internals import (
     _build_error_response,
     _is_no_auth_required,
     _to_authorize_result,
+    _is_no_auth_test_call_required,
 )
+from ...authorization import AuthorizeResult
 
 
 class SingleTeamAuthorization(Authorization):
@@ -26,6 +28,16 @@ class SingleTeamAuthorization(Authorization):
         self, *, req: BoltRequest, resp: BoltResponse, next: Callable[[], BoltResponse],
     ) -> BoltResponse:
         if _is_no_auth_required(req):
+            return next()
+
+        if _is_no_auth_test_call_required(req):
+            req.context.set_authorize_result(
+                AuthorizeResult(
+                    enterprise_id=req.context.enterprise_id,
+                    team_id=req.context.team_id,
+                    user_id=req.context.user_id,
+                )
+            )
             return next()
 
         try:

--- a/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
@@ -36,6 +36,7 @@ class IgnoringSelfEvents(Middleware):
     ):
         return (
             auth_result is not None
+            and user_id is not None
             and user_id == auth_result.bot_user_id
             and body.get("event") is not None
             and body.get("event", {}).get("type") not in cls.events_that_should_be_kept


### PR DESCRIPTION
This pull request fixes #121 

See the issue for details.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
