### PR TITLE
Fix #140 by updating the default install page handler

### DIFF
--- a/slack_bolt/oauth/internals.py
+++ b/slack_bolt/oauth/internals.py
@@ -64,3 +64,22 @@ class CallbackResponseBuilder:
             },
             body=html,
         )
+
+
+def _build_default_install_page_html(url: str) -> str:
+    return f"""<html>
+<head>
+<style>
+body {{
+  padding: 10px 15px;
+  font-family: verdana;
+  text-align: center;
+}}
+</style>
+</head>
+<body>
+<h2>Slack App Installation</h2>
+<p><a href="{url}"><img alt=""Add to Slack"" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a></p>
+</body>
+</html>
+"""

--- a/tests/adapter_tests/test_aws_chalice.py
+++ b/tests/adapter_tests/test_aws_chalice.py
@@ -272,4 +272,7 @@ class TestAwsChalice:
         response: Dict[str, Any] = LocalGateway(chalice_app, Config()).handle_request(
             method="GET", path="/slack/install", body="", headers={}
         )
-        assert response["statusCode"] == 302
+        assert response["statusCode"] == 200
+        assert response["headers"]["content-type"] == "text/html; charset=utf-8"
+        assert response["headers"]["content-length"] == "565"
+        assert response.get("body") is not None

--- a/tests/adapter_tests/test_aws_lambda.py
+++ b/tests/adapter_tests/test_aws_lambda.py
@@ -283,7 +283,10 @@ class TestAWSLambda:
             "isBase64Encoded": False,
         }
         response = SlackRequestHandler(app).handle(event, self.context)
-        assert response["statusCode"] == 302
+        assert response["statusCode"] == 200
+        assert response["headers"]["content-type"] == "text/html; charset=utf-8"
+        assert response["headers"]["content-length"] == "565"
+        assert response.get("body") is not None
 
         event = {
             "body": "",
@@ -293,4 +296,7 @@ class TestAWSLambda:
             "isBase64Encoded": False,
         }
         response = SlackRequestHandler(app).handle(event, self.context)
-        assert response["statusCode"] == 302
+        assert response["statusCode"] == 200
+        assert response["headers"]["content-type"] == "text/html; charset=utf-8"
+        assert response["headers"]["content-length"] == "565"
+        assert response.get("body") is not None

--- a/tests/adapter_tests/test_bottle_oauth.py
+++ b/tests/adapter_tests/test_bottle_oauth.py
@@ -26,9 +26,6 @@ class TestBottle:
     def test_oauth(self):
         with boddle(method="GET", path="/slack/install"):
             response_body = install()
-            assert response_body == ""
-            assert response.status_code == 302
-            assert re.match(
-                "https://slack.com/oauth/v2/authorize\\?state=[^&]+&client_id=111.111&scope=chat:write,commands&user_scope=",
-                response.headers["Location"],
-            )
+            assert response.status_code == 200
+            assert response.headers.get("content-type") == "text/html; charset=utf-8"
+            assert "https://slack.com/oauth/v2/authorize?state=" in response_body

--- a/tests/adapter_tests/test_cherrypy_oauth.py
+++ b/tests/adapter_tests/test_cherrypy_oauth.py
@@ -49,4 +49,4 @@ class TestCherryPy(helper.CPWebCase):
     def test_oauth(self):
         cherrypy.request.process_request_body = False
         self.getPage("/slack/install", method="GET")
-        self.assertStatus("302 Found")
+        self.assertStatus("200 OK")

--- a/tests/adapter_tests/test_django.py
+++ b/tests/adapter_tests/test_django.py
@@ -170,4 +170,9 @@ class TestDjango(TestCase):
         )
         request = self.rf.get("/slack/install")
         response = SlackRequestHandler(app).handle(request)
-        assert response.status_code == 302
+        assert response.status_code == 200
+        assert response.get("content-type") == "text/html; charset=utf-8"
+        assert response.get("content-length") == "565"
+        assert "https://slack.com/oauth/v2/authorize?state=" in response.content.decode(
+            "utf-8"
+        )

--- a/tests/adapter_tests/test_falcon.py
+++ b/tests/adapter_tests/test_falcon.py
@@ -179,8 +179,5 @@ class TestFalcon:
 
         client = testing.TestClient(api)
         response = client.simulate_get("/slack/install")
-        assert response.status_code == 302
-        assert re.match(
-            "https://slack.com/oauth/v2/authorize\\?state=[^&]+&client_id=111.111&scope=chat:write,commands&user_scope=",
-            response.headers["Location"],
-        )
+        assert response.status_code == 200
+        assert "https://slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests/test_fastapi.py
+++ b/tests/adapter_tests/test_fastapi.py
@@ -192,8 +192,7 @@ class TestFastAPI:
 
         client = TestClient(api)
         response = client.get("/slack/install", allow_redirects=False)
