### PR TITLE
Fix Events API handling issue in shared channels

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -766,7 +766,20 @@ class App:
     def _init_context(self, req: BoltRequest):
         req.context["logger"] = get_bolt_app_logger(self.name)
         req.context["token"] = self._token
-        req.context["client"] = self._client
+        if self._token is not None:
+            # This WebClient instance can be safely singleton
+            req.context["client"] = self._client
+        else:
+            # Set a new dedicated instance for this request
+            client_per_request: WebClient = WebClient(
+                token=None,  # the token will be set later
+                base_url=self._client.base_url,
+                timeout=self._client.timeout,
+                ssl=self._client.ssl,
+                proxy=self._client.proxy,
+                headers=self._client.headers,
+            )
+            req.context["client"] = client_per_request
 
     @staticmethod
     def _to_listener_functions(

--- a/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
@@ -9,7 +9,6 @@ from .async_internals import _build_error_response, _is_no_auth_required
 from .internals import _is_no_auth_test_call_required
 from ...authorization import AuthorizeResult
 from ...authorization.async_authorize import AsyncAuthorize
-from ...util.async_utils import create_async_web_client
 
 
 class AsyncMultiTeamsAuthorization(AsyncAuthorization):
@@ -54,7 +53,9 @@ class AsyncMultiTeamsAuthorization(AsyncAuthorization):
                 req.context.set_authorize_result(auth_result)
                 token = auth_result.bot_token or auth_result.user_token
                 req.context["token"] = token
-                req.context["client"] = create_async_web_client(token)
+                # As AsyncApp#_init_context() generates a new AsyncWebClient for this request,
+                # it's safe to modify this instance.
+                req.context.client.token = token
                 return await next()
             else:
                 # Just in case

--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -53,6 +53,10 @@ def extract_enterprise_id(payload: Dict[str, Any]) -> Optional[str]:
             return org
         elif "id" in org:
             return org.get("id")  # type: ignore
+    if "authorizations" in payload and len(payload["authorizations"]) > 0:
+        # To make Events API handling functioning also for shared channels,
+        # we should use .authorizations[0].enterprise_id over .enterprise_id
+        return extract_enterprise_id(payload["authorizations"][0])
     if "enterprise_id" in payload:
         return payload.get("enterprise_id")
     if "team" in payload and "enterprise_id" in payload["team"]:
@@ -70,6 +74,10 @@ def extract_team_id(payload: Dict[str, Any]) -> Optional[str]:
             return team
         elif team and "id" in team:
             return team.get("id")
+    if "authorizations" in payload and len(payload["authorizations"]) > 0:
+        # To make Events API handling functioning also for shared channels,
+        # we should use .authorizations[0].team_id over .team_id
+        return extract_team_id(payload["authorizations"][0])
     if "team_id" in payload:
         return payload.get("team_id")
     if "event" in payload:
@@ -110,21 +118,21 @@ def extract_channel_id(payload: Dict[str, Any]) -> Optional[str]:
     return None
 
 
-def build_context(context: BoltContext, payload: Dict[str, Any],) -> BoltContext:
-    enterprise_id = extract_enterprise_id(payload)
+def build_context(context: BoltContext, body: Dict[str, Any]) -> BoltContext:
+    enterprise_id = extract_enterprise_id(body)
     if enterprise_id:
         context["enterprise_id"] = enterprise_id
-    team_id = extract_team_id(payload)
+    team_id = extract_team_id(body)
     if team_id:
         context["team_id"] = team_id
-    user_id = extract_user_id(payload)
+    user_id = extract_user_id(body)
     if user_id:
         context["user_id"] = user_id
-    channel_id = extract_channel_id(payload)
+    channel_id = extract_channel_id(body)
     if channel_id:
         context["channel_id"] = channel_id
-    if "response_url" in payload:
-        context["response_url"] = payload["response_url"]
+    if "response_url" in body:
+        context["response_url"] = body["response_url"]
     return context
 
 

--- a/tests/scenario_tests/test_events_shared_channels.py
+++ b/tests/scenario_tests/test_events_shared_channels.py
@@ -1,0 +1,514 @@
+import json
+from time import time, sleep
+
+from slack_sdk.signature import SignatureVerifier
+from slack_sdk.web import WebClient
+
+from slack_bolt import App, BoltRequest, Say
+from slack_bolt.authorization import AuthorizeResult
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+valid_token = "xoxb-valid"
+
+
+def authorize(enterprise_id, team_id, client: WebClient):
+    assert enterprise_id == "E_INSTALLED"
+    assert team_id == "T_INSTALLED"
+    auth_test = client.auth_test(token=valid_token)
+    return AuthorizeResult.from_auth_test_response(
+        auth_test_response=auth_test, bot_token=valid_token,
+    )
+
+
+class TestEventsSharedChannels:
+    signing_secret = "secret"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client: WebClient = WebClient(
+        token=None, base_url=mock_api_server_base_url,
+    )
+
+    def setup_method(self):
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body, timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        return {
+            "content-type": ["application/json"],
+            "x-slack-signature": [self.generate_signature(body, timestamp)],
+            "x-slack-request-timestamp": [timestamp],
+        }
+
+    valid_event_body = {
+        "token": "verification_token",
+        "team_id": "T_INSTALLED",
+        "enterprise_id": "E_INSTALLED",
+        "api_app_id": "A111",
+        "event": {
+            "client_msg_id": "9cbd4c5b-7ddf-4ede-b479-ad21fca66d63",
+            "type": "app_mention",
+            "text": "<@W111> Hi there!",
+            "user": "W222",
+            "ts": "1595926230.009600",
+            "team": "T_INSTALLED",
+            "channel": "C111",
+            "event_ts": "1595926230.009600",
+        },
+        "type": "event_callback",
+        "event_id": "Ev111",
+        "event_time": 1595926230,
+        "authorizations": [
+            {
+                "enterprise_id": "E_INSTALLED",
+                "team_id": "T_INSTALLED",
+                "user_id": "W111",
+                "is_bot": True,
+                "is_enterprise_install": False,
+            }
+        ],
+    }
+
+    def test_mock_server_is_running(self):
+        resp = self.web_client.api_test(token=valid_token)
+        assert resp != None
+
+    def test_middleware(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+
+        @app.event("app_mention")
+        def handle_app_mention(body, say: Say, payload, event):
+            assert body == self.valid_event_body
+            assert body["event"] == payload
+            assert payload == event
+            say("What's up?")
+
+        timestamp, body = str(int(time())), json.dumps(self.valid_event_body)
+        request: BoltRequest = BoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+        sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests["/chat.postMessage"] == 1
+
+    def test_middleware_skip(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+
+        def skip_middleware(req, resp, next):
+            # return next()
+            pass
+
+        @app.event("app_mention", middleware=[skip_middleware])
+        def handle_app_mention(body, logger, payload, event):
+            assert body["event"] == payload
+            assert payload == event
+            logger.info(payload)
+
+        timestamp, body = str(int(time())), json.dumps(self.valid_event_body)
+        request: BoltRequest = BoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = app.dispatch(request)
+        assert response.status == 404
+        assert self.mock_received_requests["/auth.test"] == 1
+
+    valid_reaction_added_body = {
+        "token": "verification_token",
+        "team_id": "T_SOURCE",
+        "enterprise_id": "E_SOURCE",
+        "api_app_id": "A111",
+        "event": {
+            "type": "reaction_added",
+            "user": "W111",
+            "item": {"type": "message", "channel": "C111", "ts": "1599529504.000400"},
+            "reaction": "heart_eyes",
+            "item_user": "W111",
+            "event_ts": "1599616881.000800",
+        },
+        "type": "event_callback",
+        "event_id": "Ev111",
+        "event_time": 1599616881,
+        "authorizations": [
+            {
+                "enterprise_id": "E_INSTALLED",
+                "team_id": "T_INSTALLED",
+                "user_id": "W111",
+                "is_bot": True,
+                "is_enterprise_install": False,
+            }
+        ],
+    }
+
+    def test_reaction_added(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+
+        @app.event("reaction_added")
+        def handle_app_mention(body, say, payload, event):
+            assert body == self.valid_reaction_added_body
+            assert body["event"] == payload
+            assert payload == event
+            say("What's up?")
+
+        timestamp, body = str(int(time())), json.dumps(self.valid_reaction_added_body)
+        request: BoltRequest = BoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+        sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests["/chat.postMessage"] == 1
+
+    def test_stable_auto_ack(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+
+        @app.event("reaction_added")
+        def handle_app_mention():
+            raise Exception("Something wrong!")
+
+        for _ in range(10):
+            timestamp, body = (
+                str(int(time())),
+                json.dumps(self.valid_reaction_added_body),
+            )
+            request: BoltRequest = BoltRequest(
+                body=body, headers=self.build_headers(timestamp, body)
+            )
+            response = app.dispatch(request)
+            assert response.status == 200
+
+    def test_self_events(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+
+        event_body = {
+            "token": "verification_token",
+            "team_id": "T_SOURCE",
+            "enterprise_id": "E_SOURCE",
+            "api_app_id": "A111",
+            "event": {
+                "type": "reaction_added",
+                "user": "W23456789",  # bot_user_id
+                "item": {
+                    "type": "message",
+                    "channel": "C111",
+                    "ts": "1599529504.000400",
+                },
+                "reaction": "heart_eyes",
+                "item_user": "W111",
+                "event_ts": "1599616881.000800",
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1599616881,
+            "authorizations": [
+                {
+                    "enterprise_id": "E_INSTALLED",
+                    "team_id": "T_INSTALLED",
+                    "user_id": "W111",
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+        }
+
+        @app.event("reaction_added")
+        def handle_app_mention(say):
+            say("What's up?")
+
+        timestamp, body = str(int(time())), json.dumps(event_body)
+        request: BoltRequest = BoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+        sleep(1)  # wait a bit after auto ack()
+        # The listener should not be executed
+        assert self.mock_received_requests.get("/chat.postMessage") is None
+
+    def test_self_member_join_left_events(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+
+        join_event_body = {
+            "token": "verification_token",
+            "team_id": "T_SOURCE",
+            "enterprise_id": "E_SOURCE",
+            "api_app_id": "A111",
+            "event": {
+                "type": "member_joined_channel",
+                "user": "W23456789",  # bot_user_id
+                "channel": "C111",
+                "channel_type": "C",
+                "team": "T_INSTALLED",
+                "inviter": "U222",
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1599616881,
+            "authorizations": [
+                {
+                    "enterprise_id": "E_INSTALLED",
+                    "team_id": "T_INSTALLED",
+                    "user_id": "W111",
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+        }
+
+        left_event_body = {
+            "token": "verification_token",
+            "team_id": "T_SOURCE",
+            "enterprise_id": "E_SOURCE",
+            "api_app_id": "A111",
+            "event": {
+                "type": "member_left_channel",
+                "user": "W23456789",  # bot_user_id
+                "channel": "C111",
+                "channel_type": "C",
+                "team": "T_INSTALLED",
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1599616881,
+            "authorizations": [
+                {
+                    "enterprise_id": "E_INSTALLED",
+                    "team_id": "T_INSTALLED",
+                    "user_id": "W111",
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+        }
+
+        @app.event("member_joined_channel")
+        def handle_member_joined_channel(say):
+            say("What's up?")
+
+        @app.event("member_left_channel")
+        def handle_member_left_channel(say):
+            say("What's up?")
+
+        timestamp, body = str(int(time())), json.dumps(join_event_body)
+        request: BoltRequest = BoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
+        timestamp, body = str(int(time())), json.dumps(left_event_body)
+        request: BoltRequest = BoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = app.dispatch(request)
+        assert response.status == 200
+
+        sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests["/chat.postMessage"] == 2
+
+    def test_member_join_left_events(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+
+        join_event_body = {
+            "token": "verification_token",
+            "team_id": "T_SOURCE",
+            "enterprise_id": "E_SOURCE",
+            "api_app_id": "A111",
+            "event": {
+                "type": "member_joined_channel",
+                "user": "U999",  # not self
+                "channel": "C111",
+                "channel_type": "C",
+                "team": "T_INSTALLED",
+                "inviter": "U222",
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1599616881,
+            "authorizations": [
+                {
+                    "enterprise_id": "E_INSTALLED",
+                    "team_id": "T_INSTALLED",
+                    "user_id": "W111",
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+        }
+
+        left_event_body = {
+            "token": "verification_token",
+            "team_id": "T_SOURCE",
+            "enterprise_id": "E_SOURCE",
+            "api_app_id": "A111",
+            "event": {
+                "type": "member_left_channel",
+                "user": "U999",  # not self
+                "channel": "C111",
+                "channel_type": "C",
+                "team": "T_INSTALLED",
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1599616881,
+            "authorizations": [
+                {
+                    "enterprise_id": "E_INSTALLED",
+                    "team_id": "T_INSTALLED",
+                    "user_id": "W111",
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+        }
+
+        @app.event("member_joined_channel")
+        def handle_app_mention(say):
+            say("What's up?")
+
+        @app.event("member_left_channel")
+        def handle_app_mention(say):
+            say("What's up?")
+
+        timestamp, body = str(int(time())), json.dumps(join_event_body)
+        request: BoltRequest = BoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
+        timestamp, body = str(int(time())), json.dumps(left_event_body)
+        request: BoltRequest = BoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = app.dispatch(request)
+        assert response.status == 200
+
+        sleep(1)  # wait a bit after auto ack()
+        # the listeners should not be executed
+        assert self.mock_received_requests["/chat.postMessage"] == 2
+
+    def test_uninstallation_and_revokes(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+        app._client = WebClient(
+            token="uninstalled-revoked", base_url=self.mock_api_server_base_url
+        )
+
+        @app.event("app_uninstalled")
+        def handler1(say: Say):
+            say(channel="C111", text="What's up?")
+
+        @app.event("tokens_revoked")
+        def handler2(say: Say):
+            say(channel="C111", text="What's up?")
+
+        app_uninstalled_body = {
+            "token": "verification_token",
+            "team_id": "T_INSTALLED",
+            "enterprise_id": "E_INSTALLED",
+            "api_app_id": "A111",
+            "event": {"type": "app_uninstalled"},
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1599616881,
+            "authorizations": [
+                {
+                    "enterprise_id": "E_INSTALLED",
+                    "team_id": "T_INSTALLED",
+                    "user_id": "W111",
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+        }
+
+        timestamp, body = str(int(time())), json.dumps(app_uninstalled_body)
+        request: BoltRequest = BoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = app.dispatch(request)
+        assert response.status == 200
+
+        tokens_revoked_body = {
+            "token": "verification_token",
+            "team_id": "T_INSTALLED",
+            "enterprise_id": "E_INSTALLED",
+            "api_app_id": "A111",
+            "event": {
+                "type": "tokens_revoked",
+                "tokens": {"oauth": ["UXXXXXXXX"], "bot": ["UXXXXXXXX"]},
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1599616881,
+            "authorizations": [
+                {
+                    "enterprise_id": "E_INSTALLED",
+                    "team_id": "T_INSTALLED",
+                    "user_id": "W111",
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+        }
+
+        timestamp, body = str(int(time())), json.dumps(tokens_revoked_body)
+        request: BoltRequest = BoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = app.dispatch(request)
+        assert response.status == 200
+
+        # this should not be called when we have authorize
+        assert self.mock_received_requests.get("/auth.test") is None
+        sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests["/chat.postMessage"] == 2

--- a/tests/scenario_tests_async/test_events_shared_channels.py
+++ b/tests/scenario_tests_async/test_events_shared_channels.py
@@ -1,0 +1,564 @@
+import asyncio
+import json
+from random import random
+from time import time
+
+import pytest
+from slack_sdk.signature import SignatureVerifier
+from slack_sdk.web.async_client import AsyncWebClient
+
+from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.authorization import AuthorizeResult
+from slack_bolt.context.say.async_say import AsyncSay
+from slack_bolt.request.async_request import AsyncBoltRequest
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+valid_token = "xoxb-valid"
+
+
+async def authorize(enterprise_id, team_id, client: AsyncWebClient):
+    assert enterprise_id == "E_INSTALLED"
+    assert team_id == "T_INSTALLED"
+    auth_test = await client.auth_test(token=valid_token)
+    return AuthorizeResult.from_auth_test_response(
+        auth_test_response=auth_test, bot_token=valid_token,
+    )
+
+
+class TestAsyncEventsSharedChannels:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = AsyncWebClient(token=None, base_url=mock_api_server_base_url)
+
+    @pytest.fixture
+    def event_loop(self):
+        old_os_env = remove_os_env_temporarily()
+        try:
+            setup_mock_web_api_server(self)
+            loop = asyncio.get_event_loop()
+            yield loop
+            loop.close()
+            cleanup_mock_web_api_server(self)
+        finally:
+            restore_os_env(old_os_env)
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body, timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        return {
+            "content-type": ["application/json"],
+            "x-slack-signature": [self.generate_signature(body, timestamp)],
+            "x-slack-request-timestamp": [timestamp],
+        }
+
+    def build_valid_app_mention_request(self) -> AsyncBoltRequest:
+        timestamp, body = str(int(time())), json.dumps(app_mention_body)
+        return AsyncBoltRequest(body=body, headers=self.build_headers(timestamp, body))
+
+    @pytest.mark.asyncio
+    async def test_mock_server_is_running(self):
+        resp = await self.web_client.api_test(token=valid_token)
+        assert resp != None
+
+    @pytest.mark.asyncio
+    async def test_app_mention(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+        app.event("app_mention")(whats_up)
+
+        request = self.build_valid_app_mention_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+        await asyncio.sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests["/chat.postMessage"] == 1
+
+    @pytest.mark.asyncio
+    async def test_process_before_response(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+            process_before_response=True,
+        )
+        app.event("app_mention")(whats_up)
+
+        request = self.build_valid_app_mention_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+        # no sleep here
+        assert self.mock_received_requests["/chat.postMessage"] == 1
+
+    @pytest.mark.asyncio
+    async def test_middleware_skip(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+        app.event("app_mention", middleware=[skip_middleware])(whats_up)
+
+        request = self.build_valid_app_mention_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        assert self.mock_received_requests["/auth.test"] == 1
+
+    @pytest.mark.asyncio
+    async def test_simultaneous_requests(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+        app.event("app_mention")(random_sleeper)
+
+        request = self.build_valid_app_mention_request()
+
+        times = 10
+        tasks = []
+        for i in range(times):
+            tasks.append(asyncio.ensure_future(app.async_dispatch(request)))
+
+        await asyncio.sleep(5)
+        # Verifies all the tasks have been completed with 200 OK
+        assert sum([t.result().status for t in tasks if t.done()]) == 200 * times
+
+        assert self.mock_received_requests["/auth.test"] == times
+        assert self.mock_received_requests["/chat.postMessage"] == times
+
+    def build_valid_reaction_added_request(self) -> AsyncBoltRequest:
+        timestamp, body = str(int(time())), json.dumps(reaction_added_body)
+        return AsyncBoltRequest(body=body, headers=self.build_headers(timestamp, body))
+
+    @pytest.mark.asyncio
+    async def test_reaction_added(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+        app.event("reaction_added")(whats_up)
+
+        request = self.build_valid_reaction_added_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+        await asyncio.sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests["/chat.postMessage"] == 1
+
+    @pytest.mark.asyncio
+    async def test_stable_auto_ack(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+        app.event("reaction_added")(always_failing)
+
+        for _ in range(10):
+            request = self.build_valid_reaction_added_request()
+            response = await app.async_dispatch(request)
+            assert response.status == 200
+
+    @pytest.mark.asyncio
+    async def test_self_events(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+        app.event("reaction_added")(whats_up)
+
+        self_event = {
+            "token": "verification_token",
+            "team_id": "T_SOURCE",
+            "enterprise_id": "E_SOURCE",
+            "api_app_id": "A111",
+            "event": {
+                "type": "reaction_added",
+                "user": "W23456789",  # bot_user_id
+                "item": {
+                    "type": "message",
+                    "channel": "C111",
+                    "ts": "1599529504.000400",
+                },
+                "reaction": "heart_eyes",
+                "item_user": "W111",
+                "event_ts": "1599616881.000800",
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1599616881,
+            "authorizations": [
+                {
+                    "enterprise_id": "E_INSTALLED",
+                    "team_id": "T_INSTALLED",
+                    "user_id": "W111",
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+        }
+        timestamp, body = str(int(time())), json.dumps(self_event)
+        request = AsyncBoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+        await asyncio.sleep(1)  # wait a bit after auto ack()
+        # The listener should not be executed
+        assert self.mock_received_requests.get("/chat.postMessage") is None
+
+    @pytest.mark.asyncio
+    async def test_self_joined_left_events(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+        app.event("reaction_added")(whats_up)
+
+        join_event_body = {
+            "token": "verification_token",
+            "team_id": "T_SOURCE",
+            "enterprise_id": "E_SOURCE",
+            "api_app_id": "A111",
+            "event": {
+                "type": "member_joined_channel",
+                "user": "W23456789",  # bot_user_id
+                "channel": "C111",
+                "channel_type": "C",
+                "team": "T_INSTALLED",
+                "inviter": "U222",
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1599616881,
+            "authorizations": [
+                {
+                    "enterprise_id": "E_INSTALLED",
+                    "team_id": "T_INSTALLED",
+                    "user_id": "W111",
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+        }
+
+        left_event_body = {
+            "token": "verification_token",
+            "team_id": "T_SOURCE",
+            "enterprise_id": "E_SOURCE",
+            "api_app_id": "A111",
+            "event": {
+                "type": "member_left_channel",
+                "user": "W23456789",  # bot_user_id
+                "channel": "C111",
+                "channel_type": "C",
+                "team": "T_INSTALLED",
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1599616881,
+            "authorizations": [
+                {
+                    "enterprise_id": "E_INSTALLED",
+                    "team_id": "T_INSTALLED",
+                    "user_id": "W111",
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+        }
+
+        @app.event("member_joined_channel")
+        async def handle_member_joined_channel(say):
+            await say("What's up?")
+
+        @app.event("member_left_channel")
+        async def handle_member_left_channel(say):
+            await say("What's up?")
+
+        timestamp, body = str(int(time())), json.dumps(join_event_body)
+        request = AsyncBoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
+        timestamp, body = str(int(time())), json.dumps(left_event_body)
+        request = AsyncBoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+
+        await asyncio.sleep(1)  # wait a bit after auto ack()
+        # The listeners should be executed
+        assert self.mock_received_requests.get("/chat.postMessage") == 2
+
+    @pytest.mark.asyncio
+    async def test_joined_left_events(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+        app.event("reaction_added")(whats_up)
+
+        join_event_body = {
+            "token": "verification_token",
+            "team_id": "T_SOURCE",
+            "enterprise_id": "E_SOURCE",
+            "api_app_id": "A111",
+            "event": {
+                "type": "member_joined_channel",
+                "user": "W111",  # other user
+                "channel": "C111",
+                "channel_type": "C",
+                "team": "T_INSTALLED",
+                "inviter": "U222",
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1599616881,
+            "authorizations": [
+                {
+                    "enterprise_id": "E_INSTALLED",
+                    "team_id": "T_INSTALLED",
+                    "user_id": "W111",
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+        }
+
+        left_event_body = {
+            "token": "verification_token",
+            "team_id": "T_SOURCE",
+            "enterprise_id": "E_SOURCE",
+            "api_app_id": "A111",
+            "event": {
+                "type": "member_left_channel",
+                "user": "W111",  # other user
+                "channel": "C111",
+                "channel_type": "C",
+                "team": "T_INSTALLED",
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1599616881,
+            "authorizations": [
+                {
+                    "enterprise_id": "E_INSTALLED",
+                    "team_id": "T_INSTALLED",
+                    "user_id": "W111",
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+        }
+
+        @app.event("member_joined_channel")
+        async def handle_member_joined_channel(say):
+            await say("What's up?")
+
+        @app.event("member_left_channel")
+        async def handle_member_left_channel(say):
+            await say("What's up?")
+
+        timestamp, body = str(int(time())), json.dumps(join_event_body)
+        request = AsyncBoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert self.mock_received_requests["/auth.test"] == 1
+
+        timestamp, body = str(int(time())), json.dumps(left_event_body)
+        request = AsyncBoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+
+        await asyncio.sleep(1)  # wait a bit after auto ack()
+        # The listeners should be executed
+        assert self.mock_received_requests.get("/chat.postMessage") == 2
+
+    @pytest.mark.asyncio
+    async def test_uninstallation_and_revokes(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            authorize=authorize,
+        )
+        app._client = AsyncWebClient(
+            token="uninstalled-revoked", base_url=self.mock_api_server_base_url
+        )
+
+        @app.event("app_uninstalled")
+        async def handler1(say: AsyncSay):
+            await say(channel="C111", text="What's up?")
+
+        @app.event("tokens_revoked")
+        async def handler2(say: AsyncSay):
+            await say(channel="C111", text="What's up?")
+
+        app_uninstalled_body = {
+            "token": "verification_token",
+            "team_id": "T_SOURCE",
+            "enterprise_id": "E_SOURCE",
+            "api_app_id": "A111",
+            "event": {"type": "app_uninstalled"},
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1599616881,
+            "authorizations": [
+                {
+                    "enterprise_id": "E_INSTALLED",
+                    "team_id": "T_INSTALLED",
+                    "user_id": "W111",
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+        }
+
+        timestamp, body = str(int(time())), json.dumps(app_uninstalled_body)
+        request: AsyncBoltRequest = AsyncBoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+
+        tokens_revoked_body = {
+            "token": "verification_token",
+            "team_id": "T_SOURCE",
+            "enterprise_id": "E_SOURCE",
+            "api_app_id": "A111",
+            "event": {
+                "type": "tokens_revoked",
+                "tokens": {"oauth": ["UXXXXXXXX"], "bot": ["UXXXXXXXX"]},
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1599616881,
+            "authorizations": [
+                {
+                    "enterprise_id": "E_INSTALLED",
+                    "team_id": "T_INSTALLED",
+                    "user_id": "W111",
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+        }
+
+        timestamp, body = str(int(time())), json.dumps(tokens_revoked_body)
+        request: AsyncBoltRequest = AsyncBoltRequest(
+            body=body, headers=self.build_headers(timestamp, body)
+        )
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+
+        # AsyncApp doesn't call auth.test when booting
+        assert self.mock_received_requests.get("/auth.test") is None
+        await asyncio.sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests["/chat.postMessage"] == 2
+
+
+app_mention_body = {
+    "token": "verification_token",
+    "team_id": "T_INSTALLED",
+    "enterprise_id": "E_SOURCE",
+    "api_app_id": "A111",
+    "event": {
+        "client_msg_id": "9cbd4c5b-7ddf-4ede-b479-ad21fca66d63",
+        "type": "app_mention",
+        "text": "<@W111> Hi there!",
+        "user": "W222",
+        "ts": "1595926230.009600",
+        "team": "T_INSTALLED",
+        "channel": "C111",
+        "event_ts": "1595926230.009600",
+    },
+    "type": "event_callback",
+    "event_id": "Ev111",
+    "event_time": 1595926230,
+    "authorizations": [
+        {
+            "enterprise_id": "E_INSTALLED",
+            "team_id": "T_INSTALLED",
+            "user_id": "W111",
+            "is_bot": True,
+            "is_enterprise_install": False,
+        }
+    ],
+}
+
+reaction_added_body = {
+    "token": "verification_token",
+    "team_id": "T_SOURCE",
+    "enterprise_id": "E_SOURCE",
+    "api_app_id": "A111",
+    "event": {
+        "type": "reaction_added",
+        "user": "W111",
+        "item": {"type": "message", "channel": "C111", "ts": "1599529504.000400"},
+        "reaction": "heart_eyes",
+        "item_user": "W111",
+        "event_ts": "1599616881.000800",
+    },
+    "type": "event_callback",
+    "event_id": "Ev111",
+    "event_time": 1599616881,
+    "authorizations": [
+        {
+            "enterprise_id": "E_INSTALLED",
+            "team_id": "T_INSTALLED",
+            "user_id": "W111",
+            "is_bot": True,
+            "is_enterprise_install": False,
+        }
+    ],
+}
+
+
+async def random_sleeper(body, say, payload, event):
+    assert body == app_mention_body
+    assert body["event"] == payload
+    assert payload == event
+    seconds = random() + 2  # 2-3 seconds
+    await asyncio.sleep(seconds)
+    await say(f"Sending this message after sleeping for {seconds} seconds")
+
+
+async def whats_up(body, say, payload, event):
+    assert body["event"] == payload
+    assert payload == event
+    await say("What's up?")
+
+
+async def skip_middleware(req, resp, next):
+    # return next()
+    pass
+
+
+async def always_failing():
+    raise Exception("Something wrong!")


### PR DESCRIPTION
This pull request fixes a bug where some Events API handling code (e.g., `message` events) does not properly work in shared channels. All Bolt framework have the same issue. For the details of the issue, refer to  https://github.com/slackapi/java-slack-sdk/issues/629

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
