### PR TITLE
Fix #132 by handling requestContext in AWS Lambda payloads

### DIFF
--- a/scripts/install_all_and_run_tests.sh
+++ b/scripts/install_all_and_run_tests.sh
@@ -6,6 +6,8 @@
 script_dir=`dirname $0`
 cd ${script_dir}/..
 rm -rf ./slack_bolt.egg-info
+# The package causes a conflict with moto
+pip uninstall python-lambda
 
 test_target="$1"
 

--- a/slack_bolt/adapter/aws_lambda/handler.py
+++ b/slack_bolt/adapter/aws_lambda/handler.py
@@ -34,6 +34,9 @@ class SlackRequestHandler:
 
         method = event.get("requestContext", {}).get("http", {}).get("method")
         if method is None:
+            method = event.get("requestContext", {}).get("httpMethod")
+
+        if method is None:
             return not_found()
         if method == "GET":
             if self.app.oauth_flow is not None:

--- a/tests/adapter_tests/test_aws_lambda.py
+++ b/tests/adapter_tests/test_aws_lambda.py
@@ -115,6 +115,17 @@ class TestAWSLambda:
         assert response["statusCode"] == 200
         assert self.mock_received_requests["/auth.test"] == 1
 
+        event = {
+            "body": body,
+            "queryStringParameters": {},
+            "headers": self.build_headers(timestamp, body),
+            "requestContext": {"httpMethod": "POST"},
+            "isBase64Encoded": False,
+        }
+        response = SlackRequestHandler(app).handle(event, self.context)
+        assert response["statusCode"] == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
     @mock_lambda
     def test_shortcuts(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -151,6 +162,17 @@ class TestAWSLambda:
         assert response["statusCode"] == 200
         assert self.mock_received_requests["/auth.test"] == 1
 
+        event = {
+            "body": body,
+            "queryStringParameters": {},
+            "headers": self.build_headers(timestamp, body),
+            "requestContext": {"httpMethod": "POST"},
+            "isBase64Encoded": False,
+        }
+        response = SlackRequestHandler(app).handle(event, self.context)
+        assert response["statusCode"] == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
     @mock_lambda
     def test_commands(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret,)
@@ -181,6 +203,17 @@ class TestAWSLambda:
             "queryStringParameters": {},
             "headers": self.build_headers(timestamp, body),
             "requestContext": {"http": {"method": "POST"}},
+            "isBase64Encoded": False,
+        }
+        response = SlackRequestHandler(app).handle(event, self.context)
+        assert response["statusCode"] == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
+        event = {
+            "body": body,
+            "queryStringParameters": {},
+            "headers": self.build_headers(timestamp, body),
+            "requestContext": {"httpMethod": "POST"},
             "isBase64Encoded": False,
         }
         response = SlackRequestHandler(app).handle(event, self.context)
@@ -247,6 +280,16 @@ class TestAWSLambda:
             "queryStringParameters": {},
             "headers": {},
             "requestContext": {"http": {"method": "GET"}},
+            "isBase64Encoded": False,
+        }
+        response = SlackRequestHandler(app).handle(event, self.context)
+        assert response["statusCode"] == 302
+
+        event = {
+            "body": "",
+            "queryStringParameters": {},
+            "headers": {},
+            "requestContext": {"httpMethod": "GET"},
             "isBase64Encoded": False,
         }
         response = SlackRequestHandler(app).handle(event, self.context)


### PR DESCRIPTION
This pull request fixes #132 by updating the AWS Lambda handler to be compatible with all the patterns in the environment.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