-        assert response.status_code == 302
-        assert re.match(
-            "https://slack.com/oauth/v2/authorize\\?state=[^&]+&client_id=111.111&scope=chat:write,commands&user_scope=",
-            response.headers["Location"],
-        )
+        assert response.status_code == 200
+        assert response.headers.get("content-type") == "text/html; charset=utf-8"
+        assert response.headers.get("content-length") == "565"
+        assert "https://slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests/test_flask.py
+++ b/tests/adapter_tests/test_flask.py
@@ -185,4 +185,4 @@ class TestFlask:
 
         with flask_app.test_client() as client:
             rv = client.get("/slack/install")
-            assert rv.status_code == 302
+            assert rv.status_code == 200

--- a/tests/adapter_tests/test_pyramid.py
+++ b/tests/adapter_tests/test_pyramid.py
@@ -175,4 +175,7 @@ class TestPyramid(TestCase):
         request.path = "/slack/install"
         request.method = "GET"
         response: Response = SlackRequestHandler(app).handle(request)
-        assert response.status_code == 302
+        assert response.status_code == 200
+        assert "https://slack.com/oauth/v2/authorize?state=" in response.body.decode(
+            "utf-8"
+        )

--- a/tests/adapter_tests/test_starlette.py
+++ b/tests/adapter_tests/test_starlette.py
@@ -201,8 +201,7 @@ class TestStarlette:
         )
         client = TestClient(api)
         response = client.get("/slack/install", allow_redirects=False)
-        assert response.status_code == 302
-        assert re.match(
-            "https://slack.com/oauth/v2/authorize\\?state=[^&]+&client_id=111.111&scope=chat:write,commands&user_scope=",
-            response.headers["Location"],
-        )
+        assert response.status_code == 200
+        assert response.headers.get("content-type") == "text/html; charset=utf-8"
+        assert response.headers.get("content-length") == "565"
+        assert "https://slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests/test_tornado_oauth.py
+++ b/tests/adapter_tests/test_tornado_oauth.py
@@ -37,6 +37,6 @@ class TestTornado(AsyncHTTPTestCase):
         )
         try:
             response: HTTPResponse = await self.http_client.fetch(request)
-            assert response.code == 302
+            assert response.code == 200
         except tornado.httpclient.HTTPClientError as e:
-            assert e.code == 302
+            assert e.code == 200

--- a/tests/adapter_tests_async/test_async_fastapi.py
+++ b/tests/adapter_tests_async/test_async_fastapi.py
@@ -192,8 +192,7 @@ class TestFastAPI:
 
         client = TestClient(api)
         response = client.get("/slack/install", allow_redirects=False)
-        assert response.status_code == 302
-        assert re.match(
-            "https://slack.com/oauth/v2/authorize\\?state=[^&]+&client_id=111.111&scope=chat:write,commands&user_scope=",
-            response.headers["Location"],
-        )
+        assert response.status_code == 200
+        assert response.headers.get("content-type") == "text/html; charset=utf-8"
+        assert response.headers.get("content-length") == "565"
+        assert "https://slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests_async/test_async_sanic.py
+++ b/tests/adapter_tests_async/test_async_sanic.py
@@ -199,8 +199,8 @@ class TestSanic:
         _, response = await api.asgi_client.get(
             url="/slack/install", allow_redirects=False
         )
-        assert response.status_code == 302
-        assert re.match(
-            "https://slack.com/oauth/v2/authorize\\?state=[^&]+&client_id=111.111&scope=chat:write,commands&user_scope=",
-            response.headers["Location"],
-        )
+        assert response.status_code == 200
+        assert response.status_code == 200
+        assert response.headers.get("content-type") == "text/html; charset=utf-8"
+        assert response.headers.get("content-length") == "565"
+        assert "https://slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests_async/test_async_starlette.py
+++ b/tests/adapter_tests_async/test_async_starlette.py
@@ -202,8 +202,8 @@ class TestAsyncStarlette:
 
         client = TestClient(api)
         response = client.get("/slack/install", allow_redirects=False)
