### PR TITLE
Add default to CallbackOptions handler args

### DIFF
--- a/examples/oauth_app_settings.py
+++ b/examples/oauth_app_settings.py
@@ -18,7 +18,10 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 def success(args: SuccessArgs) -> BoltResponse:
-    return BoltResponse(status=200, body="Thanks!")
+    # Do anything here ...
+    # Call the default handler to return HTTP response
+    return args.default.success(args)
+    # return BoltResponse(status=200, body="Thanks!")
 
 
 def failure(args: FailureArgs) -> BoltResponse:

--- a/slack_bolt/oauth/async_callback_options.py
+++ b/slack_bolt/oauth/async_callback_options.py
@@ -17,16 +17,19 @@ class AsyncSuccessArgs:
         request: AsyncBoltRequest,
         installation: Installation,
         settings: "AsyncOAuthSettings",
+        default: "AsyncCallbackOptions",
     ):
         """The arguments for a success function.
 
         :param request: The request.
         :param installation: The installation data.
         :param settings: The settings for OAuth flow.
+        :param default: The default AsyncCallbackOptions.
         """
         self.request = request
         self.installation = installation
         self.settings = settings
+        self.default = default
 
 
 class AsyncFailureArgs:
@@ -38,6 +41,7 @@ class AsyncFailureArgs:
         error: Optional[Exception] = None,
         suggested_status_code: int,
         settings: "AsyncOAuthSettings",
+        default: "AsyncCallbackOptions",
     ):
         """The arguments for a failure function.
 
@@ -46,12 +50,14 @@ class AsyncFailureArgs:
         :param error: An exception if exists.
         :param suggested_status_code: The recommended HTTP status code for the failure.
         :param settings: The settings for OAuth flow.
+        :param default: The default AsyncCallbackOptions.
         """
         self.request = request
         self.reason = reason
         self.error = error
         self.suggested_status_code = suggested_status_code
         self.settings = settings
+        self.default = default
 
 
 class AsyncCallbackOptions:

--- a/slack_bolt/oauth/async_oauth_flow.py
+++ b/slack_bolt/oauth/async_oauth_flow.py
@@ -69,12 +69,13 @@ class AsyncOAuthFlow:
         self.install_path = self.settings.install_path
         self.redirect_uri_path = self.settings.redirect_uri_path
 
+        self.default_callback_options = DefaultAsyncCallbackOptions(
+            logger=logger,
+            state_utils=self.settings.state_utils,
+            redirect_uri_page_renderer=self.settings.redirect_uri_page_renderer,
+        )
         if settings.callback_options is None:
-            settings.callback_options = DefaultAsyncCallbackOptions(
-                logger=logger,
-                state_utils=self.settings.state_utils,
-                redirect_uri_page_renderer=self.settings.redirect_uri_page_renderer,
-            )
+            settings.callback_options = self.default_callback_options
         self.success_handler = settings.callback_options.success
         self.failure_handler = settings.callback_options.failure
 
@@ -186,6 +187,7 @@ class AsyncOAuthFlow:
                     reason=error,  # type: ignore
                     suggested_status_code=200,
                     settings=self.settings,
+                    default=self.default_callback_options,
                 )
             )
 
@@ -198,6 +200,7 @@ class AsyncOAuthFlow:
                     reason="invalid_browser",
                     suggested_status_code=400,
                     settings=self.settings,
+                    default=self.default_callback_options,
                 )
             )
 
@@ -209,6 +212,7 @@ class AsyncOAuthFlow:
                     reason="invalid_state",
                     suggested_status_code=401,
                     settings=self.settings,
+                    default=self.default_callback_options,
                 )
             )
 
@@ -221,6 +225,7 @@ class AsyncOAuthFlow:
                     reason="missing_code",
                     suggested_status_code=401,
                     settings=self.settings,
+                    default=self.default_callback_options,
                 )
             )
 
@@ -233,6 +238,7 @@ class AsyncOAuthFlow:
                     reason="invalid_code",
                     suggested_status_code=401,
                     settings=self.settings,
+                    default=self.default_callback_options,
                 )
             )
 
@@ -247,13 +253,17 @@ class AsyncOAuthFlow:
                     error=err,
                     suggested_status_code=500,
                     settings=self.settings,
+                    default=self.default_callback_options,
                 )
             )
 
         # display a successful completion page to the end-user
         return await self.success_handler(
             AsyncSuccessArgs(
-                request=request, installation=installation, settings=self.settings,
+                request=request,
+                installation=installation,
+                settings=self.settings,
+                default=self.default_callback_options,
             )
         )
 

