### PR TITLE
Use Sequence type hints over List for args

### DIFF
--- a/slack_bolt/adapter/aws_lambda/handler.py
+++ b/slack_bolt/adapter/aws_lambda/handler.py
@@ -1,6 +1,6 @@
 import base64
 import logging
-from typing import List, Dict, Any
+from typing import Dict, Any, Sequence
 
 from slack_bolt.adapter.aws_lambda.internals import _first_value
 from slack_bolt.adapter.aws_lambda.lazy_listener_runner import LambdaLazyListenerRunner
@@ -78,7 +78,7 @@ def to_bolt_request(event) -> BoltRequest:
     body = event.get("body", "")
     if event["isBase64Encoded"]:
         body = base64.b64decode(body).decode("utf-8")
-    cookies: List[str] = event.get("cookies", [])
+    cookies: Sequence[str] = event.get("cookies", [])
     headers = event.get("headers", {})
     headers["cookie"] = cookies
     return BoltRequest(

--- a/slack_bolt/adapter/aws_lambda/internals.py
+++ b/slack_bolt/adapter/aws_lambda/internals.py
@@ -1,7 +1,7 @@
-from typing import Dict, List, Optional
+from typing import Dict, Optional, Sequence
 
 
-def _first_value(query: Dict[str, List[str]], name: str) -> Optional[str]:
+def _first_value(query: Dict[str, Sequence[str]], name: str) -> Optional[str]:
     if query:
         values = query.get(name, [])
         if values and len(values) > 0:

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -4,7 +4,7 @@ import logging
 import os
 from concurrent.futures.thread import ThreadPoolExecutor
 from http.server import SimpleHTTPRequestHandler, HTTPServer
-from typing import List, Union, Pattern, Callable, Dict, Optional
+from typing import List, Union, Pattern, Callable, Dict, Optional, Sequence
 
 from slack_sdk.errors import SlackApiError
 from slack_sdk.oauth.installation_store import InstallationStore
@@ -374,13 +374,13 @@ class App:
         self,
         callback_id: Union[str, Pattern, WorkflowStep],
         edit: Optional[
-            Union[Callable[..., Optional[BoltResponse]], Listener, List[Callable]]
+            Union[Callable[..., Optional[BoltResponse]], Listener, Sequence[Callable]]
         ] = None,
         save: Optional[
-            Union[Callable[..., Optional[BoltResponse]], Listener, List[Callable]]
+            Union[Callable[..., Optional[BoltResponse]], Listener, Sequence[Callable]]
         ] = None,
         execute: Optional[
-            Union[Callable[..., Optional[BoltResponse]], Listener, List[Callable]]
+            Union[Callable[..., Optional[BoltResponse]], Listener, Sequence[Callable]]
         ] = None,
     ):
         """Registers a new Workflow Step listener"""
