### PR TITLE
Improve the app.installation_store field consistency

### DIFF
--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -64,6 +64,10 @@ def warning_token_skipped() -> str:
     )
 
 
+def warning_installation_store_conflicts() -> str:
+    return "As you gave both `installation_store` and `oauth_settings`/`auth_flow`, the top level one is unused."
+
+
 def warning_unhandled_request(req: Union[BoltRequest, "AsyncBoltRequest"]) -> str:  # type: ignore
     return f"Unhandled request ({req.body})"
 

--- a/slack_bolt/oauth/async_internals.py
+++ b/slack_bolt/oauth/async_internals.py
@@ -1,0 +1,45 @@
+from logging import Logger
+from typing import Optional
+
+from slack_sdk.oauth.installation_store import FileInstallationStore
+from slack_sdk.oauth.installation_store.async_installation_store import (
+    AsyncInstallationStore,
+)
+
+from ..logger.messages import warning_installation_store_conflicts
+
+# key: client_id, value: AsyncInstallationStore
+default_installation_stores = {}
+
+
+def get_or_create_default_installation_store(client_id: str) -> AsyncInstallationStore:
+    store = default_installation_stores.get(client_id)
+    if store is None:
+        store = FileInstallationStore(client_id=client_id)
+        default_installation_stores[client_id] = store
+    return store
+
+
+def select_consistent_installation_store(
+    client_id: str,
+    app_store: Optional[AsyncInstallationStore],
+    oauth_flow_store: Optional[AsyncInstallationStore],
+    logger: Logger,
+) -> Optional[AsyncInstallationStore]:
+    default = get_or_create_default_installation_store(client_id)
+    if app_store is not None:
+        if oauth_flow_store is not None:
+            if oauth_flow_store is default:
+                # only app_store is intentionally set in this case
+                return app_store
+
+            # if both are intentionally set, prioritize app_store
+            if oauth_flow_store is not app_store:
+                logger.warning(warning_installation_store_conflicts())
+            return oauth_flow_store
+        else:
+            # only app_store is available
+            return app_store
+    else:
+        # only oauth_flow_store is available
+        return oauth_flow_store

--- a/slack_bolt/oauth/async_oauth_settings.py
+++ b/slack_bolt/oauth/async_oauth_settings.py
@@ -8,7 +8,6 @@ from slack_sdk.oauth import (
     AuthorizeUrlGenerator,
     RedirectUriPageRenderer,
 )
-from slack_sdk.oauth.installation_store import FileInstallationStore
 from slack_sdk.oauth.installation_store.async_installation_store import (
     AsyncInstallationStore,
 )
@@ -20,6 +19,7 @@ from slack_bolt.authorization.async_authorize import (
     AsyncAuthorize,
 )
 from slack_bolt.error import BoltError
+from slack_bolt.oauth.async_internals import get_or_create_default_installation_store
 from slack_bolt.oauth.callback_options import CallbackOptions
 
 
@@ -122,8 +122,8 @@ class AsyncOAuthSettings:
             authorization_url or "https://slack.com/oauth/v2/authorize"
         )
         # Installation Management
-        self.installation_store = installation_store or FileInstallationStore(
-            client_id=client_id
+        self.installation_store = (
+            installation_store or get_or_create_default_installation_store(client_id)
         )
         self.authorize = AsyncInstallationStoreAuthorize(
             logger=logger, installation_store=self.installation_store,

--- a/slack_bolt/oauth/oauth_settings.py
+++ b/slack_bolt/oauth/oauth_settings.py
@@ -10,11 +10,11 @@ from slack_sdk.oauth import (
     AuthorizeUrlGenerator,
     RedirectUriPageRenderer,
 )
-from slack_sdk.oauth.installation_store import FileInstallationStore
 from slack_sdk.oauth.state_store import FileOAuthStateStore
 
 from slack_bolt.authorization.authorize import Authorize, InstallationStoreAuthorize
 from slack_bolt.error import BoltError
+from slack_bolt.oauth.internals import get_or_create_default_installation_store
 from slack_bolt.oauth.callback_options import CallbackOptions
 
 
@@ -116,8 +116,8 @@ class OAuthSettings:
             authorization_url or "https://slack.com/oauth/v2/authorize"
         )
         # Installation Management
-        self.installation_store = installation_store or FileInstallationStore(
-            client_id=client_id
+        self.installation_store = (
+            installation_store or get_or_create_default_installation_store(client_id)
         )
         self.authorize = InstallationStoreAuthorize(
             logger=logger, installation_store=self.installation_store,

--- a/tests/scenario_tests/test_app.py
+++ b/tests/scenario_tests/test_app.py
@@ -121,3 +121,37 @@ class TestApp:
 
         with pytest.raises(BoltError):
             App(signing_secret="valid", authorize=authorize, oauth_flow=oauth_flow)
+
+    def test_installation_store_conflicts(self):
+        store1 = FileInstallationStore()
+        store2 = FileInstallationStore()
+        app = App(
+            signing_secret="valid",
+            oauth_settings=OAuthSettings(
+                client_id="111.222", client_secret="valid", installation_store=store1,
+            ),
+            installation_store=store2,
+        )
+        assert app.installation_store is store1
+
+        app = App(
+            signing_secret="valid",
+            oauth_flow=OAuthFlow(
+                settings=OAuthSettings(
+                    client_id="111.222",
+                    client_secret="valid",
+                    installation_store=store1,
+                )
+            ),
+            installation_store=store2,
+        )
+        assert app.installation_store is store1
+
+        app = App(
+            signing_secret="valid",
+            oauth_flow=OAuthFlow(
+                settings=OAuthSettings(client_id="111.222", client_secret="valid",)
+            ),
+            installation_store=store1,
+        )
+        assert app.installation_store is store1


### PR DESCRIPTION
`App`/`AsyncApp` enables developers to use `installation_store` without `oauth_settings` / `oauth_flow` for fetching installation data. With this support, developers can serve Slack OAuth flow as a separate app and share the installation data with an app that handles incoming requests from the Slack API servers.

This pull request improves the consistency of `app.installation_store` field to return a single instance to remove the risks of confusing situations by misconfiguration.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