--- a/slack_bolt/oauth/callback_options.py
+++ b/slack_bolt/oauth/callback_options.py
@@ -17,16 +17,19 @@ class SuccessArgs:
         request: BoltRequest,
         installation: Installation,
         settings: "OAuthSettings",
+        default: "CallbackOptions",
     ):
         """The arguments for a success function.
 
         :param request: The request.
         :param installation: The installation data.
         :param settings: The settings for OAuth flow.
+        :param default: The default CallbackOptions.
         """
         self.request = request
         self.installation = installation
         self.settings = settings
+        self.default = default
 
 
 class FailureArgs:
@@ -38,6 +41,7 @@ class FailureArgs:
         error: Optional[Exception] = None,
         suggested_status_code: int,
         settings: "OAuthSettings",
+        default: "CallbackOptions",
     ):
         """The arguments for a failure function.
 
@@ -46,12 +50,14 @@ class FailureArgs:
         :param error: An exception if exists.
         :param suggested_status_code: The recommended HTTP status code for the failure.
         :param settings: The settings for OAuth flow.
+        :param default: The default CallbackOptions.
         """
         self.request = request
         self.reason = reason
         self.error = error
         self.suggested_status_code = suggested_status_code
         self.settings = settings
+        self.default = default
 
 
 class CallbackOptions:

--- a/slack_bolt/oauth/oauth_flow.py
+++ b/slack_bolt/oauth/oauth_flow.py
@@ -69,12 +69,13 @@ class OAuthFlow:
         self.install_path = self.settings.install_path
         self.redirect_uri_path = self.settings.redirect_uri_path
 
+        self.default_callback_options = DefaultCallbackOptions(
+            logger=logger,
+            state_utils=self.settings.state_utils,
+            redirect_uri_page_renderer=self.settings.redirect_uri_page_renderer,
+        )
         if settings.callback_options is None:
-            settings.callback_options = DefaultCallbackOptions(
-                logger=logger,
-                state_utils=self.settings.state_utils,
-                redirect_uri_page_renderer=self.settings.redirect_uri_page_renderer,
-            )
+            settings.callback_options = self.default_callback_options
         self.success_handler = settings.callback_options.success
         self.failure_handler = settings.callback_options.failure
 
@@ -186,6 +187,7 @@ class OAuthFlow:
                     reason=error,
                     suggested_status_code=200,
                     settings=self.settings,
+                    default=self.default_callback_options,
                 )
             )
 
@@ -198,6 +200,7 @@ class OAuthFlow:
                     reason="invalid_browser",
                     suggested_status_code=400,
                     settings=self.settings,
+                    default=self.default_callback_options,
                 )
             )
 
@@ -209,6 +212,7 @@ class OAuthFlow:
                     reason="invalid_state",
                     suggested_status_code=401,
                     settings=self.settings,
+                    default=self.default_callback_options,
                 )
             )
 
@@ -221,6 +225,7 @@ class OAuthFlow:
                     reason="missing_code",
                     suggested_status_code=401,
                     settings=self.settings,
+                    default=self.default_callback_options,
                 )
             )
 
@@ -233,6 +238,7 @@ class OAuthFlow:
                     reason="invalid_code",
                     suggested_status_code=401,
                     settings=self.settings,
+                    default=self.default_callback_options,
                 )
             )
 
@@ -247,13 +253,17 @@ class OAuthFlow:
                     error=err,
                     suggested_status_code=500,
                     settings=self.settings,
+                    default=self.default_callback_options,
                 )
             )
 
         # display a successful completion page to the end-user
         return self.success_handler(
             SuccessArgs(
-                request=request, installation=installation, settings=self.settings,
+                request=request,
+                installation=installation,
+                settings=self.settings,
+                default=self.default_callback_options,
             )
         )
 


### PR DESCRIPTION
This pull request resolves #137 by providing the access to the `DefaultCallbackOptions` handlers in callback options. As mentioned in the issue #137, this arg is greatly useful for developers that would like to reuse redirect_uri_page_renderer and so on in callback_options handlers.

```python
def success(args: SuccessArgs) -> BoltResponse:
    # Do anything here ...

    # Call the default handler to return HTTP response
    return args.default.success(args)

def failure(args: FailureArgs) -> BoltResponse:
    # Do anything here ...

    # Call the default handler to return HTTP response
    return args.default.failure(args)

app = App(
    oauth_settings=OAuthSettings(
        callback_options=CallbackOptions(success=success, failure=failure),
    ),
)
```

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
