### PR TITLE
Fix CI build failures with pytype 2020.11.3 in Python 3.8+

### DIFF
--- a/scripts/install_all_and_run_tests.sh
+++ b/scripts/install_all_and_run_tests.sh
@@ -22,5 +22,6 @@ else
     pip install -e ".[adapter]" && \
     black slack_bolt/ tests/ && \
     pytest && \
+    pip install -U pytype && \
     pytype slack_bolt/
 fi

--- a/scripts/run_pytype.sh
+++ b/scripts/run_pytype.sh
@@ -2,5 +2,7 @@
 # ./scripts/run_pytype.sh
 
 script_dir=$(dirname $0)
-cd ${script_dir}/..
-pip install -e ".[adapter]" && pytype slack_bolt/
+cd ${script_dir}/.. && \
+  pip install -e ".[adapter]" && \
+  pip install -U pytype && \
+  pytype slack_bolt/

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -20,6 +20,7 @@ else
     black slack_bolt/ tests/ \
       && pytest \
       && pip install -e ".[adapter]" \
+      && pip install -U pytype \
       && pytype slack_bolt/
   else
     black slack_bolt/ tests/ && pytest

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ test_dependencies = [
     "pytest-asyncio<1",  # for async
     "aiohttp>=3,<4",  # for async
     "black==19.10b0",
-    "pytype",
 ]
 
 setuptools.setup(


### PR DESCRIPTION
Loading pytype in `python setup.py test` started failing since version 2020.11.3. In CI builds, pytype is manually loaded so that we can safely remove from the from tests_require.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