-        assert response.status_code == 302
-        assert re.match(
-            "https://slack.com/oauth/v2/authorize\\?state=[^&]+&client_id=111.111&scope=chat:write,commands&user_scope=",
-            response.headers["Location"],
-        )
+        assert response.status_code == 200
+        assert response.status_code == 200
+        assert response.headers.get("content-type") == "text/html; charset=utf-8"
+        assert response.headers.get("content-length") == "565"
+        assert "https://slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/slack_bolt/oauth/test_oauth_flow.py
+++ b/tests/slack_bolt/oauth/test_oauth_flow.py
@@ -53,17 +53,10 @@ class TestOAuthFlow:
         )
         req = BoltRequest(body="")
         resp = oauth_flow.handle_installation(req)
-        assert resp.status == 302
-        url = resp.headers["location"][0]
-        assert (
-            re.compile(
-                "https://slack.com/oauth/v2/authorize\\?state=[-0-9a-z]+."
-                "&client_id=111\\.222"
-                "&scope=chat:write,commands"
-                "&user_scope="
-            ).match(url)
-            is not None
-        )
+        assert resp.status == 200
+        assert resp.headers.get("content-type") == ["text/html; charset=utf-8"]
+        assert resp.headers.get("content-length") == ["565"]
+        assert "https://slack.com/oauth/v2/authorize?state=" in resp.body
 
     def test_handle_callback(self):
         oauth_flow = OAuthFlow(

--- a/tests/slack_bolt/oauth/test_oauth_flow_sqlite3.py
+++ b/tests/slack_bolt/oauth/test_oauth_flow_sqlite3.py
@@ -41,17 +41,10 @@ class TestOAuthFlowSQLite3:
         )
         req = BoltRequest(body="")
         resp = oauth_flow.handle_installation(req)
-        assert resp.status == 302
-        url = resp.headers["location"][0]
-        assert (
-            re.compile(
-                "https://slack.com/oauth/v2/authorize\\?state=[-0-9a-z]+."
-                "&client_id=111\\.222"
-                "&scope=chat:write,commands"
-                "&user_scope="
-            ).match(url)
-            is not None
-        )
+        assert resp.status == 200
+        assert resp.headers.get("content-type") == ["text/html; charset=utf-8"]
+        assert resp.headers.get("content-length") == ["565"]
+        assert "https://slack.com/oauth/v2/authorize?state=" in resp.body
 
     def test_handle_callback(self):
         oauth_flow = OAuthFlow.sqlite3(

--- a/tests/slack_bolt_async/oauth/test_async_oauth_flow.py
+++ b/tests/slack_bolt_async/oauth/test_async_oauth_flow.py
@@ -68,17 +68,10 @@ class TestAsyncOAuthFlow:
         )
         req = AsyncBoltRequest(body="")
         resp = await oauth_flow.handle_installation(req)
-        assert resp.status == 302
-        url = resp.headers["location"][0]
-        assert (
-            re.compile(
-                "https://slack.com/oauth/v2/authorize\\?state=[-0-9a-z]+."
-                "&client_id=111\\.222"
-                "&scope=chat:write,commands"
-                "&user_scope="
-            ).match(url)
-            is not None
-        )
+        assert resp.status == 200
+        assert resp.headers.get("content-type") == ["text/html; charset=utf-8"]
+        assert resp.headers.get("content-length") == ["565"]
+        assert "https://slack.com/oauth/v2/authorize?state=" in resp.body
 
     @pytest.mark.asyncio
     async def test_handle_callback(self):

--- a/tests/slack_bolt_async/oauth/test_async_oauth_flow_sqlite3.py
+++ b/tests/slack_bolt_async/oauth/test_async_oauth_flow_sqlite3.py
@@ -54,17 +54,10 @@ class TestAsyncOAuthFlowSQLite3:
         )
         req = AsyncBoltRequest(body="")
         resp = await oauth_flow.handle_installation(req)
-        assert resp.status == 302
-        url = resp.headers["location"][0]
-        assert (
-            re.compile(
-                "https://slack.com/oauth/v2/authorize\\?state=[-0-9a-z]+."
-                "&client_id=111\\.222"
-                "&scope=chat:write,commands"
-                "&user_scope="
-            ).match(url)
-            is not None
-        )
+        assert resp.status == 200
+        assert resp.headers.get("content-type") == ["text/html; charset=utf-8"]
+        assert resp.headers.get("content-length") == ["565"]
+        assert "https://slack.com/oauth/v2/authorize?state=" in resp.body
 
     @pytest.mark.asyncio
     async def test_handle_callback(self):


### PR DESCRIPTION
This pull request fixes #140 by changing the default installation page handler's behavior to display a web page. The following is a screenshot of the default HTML. Developers can override the method to generate the HTML page.

<img width="400" src="https://user-images.githubusercontent.com/19658/97979003-ca2a9e00-1e11-11eb-9989-031e56b29805.png">

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