@@ -417,8 +417,8 @@ class App:
     def event(
         self,
         event: Union[str, Pattern, Dict[str, str]],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new event listener.
 
@@ -440,14 +440,14 @@ class App:
     def message(
         self,
         keyword: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new message event listener.
         Check the #event method's docstring for details.
         """
-        matchers = matchers if matchers else []
-        middleware = middleware if middleware else []
+        matchers = list(matchers) if matchers else []
+        middleware = list(middleware) if middleware else []
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -467,8 +467,8 @@ class App:
     def command(
         self,
         command: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new slash command listener.
 
@@ -493,8 +493,8 @@ class App:
     def shortcut(
         self,
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new shortcut listener.
 
@@ -516,8 +516,8 @@ class App:
     def global_shortcut(
         self,
         callback_id: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new global shortcut listener."""
 
@@ -533,8 +533,8 @@ class App:
     def message_shortcut(
         self,
         callback_id: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new message shortcut listener."""
 
@@ -553,8 +553,8 @@ class App:
     def action(
         self,
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new action listener.
 
@@ -576,8 +576,8 @@ class App:
     def block_action(
         self,
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new block_actions listener."""
 
@@ -593,8 +593,8 @@ class App:
     def attachment_action(
         self,
         callback_id: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new interactive_message listener."""
 
@@ -610,8 +610,8 @@ class App:
     def dialog_submission(
         self,
         callback_id: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new dialog_submission listener."""
 
@@ -627,8 +627,8 @@ class App:
     def dialog_cancellation(
         self,
         callback_id: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new dialog_cancellation listener."""
 
@@ -647,8 +647,8 @@ class App:
     def view(
         self,
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new view submission/closed event listener.
 
@@ -670,8 +670,8 @@ class App:
     def view_submission(
         self,
         constraints: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new view_submission listener."""
 
@@ -687,8 +687,8 @@ class App:
     def view_closed(
         self,
         constraints: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new view_closed listener."""
 
@@ -707,8 +707,8 @@ class App:
     def options(
         self,
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new options listener.
 
@@ -730,8 +730,8 @@ class App:
     def block_suggestion(
         self,
         action_id: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new block_suggestion listener."""
 
@@ -747,8 +747,8 @@ class App:
     def dialog_suggestion(
         self,
         callback_id: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., bool]]] = None,
-        middleware: Optional[List[Union[Callable, Middleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., bool]]] = None,
+        middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         """Registers a new dialog_submission listener."""
 
@@ -771,7 +771,7 @@ class App:
     @staticmethod
     def _to_listener_functions(
         kwargs: dict,
-    ) -> Optional[List[Callable[..., Optional[BoltResponse]]]]:
+    ) -> Optional[Sequence[Callable[..., Optional[BoltResponse]]]]:
         if kwargs:
             functions = [kwargs["ack"]]
             for sub in kwargs["lazy"]:
@@ -781,10 +781,10 @@ class App:
 
     def _register_listener(
         self,
-        functions: List[Callable[..., Optional[BoltResponse]]],
+        functions: Sequence[Callable[..., Optional[BoltResponse]]],
         primary_matcher: ListenerMatcher,
-        matchers: Optional[List[Callable[..., bool]]],
-        middleware: Optional[List[Union[Callable, Middleware]]],
+        matchers: Optional[Sequence[Callable[..., bool]]],
+        middleware: Optional[Sequence[Union[Callable, Middleware]]],
         auto_acknowledgement: bool = False,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         value_to_return = None
@@ -893,7 +893,7 @@ class SlackAppDevelopmentServer:
             def _send_response(
                 self,
                 status: int,
-                headers: Dict[str, List[str]],
+                headers: Dict[str, Sequence[str]],
                 body: Union[str, dict] = "",
             ):
                 self.send_response(status)

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -1,7 +1,7 @@
 import inspect
 import logging
 import os
-from typing import Optional, List, Union, Callable, Pattern, Dict, Awaitable
+from typing import Optional, List, Union, Callable, Pattern, Dict, Awaitable, Sequence
 
 from slack_bolt.listener.asyncio_runner import AsyncioListenerRunner
 from slack_bolt.middleware.message_listener_matches.async_message_listener_matches import (
@@ -386,13 +386,19 @@ class AsyncApp:
         self,
         callback_id: Union[str, Pattern, AsyncWorkflowStep],
         edit: Optional[
-            Union[Callable[..., Optional[BoltResponse]], AsyncListener, List[Callable]]
+            Union[
+                Callable[..., Optional[BoltResponse]], AsyncListener, Sequence[Callable]
+            ]
         ] = None,
         save: Optional[
-            Union[Callable[..., Optional[BoltResponse]], AsyncListener, List[Callable]]
+            Union[
+                Callable[..., Optional[BoltResponse]], AsyncListener, Sequence[Callable]
+            ]
         ] = None,
         execute: Optional[
-            Union[Callable[..., Optional[BoltResponse]], AsyncListener, List[Callable]]
+            Union[
+                Callable[..., Optional[BoltResponse]], AsyncListener, Sequence[Callable]
+            ]
         ] = None,
     ):
         """Registers a new Workflow Step listener"""
@@ -429,8 +435,8 @@ class AsyncApp:
     def event(
         self,
         event: Union[str, Pattern, Dict[str, str]],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new event listener.
 
@@ -452,12 +458,12 @@ class AsyncApp:
     def message(
         self,
         keyword: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Register a new message event listener."""
-        matchers = matchers if matchers else []
-        middleware = middleware if middleware else []
+        matchers = list(matchers) if matchers else []
+        middleware = list(middleware) if middleware else []
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -477,8 +483,8 @@ class AsyncApp:
     def command(
         self,
         command: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new slash command listener.
 
@@ -503,8 +509,8 @@ class AsyncApp:
     def shortcut(
         self,
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new shortcut listener.
 
@@ -526,8 +532,8 @@ class AsyncApp:
     def global_shortcut(
         self,
         callback_id: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new global shortcut listener."""
 
@@ -543,8 +549,8 @@ class AsyncApp:
     def message_shortcut(
         self,
         callback_id: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new message shortcut listener."""
 
@@ -563,8 +569,8 @@ class AsyncApp:
     def action(
         self,
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new action listener.
 
@@ -586,8 +592,8 @@ class AsyncApp:
     def block_action(
         self,
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new block_actions listener."""
 
@@ -603,8 +609,8 @@ class AsyncApp:
     def attachment_action(
         self,
         callback_id: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new interactive_message listener."""
 
@@ -620,8 +626,8 @@ class AsyncApp:
     def dialog_submission(
         self,
         callback_id: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new dialog_submission listener."""
 
@@ -637,8 +643,8 @@ class AsyncApp:
     def dialog_cancellation(
         self,
         callback_id: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new dialog_cancellation listener."""
 
@@ -657,8 +663,8 @@ class AsyncApp:
     def view(
         self,
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new view submission/closed listener.
 
@@ -680,8 +686,8 @@ class AsyncApp:
     def view_submission(
         self,
         constraints: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new view_submission listener."""
 
@@ -697,8 +703,8 @@ class AsyncApp:
     def view_closed(
         self,
         constraints: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new view_closed listener."""
 
@@ -717,8 +723,8 @@ class AsyncApp:
     def options(
         self,
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new options listener.
 
@@ -740,8 +746,8 @@ class AsyncApp:
     def block_suggestion(
         self,
         action_id: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new block_suggestion listener."""
 
@@ -757,8 +763,8 @@ class AsyncApp:
     def dialog_suggestion(
         self,
         callback_id: Union[str, Pattern],
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]] = None,
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]] = None,
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         """Registers a new dialog_submission listener."""
 
@@ -781,7 +787,7 @@ class AsyncApp:
     @staticmethod
     def _to_listener_functions(
         kwargs: dict,
-    ) -> Optional[List[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
+    ) -> Optional[Sequence[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         if kwargs:
             functions = [kwargs["ack"]]
             for sub in kwargs["lazy"]:
@@ -791,10 +797,10 @@ class AsyncApp:
 
     def _register_listener(
         self,
-        functions: List[Callable[..., Awaitable[Optional[BoltResponse]]]],
+        functions: Sequence[Callable[..., Awaitable[Optional[BoltResponse]]]],
         primary_matcher: AsyncListenerMatcher,
-        matchers: Optional[List[Callable[..., Awaitable[bool]]]],
-        middleware: Optional[List[Union[Callable, AsyncMiddleware]]],
+        matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]],
+        middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]],
         auto_acknowledgement: bool = False,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         value_to_return = None

--- a/slack_bolt/context/ack/ack.py
+++ b/slack_bolt/context/ack/ack.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union, Dict
+from typing import Optional, Union, Dict, Sequence
 
 from slack_sdk.models.attachments import Attachment
 from slack_sdk.models.blocks import Block, Option, OptionGroup
@@ -17,12 +17,12 @@ class Ack:
     def __call__(
         self,
         text: Union[str, dict] = "",  # text: str or whole_response: dict
-        blocks: Optional[List[Union[dict, Block]]] = None,
-        attachments: Optional[List[Union[dict, Attachment]]] = None,
+        blocks: Optional[Sequence[Union[dict, Block]]] = None,
+        attachments: Optional[Sequence[Union[dict, Attachment]]] = None,
         response_type: Optional[str] = None,  # in_channel / ephemeral
         # block_suggestion / dialog_suggestion
-        options: Optional[List[Union[dict, Option]]] = None,
-        option_groups: Optional[List[Union[dict, OptionGroup]]] = None,
+        options: Optional[Sequence[Union[dict, Option]]] = None,
+        option_groups: Optional[Sequence[Union[dict, OptionGroup]]] = None,
         # view_submission
         response_action: Optional[str] = None,  # errors / update / push / clear
         errors: Optional[Dict[str, str]] = None,

--- a/slack_bolt/context/ack/async_ack.py
+++ b/slack_bolt/context/ack/async_ack.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union, Dict
+from typing import Optional, Union, Dict, Sequence
 
 from slack_sdk.models.attachments import Attachment
 from slack_sdk.models.blocks import Block, Option, OptionGroup
@@ -17,12 +17,12 @@ class AsyncAck:
     async def __call__(
         self,
         text: Union[str, dict] = "",  # text: str or whole_response: dict
-        blocks: Optional[List[Union[dict, Block]]] = None,
-        attachments: Optional[List[Union[dict, Attachment]]] = None,
+        blocks: Optional[Sequence[Union[dict, Block]]] = None,
+        attachments: Optional[Sequence[Union[dict, Attachment]]] = None,
         response_type: Optional[str] = None,  # in_channel / ephemeral
         # block_suggestion / dialog_suggestion
-        options: Optional[List[Union[dict, Option]]] = None,
-        option_groups: Optional[List[Union[dict, OptionGroup]]] = None,
+        options: Optional[Sequence[Union[dict, Option]]] = None,
+        option_groups: Optional[Sequence[Union[dict, OptionGroup]]] = None,
         # view_submission
         response_action: Optional[str] = None,  # errors / update / push / clear
         errors: Optional[Dict[str, str]] = None,

--- a/slack_bolt/context/ack/internals.py
+++ b/slack_bolt/context/ack/internals.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union, Any, Dict
+from typing import Optional, Union, Any, Dict, Sequence
 
 from slack_sdk.models.attachments import Attachment
 from slack_sdk.models.blocks import Block, Option, OptionGroup
@@ -12,15 +12,15 @@ from slack_bolt.util.utils import convert_to_dict_list, convert_to_dict
 def _set_response(
     self: Any,
     text_or_whole_response: Union[str, dict] = "",
-    blocks: Optional[List[Union[dict, Block]]] = None,
-    attachments: Optional[List[Union[dict, Attachment]]] = None,
+    blocks: Optional[Sequence[Union[dict, Block]]] = None,
+    attachments: Optional[Sequence[Union[dict, Attachment]]] = None,
     response_type: Optional[str] = None,  # in_channel / ephemeral
     # block_suggestion / dialog_suggestion
-    options: Optional[List[Union[dict, Option]]] = None,
-    option_groups: Optional[List[Union[dict, OptionGroup]]] = None,
+    options: Optional[Sequence[Union[dict, Option]]] = None,
+    option_groups: Optional[Sequence[Union[dict, OptionGroup]]] = None,
     # view_submission
     response_action: Optional[str] = None,
-    errors: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None,
+    errors: Optional[Union[Dict[str, str], Sequence[Dict[str, str]]]] = None,
     view: Optional[Union[dict, View]] = None,
 ) -> BoltResponse:
     if isinstance(text_or_whole_response, str):

--- a/slack_bolt/context/respond/async_respond.py
+++ b/slack_bolt/context/respond/async_respond.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union
+from typing import Optional, Union, Sequence
 
 from slack_sdk.models.attachments import Attachment
 from slack_sdk.models.blocks import Block
@@ -16,8 +16,8 @@ class AsyncRespond:
     async def __call__(
         self,
         text: Union[str, dict] = "",
-        blocks: Optional[List[Union[dict, Block]]] = None,
-        attachments: Optional[List[Union[dict, Attachment]]] = None,
+        blocks: Optional[Sequence[Union[dict, Block]]] = None,
+        attachments: Optional[Sequence[Union[dict, Attachment]]] = None,
         response_type: Optional[str] = None,
         replace_original: Optional[bool] = None,
         delete_original: Optional[bool] = None,

--- a/slack_bolt/context/respond/internals.py
+++ b/slack_bolt/context/respond/internals.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Union, Any
+from typing import Optional, Dict, Union, Any, Sequence
 
 from slack_sdk.models.attachments import Attachment
 from slack_sdk.models.blocks import Block
@@ -8,8 +8,8 @@ from slack_bolt.util.utils import convert_to_dict_list
 
 def _build_message(
     text: str = "",
-    blocks: Optional[List[Union[dict, Block]]] = None,
-    attachments: Optional[List[Union[dict, Attachment]]] = None,
+    blocks: Optional[Sequence[Union[dict, Block]]] = None,
+    attachments: Optional[Sequence[Union[dict, Attachment]]] = None,
     response_type: Optional[str] = None,
     replace_original: Optional[bool] = None,
     delete_original: Optional[bool] = None,

--- a/slack_bolt/context/respond/respond.py
+++ b/slack_bolt/context/respond/respond.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union
+from typing import Optional, Union, Sequence
 
 from slack_sdk.models.attachments import Attachment
 from slack_sdk.models.blocks import Block
@@ -16,8 +16,8 @@ class Respond:
     def __call__(
         self,
         text: Union[str, dict] = "",
-        blocks: Optional[List[Union[dict, Block]]] = None,
-        attachments: Optional[List[Union[dict, Attachment]]] = None,
+        blocks: Optional[Sequence[Union[dict, Block]]] = None,
+        attachments: Optional[Sequence[Union[dict, Attachment]]] = None,
         response_type: Optional[str] = None,
         replace_original: Optional[bool] = None,
         delete_original: Optional[bool] = None,

--- a/slack_bolt/context/say/async_say.py
+++ b/slack_bolt/context/say/async_say.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union, Dict
+from typing import Optional, Union, Dict, Sequence
 
 from slack_bolt.context.say.internals import _can_say
 from slack_sdk.models.attachments import Attachment
@@ -20,8 +20,8 @@ class AsyncSay:
     async def __call__(
         self,
         text: Union[str, dict] = "",
-        blocks: Optional[List[Union[Dict, Block]]] = None,
-        attachments: Optional[List[Union[Dict, Attachment]]] = None,
+        blocks: Optional[Sequence[Union[Dict, Block]]] = None,
+        attachments: Optional[Sequence[Union[Dict, Attachment]]] = None,
         channel: Optional[str] = None,
         thread_ts: Optional[str] = None,
         **kwargs,

--- a/slack_bolt/context/say/say.py
+++ b/slack_bolt/context/say/say.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union, Dict
+from typing import Optional, Union, Dict, Sequence
 
 from slack_sdk import WebClient
 from slack_sdk.models.attachments import Attachment
@@ -21,8 +21,8 @@ class Say:
     def __call__(
         self,
         text: Union[str, dict] = "",
-        blocks: Optional[List[Union[Dict, Block]]] = None,
-        attachments: Optional[List[Union[Dict, Attachment]]] = None,
+        blocks: Optional[Sequence[Union[Dict, Block]]] = None,
+        attachments: Optional[Sequence[Union[Dict, Attachment]]] = None,
         channel: Optional[str] = None,
         thread_ts: Optional[str] = None,
         **kwargs,

--- a/slack_bolt/kwargs_injection/async_utils.py
+++ b/slack_bolt/kwargs_injection/async_utils.py
@@ -1,6 +1,6 @@
 # pytype: skip-file
 import logging
-from typing import Callable, Dict, Optional, List, Any
+from typing import Callable, Dict, Optional, Any, Sequence
 
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
@@ -20,7 +20,7 @@ from slack_bolt.request.payload_utils import (
 def build_async_required_kwargs(
     *,
     logger: logging.Logger,
-    required_arg_names: List[str],
+    required_arg_names: Sequence[str],
     request: AsyncBoltRequest,
     response: Optional[BoltResponse],
     next_func: Callable[[], None] = None,

--- a/slack_bolt/kwargs_injection/utils.py
+++ b/slack_bolt/kwargs_injection/utils.py
@@ -1,6 +1,6 @@
 # pytype: skip-file
 import logging
-from typing import Callable, Dict, Optional, List, Any
+from typing import Callable, Dict, Optional, Any, Sequence
 
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
@@ -20,7 +20,7 @@ from slack_bolt.request.payload_utils import (
 def build_required_kwargs(
     *,
     logger: logging.Logger,
-    required_arg_names: List[str],
+    required_arg_names: Sequence[str],
     request: BoltRequest,
     response: Optional[BoltResponse],
     next_func: Callable[[], None] = None,

--- a/slack_bolt/listener/async_listener.py
+++ b/slack_bolt/listener/async_listener.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod, ABCMeta
-from typing import List, Callable, Awaitable, Tuple, Optional
+from typing import Callable, Awaitable, Tuple, Optional, Sequence
 
 from slack_bolt.listener_matcher.async_listener_matcher import AsyncListenerMatcher
 from slack_bolt.middleware.async_middleware import AsyncMiddleware
@@ -9,10 +9,10 @@ from ..kwargs_injection.async_utils import build_async_required_kwargs
 
 
 class AsyncListener(metaclass=ABCMeta):
-    matchers: List[AsyncListenerMatcher]
-    middleware: List[AsyncMiddleware]
+    matchers: Sequence[AsyncListenerMatcher]
+    middleware: Sequence[AsyncMiddleware]
     ack_function: Callable[..., Awaitable[BoltResponse]]
-    lazy_functions: List[Callable[..., Awaitable[None]]]
+    lazy_functions: Sequence[Callable[..., Awaitable[None]]]
     auto_acknowledgement: bool
 
     async def async_matches(
@@ -61,7 +61,7 @@ class AsyncListener(metaclass=ABCMeta):
 
 import inspect
 from logging import Logger
-from typing import Callable, List, Awaitable
+from typing import Callable, Awaitable
 
 from slack_bolt.listener_matcher.async_listener_matcher import AsyncListenerMatcher
 from slack_bolt.logger import get_bolt_app_logger
@@ -73,11 +73,11 @@ from slack_bolt.response import BoltResponse
 class AsyncCustomListener(AsyncListener):
     app_name: str
     ack_function: Callable[..., Awaitable[Optional[BoltResponse]]]
-    lazy_functions: List[Callable[..., Awaitable[None]]]
-    matchers: List[AsyncListenerMatcher]
-    middleware: List[AsyncMiddleware]
+    lazy_functions: Sequence[Callable[..., Awaitable[None]]]
+    matchers: Sequence[AsyncListenerMatcher]
+    middleware: Sequence[AsyncMiddleware]
     auto_acknowledgement: bool
-    arg_names: List[str]
+    arg_names: Sequence[str]
     logger: Logger
 
     def __init__(
@@ -85,9 +85,9 @@ class AsyncCustomListener(AsyncListener):
         *,
         app_name: str,
         ack_function: Callable[..., Awaitable[Optional[BoltResponse]]],
-        lazy_functions: List[Callable[..., Awaitable[None]]],
-        matchers: List[AsyncListenerMatcher],
-        middleware: List[AsyncMiddleware],
+        lazy_functions: Sequence[Callable[..., Awaitable[None]]],
+        matchers: Sequence[AsyncListenerMatcher],
+        middleware: Sequence[AsyncMiddleware],
         auto_acknowledgement: bool = False,
     ):
         self.app_name = app_name

--- a/slack_bolt/listener/custom_listener.py
+++ b/slack_bolt/listener/custom_listener.py
@@ -1,6 +1,6 @@
 import inspect
 from logging import Logger
-from typing import Callable, List, Optional
+from typing import Callable, Optional, Sequence
 
 from slack_bolt.kwargs_injection import build_required_kwargs
 from slack_bolt.listener_matcher import ListenerMatcher
@@ -14,11 +14,11 @@ from ..middleware import Middleware
 class CustomListener(Listener):
     app_name: str
     ack_function: Callable[..., Optional[BoltResponse]]
-    lazy_functions: List[Callable[..., None]]
-    matchers: List[ListenerMatcher]
-    middleware: List[Middleware]  # type: ignore
+    lazy_functions: Sequence[Callable[..., None]]
+    matchers: Sequence[ListenerMatcher]
+    middleware: Sequence[Middleware]  # type: ignore
     auto_acknowledgement: bool
-    arg_names: List[str]
+    arg_names: Sequence[str]
     logger: Logger
 
     def __init__(
@@ -26,9 +26,9 @@ class CustomListener(Listener):
         *,
         app_name: str,
         ack_function: Callable[..., Optional[BoltResponse]],
-        lazy_functions: List[Callable[..., None]],
-        matchers: List[ListenerMatcher],
-        middleware: List[Middleware],  # type: ignore
+        lazy_functions: Sequence[Callable[..., None]],
+        matchers: Sequence[ListenerMatcher],
+        middleware: Sequence[Middleware],  # type: ignore
         auto_acknowledgement: bool = False,
     ):
         self.app_name = app_name

--- a/slack_bolt/listener/listener.py
+++ b/slack_bolt/listener/listener.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod, ABCMeta
-from typing import List, Callable, Tuple
+from typing import Callable, Tuple, Sequence
 
 from slack_bolt.listener_matcher import ListenerMatcher
 from slack_bolt.middleware import Middleware
@@ -8,10 +8,10 @@ from slack_bolt.response import BoltResponse
 
 
 class Listener(metaclass=ABCMeta):
-    matchers: List[ListenerMatcher]
-    middleware: List[Middleware]  # type: ignore
+    matchers: Sequence[ListenerMatcher]
+    middleware: Sequence[Middleware]  # type: ignore
     ack_function: Callable[..., BoltResponse]
-    lazy_functions: List[Callable[..., None]]
+    lazy_functions: Sequence[Callable[..., None]]
     auto_acknowledgement: bool
 
     def matches(self, *, req: BoltRequest, resp: BoltResponse,) -> bool:

--- a/slack_bolt/listener_matcher/async_listener_matcher.py
+++ b/slack_bolt/listener_matcher/async_listener_matcher.py
@@ -18,7 +18,7 @@ class AsyncListenerMatcher(metaclass=ABCMeta):
 
 import inspect
 from logging import Logger
-from typing import Callable, Awaitable, List
+from typing import Callable, Awaitable, Sequence
 
 from slack_bolt.kwargs_injection.async_utils import build_async_required_kwargs
 from slack_bolt.logger import get_bolt_app_logger
@@ -29,7 +29,7 @@ from slack_bolt.response import BoltResponse
 class AsyncCustomListenerMatcher(AsyncListenerMatcher):
     app_name: str
     func: Callable[..., Awaitable[bool]]
-    arg_names: List[str]
+    arg_names: Sequence[str]
     logger: Logger
 
     def __init__(self, *, app_name: str, func: Callable[..., Awaitable[bool]]):

--- a/slack_bolt/listener_matcher/custom_listener_matcher.py
+++ b/slack_bolt/listener_matcher/custom_listener_matcher.py
@@ -1,6 +1,6 @@
 import inspect
 from logging import Logger
-from typing import Callable, List
+from typing import Callable, Sequence
 
 from slack_bolt.kwargs_injection import build_required_kwargs
 from slack_bolt.logger import get_bolt_app_logger
@@ -12,7 +12,7 @@ from .listener_matcher import ListenerMatcher
 class CustomListenerMatcher(ListenerMatcher):
     app_name: str
     func: Callable[..., bool]
-    arg_names: List[str]
+    arg_names: Sequence[str]
     logger: Logger
 
     def __init__(self, *, app_name: str, func: Callable[..., bool]):

--- a/slack_bolt/middleware/async_custom_middleware.py
+++ b/slack_bolt/middleware/async_custom_middleware.py
@@ -1,6 +1,6 @@
 import inspect
 from logging import Logger
-from typing import Callable, Awaitable, List, Any
+from typing import Callable, Awaitable, Any, Sequence
 
 from slack_bolt.kwargs_injection.async_utils import build_async_required_kwargs
 from slack_bolt.logger import get_bolt_app_logger
@@ -12,7 +12,7 @@ from .async_middleware import AsyncMiddleware
 class AsyncCustomMiddleware(AsyncMiddleware):
     app_name: str
     func: Callable[..., Awaitable[Any]]
-    arg_names: List[str]
+    arg_names: Sequence[str]
     logger: Logger
 
     def __init__(self, *, app_name: str, func: Callable[..., Awaitable[Any]]):

--- a/slack_bolt/middleware/custom_middleware.py
+++ b/slack_bolt/middleware/custom_middleware.py
@@ -1,6 +1,6 @@
 import inspect
 from logging import Logger
-from typing import Callable, List, Any
+from typing import Callable, Any, Sequence
 
 from slack_bolt.kwargs_injection import build_required_kwargs
 from slack_bolt.logger import get_bolt_app_logger
@@ -12,7 +12,7 @@ from .middleware import Middleware
 class CustomMiddleware(Middleware):
     app_name: str
     func: Callable[..., Any]
-    arg_names: List[str]
+    arg_names: Sequence[str]
     logger: Logger
 
     def __init__(self, *, app_name: str, func: Callable):

--- a/slack_bolt/oauth/async_oauth_flow.py
+++ b/slack_bolt/oauth/async_oauth_flow.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from logging import Logger
-from typing import Optional, List, Dict, Callable, Awaitable
+from typing import Optional, Dict, Callable, Awaitable, Sequence
 
 from slack_bolt.error import BoltError
 from slack_bolt.oauth.async_callback_options import (
@@ -92,8 +92,8 @@ class AsyncOAuthFlow:
         authorization_url: Optional[str] = None,
         client_id: Optional[str] = None,  # required
         client_secret: Optional[str] = None,  # required
-        scopes: Optional[List[str]] = None,
-        user_scopes: Optional[List[str]] = None,
+        scopes: Optional[Sequence[str]] = None,
+        user_scopes: Optional[Sequence[str]] = None,
         redirect_uri: Optional[str] = None,
         # Handler configuration
         install_path: Optional[str] = None,

--- a/slack_bolt/oauth/async_oauth_settings.py
+++ b/slack_bolt/oauth/async_oauth_settings.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from logging import Logger
-from typing import List, Optional
+from typing import Optional, Sequence
 
 from slack_sdk.oauth import (
     OAuthStateUtils,
@@ -27,8 +27,8 @@ class AsyncOAuthSettings:
     # OAuth flow parameters/credentials
     client_id: str
     client_secret: str
-    scopes: Optional[List[str]]
-    user_scopes: Optional[List[str]]
+    scopes: Optional[Sequence[str]]
+    user_scopes: Optional[Sequence[str]]
     redirect_uri: Optional[str]
     # Handler configuration
     install_path: str
@@ -57,8 +57,8 @@ class AsyncOAuthSettings:
         # OAuth flow parameters/credentials
         client_id: Optional[str] = None,  # required
         client_secret: Optional[str] = None,  # required
-        scopes: Optional[List[str]] = None,
-        user_scopes: Optional[List[str]] = None,
+        scopes: Optional[Sequence[str]] = None,
+        user_scopes: Optional[Sequence[str]] = None,
         redirect_uri: Optional[str] = None,
         # Handler configuration
         install_path: str = "/slack/install",

--- a/slack_bolt/oauth/oauth_flow.py
+++ b/slack_bolt/oauth/oauth_flow.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from logging import Logger
-from typing import Optional, List, Dict, Callable
+from typing import Optional, Dict, Callable, Sequence
 
 from slack_bolt.error import BoltError
 from slack_bolt.oauth.callback_options import (
@@ -91,8 +91,8 @@ class OAuthFlow:
         # OAuth flow parameters/credentials
         client_id: Optional[str] = None,  # required
         client_secret: Optional[str] = None,  # required
-        scopes: Optional[List[str]] = None,
-        user_scopes: Optional[List[str]] = None,
+        scopes: Optional[Sequence[str]] = None,
+        user_scopes: Optional[Sequence[str]] = None,
         redirect_uri: Optional[str] = None,
         # Handler configuration
         install_path: Optional[str] = None,

--- a/slack_bolt/oauth/oauth_settings.py
+++ b/slack_bolt/oauth/oauth_settings.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from logging import Logger
-from typing import List, Optional
+from typing import Optional, Sequence
 
 from slack_sdk.oauth import (
     OAuthStateStore,
@@ -22,8 +22,8 @@ class OAuthSettings:
     # OAuth flow parameters/credentials
     client_id: str
     client_secret: str
-    scopes: Optional[List[str]]
-    user_scopes: Optional[List[str]]
+    scopes: Optional[Sequence[str]]
+    user_scopes: Optional[Sequence[str]]
     redirect_uri: Optional[str]
     # Handler configuration
     install_path: str
@@ -52,8 +52,8 @@ class OAuthSettings:
         # OAuth flow parameters/credentials
         client_id: Optional[str] = None,  # required
         client_secret: Optional[str] = None,  # required
-        scopes: Optional[List[str]] = None,
-        user_scopes: Optional[List[str]] = None,
+        scopes: Optional[Sequence[str]] = None,
+        user_scopes: Optional[Sequence[str]] = None,
         redirect_uri: Optional[str] = None,
         # Handler configuration
         install_path: str = "/slack/install",

--- a/slack_bolt/request/async_request.py
+++ b/slack_bolt/request/async_request.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List, Union, Any
+from typing import Dict, Optional, Union, Any, Sequence
 
 from slack_bolt.context.async_context import AsyncBoltContext
 from slack_bolt.request.async_internals import build_async_context
@@ -13,8 +13,8 @@ from slack_bolt.request.internals import (
 class AsyncBoltRequest:
     raw_body: str
     body: Dict[str, Any]
-    query: Dict[str, List[str]]
-    headers: Dict[str, List[str]]
+    query: Dict[str, Sequence[str]]
+    headers: Dict[str, Sequence[str]]
     content_type: Optional[str]
     context: AsyncBoltContext
     lazy_only: bool
@@ -24,9 +24,8 @@ class AsyncBoltRequest:
         self,
         *,
         body: str,
-        query: Optional[Union[str, Dict[str, str], Dict[str, List[str]]]] = None,
-        # many framework use Dict[str, str] but the reality is Dict[str, List[str]]
-        headers: Optional[Dict[str, Union[str, List[str]]]] = None,
+        query: Optional[Union[str, Dict[str, str], Dict[str, Sequence[str]]]] = None,
+        headers: Optional[Dict[str, Union[str, Sequence[str]]]] = None,
         context: Optional[Dict[str, str]] = None,
     ):
         """Request to a Bolt app.

--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -1,19 +1,19 @@
 import json
-from typing import Optional, Dict, Union, List, Any
+from typing import Optional, Dict, Union, Any, Sequence
 from urllib.parse import parse_qsl, parse_qs
 
 from slack_bolt.context import BoltContext
 
 
 def parse_query(
-    query: Optional[Union[str, Dict[str, str], Dict[str, List[str]]]]
-) -> Dict[str, List[str]]:
+    query: Optional[Union[str, Dict[str, str], Dict[str, Sequence[str]]]]
+) -> Dict[str, Sequence[str]]:
     if query is None:
         return {}
     elif isinstance(query, str):
         return parse_qs(query)
     elif isinstance(query, dict) or hasattr(query, "items"):
-        result: Dict[str, List[str]] = {}
+        result: Dict[str, Sequence[str]] = {}
         for name, value in query.items():
             if isinstance(value, list):
                 result[name] = value
@@ -128,7 +128,7 @@ def build_context(context: BoltContext, payload: Dict[str, Any],) -> BoltContext
     return context
 
 
-def extract_content_type(headers: Dict[str, List[str]]) -> Optional[str]:
+def extract_content_type(headers: Dict[str, Sequence[str]]) -> Optional[str]:
     content_type: Optional[str] = headers.get("content-type", [None])[0]
     if content_type:
         return content_type.split(";")[0]
@@ -136,9 +136,9 @@ def extract_content_type(headers: Dict[str, List[str]]) -> Optional[str]:
 
 
 def build_normalized_headers(
-    headers: Optional[Dict[str, Union[str, List[str]]]]
-) -> Dict[str, List[str]]:
-    normalized_headers: Dict[str, List[str]] = {}
+    headers: Optional[Dict[str, Union[str, Sequence[str]]]]
+) -> Dict[str, Sequence[str]]:
+    normalized_headers: Dict[str, Sequence[str]] = {}
     if headers is not None:
         for key, value in headers.items():
             normalized_name = key.lower()

--- a/slack_bolt/request/request.py
+++ b/slack_bolt/request/request.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List, Union, Any
+from typing import Dict, Optional, Union, Any, Sequence
 
 from slack_bolt.context.context import BoltContext
 from slack_bolt.request.internals import (
@@ -12,8 +12,8 @@ from slack_bolt.request.internals import (
 
 class BoltRequest:
     raw_body: str
-    query: Dict[str, List[str]]
-    headers: Dict[str, List[str]]
+    query: Dict[str, Sequence[str]]
+    headers: Dict[str, Sequence[str]]
     content_type: Optional[str]
     body: Dict[str, Any]
     context: BoltContext
@@ -24,9 +24,8 @@ class BoltRequest:
         self,
         *,
         body: str,
-        query: Optional[Union[str, Dict[str, str], Dict[str, List[str]]]] = None,
-        # many framework use Dict[str, str] but the reality is Dict[str, List[str]]
-        headers: Optional[Dict[str, Union[str, List[str]]]] = None,
+        query: Optional[Union[str, Dict[str, str], Dict[str, Sequence[str]]]] = None,
+        headers: Optional[Dict[str, Union[str, Sequence[str]]]] = None,
         context: Optional[Dict[str, str]] = None,
     ):
         """Request to a Bolt app.

--- a/slack_bolt/response/response.py
+++ b/slack_bolt/response/response.py
@@ -1,19 +1,19 @@
 import json
 from http.cookies import SimpleCookie
-from typing import Union, Dict, List, Optional
+from typing import Union, Dict, Optional, Sequence
 
 
 class BoltResponse:
     status: int
     body: str
-    headers: Dict[str, List[str]]
+    headers: Dict[str, Sequence[str]]
 
     def __init__(
         self,
         *,
         status: int,
         body: Union[str, dict] = "",
-        headers: Optional[Dict[str, Union[str, List[str]]]] = None,
+        headers: Optional[Dict[str, Union[str, Sequence[str]]]] = None,
     ):
         """The response from a Bolt app.
 
@@ -23,7 +23,7 @@ class BoltResponse:
         """
         self.status: int = status
         self.body: str = json.dumps(body) if isinstance(body, dict) else body
-        self.headers: Dict[str, List[str]] = {}
+        self.headers: Dict[str, Sequence[str]] = {}
         if headers is not None:
             for name, value in headers.items():
                 if value is None:
@@ -47,7 +47,7 @@ class BoltResponse:
     def first_headers_without_set_cookie(self) -> Dict[str, str]:
         return {k: list(v)[0] for k, v in self.headers.items() if k != "set-cookie"}
 
-    def cookies(self) -> List[SimpleCookie]:
+    def cookies(self) -> Sequence[SimpleCookie]:
         header_values = self.headers.get("set-cookie", [])
         return [self._to_simple_cookie(v) for v in header_values]
 

--- a/slack_bolt/util/utils.py
+++ b/slack_bolt/util/utils.py
@@ -1,6 +1,6 @@
 import copy
 import sys
-from typing import Optional, Union, Dict, List, Any
+from typing import Optional, Union, Dict, Any, Sequence
 
 from slack_sdk import WebClient
 from slack_sdk.models import JsonObject
@@ -13,7 +13,7 @@ def create_web_client(token: Optional[str] = None) -> WebClient:
     return WebClient(token=token, user_agent_prefix=f"Bolt/{bolt_version}",)
 
 
-def convert_to_dict_list(objects: List[Union[Dict, JsonObject]]) -> List[Dict]:
+def convert_to_dict_list(objects: Sequence[Union[Dict, JsonObject]]) -> Sequence[Dict]:
     return [convert_to_dict(elm) for elm in objects]
 
 

--- a/slack_bolt/workflows/step/async_step.py
+++ b/slack_bolt/workflows/step/async_step.py
@@ -1,4 +1,4 @@
-from typing import Callable, Union, Optional, Awaitable, List
+from typing import Callable, Union, Optional, Awaitable, Sequence
 
 from slack_bolt.context.async_context import AsyncBoltContext
 from slack_bolt.listener.async_listener import AsyncListener, AsyncCustomListener
@@ -29,13 +29,13 @@ class AsyncWorkflowStep:
         *,
         callback_id: str,
         edit: Union[
-            Callable[..., Awaitable[BoltResponse]], AsyncListener, List[Callable]
+            Callable[..., Awaitable[BoltResponse]], AsyncListener, Sequence[Callable]
         ],
         save: Union[
-            Callable[..., Awaitable[BoltResponse]], AsyncListener, List[Callable]
+            Callable[..., Awaitable[BoltResponse]], AsyncListener, Sequence[Callable]
         ],
         execute: Union[
-            Callable[..., Awaitable[BoltResponse]], AsyncListener, List[Callable]
+            Callable[..., Awaitable[BoltResponse]], AsyncListener, Sequence[Callable]
         ],
         app_name: Optional[str] = None,
     ):
@@ -75,7 +75,9 @@ class AsyncWorkflowStep:
             raise ValueError(f"Invalid `{name}` listener")
 
     @classmethod
-    def _build_matchers(cls, name: str, callback_id: str) -> List[AsyncListenerMatcher]:
+    def _build_matchers(
+        cls, name: str, callback_id: str
+    ) -> Sequence[AsyncListenerMatcher]:
         if name == "edit":
             return [workflow_step_edit(callback_id, asyncio=True)]
         elif name == "save":
@@ -86,7 +88,9 @@ class AsyncWorkflowStep:
             raise ValueError(f"Invalid name {name}")
 
     @classmethod
-    def _build_middleware(cls, name: str, callback_id: str) -> List[AsyncMiddleware]:
+    def _build_middleware(
+        cls, name: str, callback_id: str
+    ) -> Sequence[AsyncMiddleware]:
         if name == "edit":
             return [_build_edit_listener_middleware(callback_id)]
         elif name == "save":

--- a/slack_bolt/workflows/step/step.py
+++ b/slack_bolt/workflows/step/step.py
@@ -1,4 +1,4 @@
-from typing import Callable, Union, Optional, List
+from typing import Callable, Union, Optional, Sequence
 
 from slack_bolt.context import BoltContext
 from slack_bolt.listener import Listener, CustomListener
@@ -27,9 +27,15 @@ class WorkflowStep:
         self,
         *,
         callback_id: str,
-        edit: Union[Callable[..., Optional[BoltResponse]], Listener, List[Callable]],
-        save: Union[Callable[..., Optional[BoltResponse]], Listener, List[Callable]],
-        execute: Union[Callable[..., Optional[BoltResponse]], Listener, List[Callable]],
+        edit: Union[
+            Callable[..., Optional[BoltResponse]], Listener, Sequence[Callable]
+        ],
+        save: Union[
+            Callable[..., Optional[BoltResponse]], Listener, Sequence[Callable]
+        ],
+        execute: Union[
+            Callable[..., Optional[BoltResponse]], Listener, Sequence[Callable]
+        ],
         app_name: Optional[str] = None,
     ):
         self.callback_id = callback_id
@@ -44,7 +50,7 @@ class WorkflowStep:
         callback_id: str,
         app_name: str,
         listener: Union[
-            Callable[..., Optional[BoltResponse]], Listener, List[Callable]
+            Callable[..., Optional[BoltResponse]], Listener, Sequence[Callable]
         ],
         name: str,
     ) -> Listener:
@@ -74,7 +80,7 @@ class WorkflowStep:
             raise ValueError(f"Invalid `{name}` listener")
 
     @classmethod
-    def _build_matchers(cls, name: str, callback_id: str) -> List[ListenerMatcher]:
+    def _build_matchers(cls, name: str, callback_id: str) -> Sequence[ListenerMatcher]:
         if name == "edit":
             return [workflow_step_edit(callback_id)]
         elif name == "save":
@@ -85,7 +91,7 @@ class WorkflowStep:
             raise ValueError(f"Invalid name {name}")
 
     @classmethod
-    def _build_middleware(cls, name: str, callback_id: str) -> List[Middleware]:
+    def _build_middleware(cls, name: str, callback_id: str) -> Sequence[Middleware]:
         if name == "edit":
             return [_build_edit_listener_middleware(callback_id)]
         elif name == "save":

--- a/slack_bolt/workflows/step/utilities/async_configure.py
+++ b/slack_bolt/workflows/step/utilities/async_configure.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Optional, Union, Sequence
 
 from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.models.blocks import Block
@@ -11,7 +11,7 @@ class AsyncConfigure:
         self.body = body
 
     async def __call__(
-        self, *, blocks: Optional[List[Union[dict, Block]]] = None,
+        self, *, blocks: Optional[Sequence[Union[dict, Block]]] = None,
     ) -> None:
         await self.client.views_open(
             trigger_id=self.body["trigger_id"],

--- a/slack_bolt/workflows/step/utilities/configure.py
+++ b/slack_bolt/workflows/step/utilities/configure.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Optional, Union, Sequence
 
 from slack_sdk.web import WebClient
 from slack_sdk.models.blocks import Block
@@ -11,7 +11,7 @@ class Configure:
         self.body = body
 
     def __call__(
-        self, *, blocks: Optional[List[Union[dict, Block]]] = None, **kwargs
+        self, *, blocks: Optional[Sequence[Union[dict, Block]]] = None, **kwargs
     ) -> None:
         self.client.views_open(
             trigger_id=self.body["trigger_id"],


### PR DESCRIPTION
This pull request updates the type hints in this library. In many cases, using `Sequence` over `List` is suitable as most methods do not intentionally modify given `List` (=mutable) objects. This is related to https://github.com/slackapi/python-slack-sdk/pull/869

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
