### PR TITLE
Add v1.0 compatible mode to #148 Org-wide App support

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -33,19 +33,7 @@ jobs:
       run: |
         pip install -e ".[adapter]"
         pytest tests/adapter_tests/
-    - name: Run async tests
-      run: |
-        python_version=`python -V`
-        # TODO: As Python 3.6 works the most stably on GitHub Actions,
-        # we use the version for code coverage and async tests
-        if [ ${python_version:7:3} == "3.6" ]; then
-          pip install -e ".[async]"
-          pip install "pytest-asyncio<1"
-          pytest tests/slack_bolt_async/
-          pytest tests/scenario_tests_async/
-          pytest tests/adapter_tests_async/
-        fi
-    - name: Run pytype verification
+    - name: Run pytype verification (3.8 only)
       run: |
         python_version=`python -V`
         if [ ${python_version:7:3} == "3.8" ]; then
@@ -53,8 +41,7 @@ jobs:
           pip install -e ".[adapter]"
           pip install "pytype" && pytype slack_bolt/
         fi
-
-    - name: Run all tests for codecov
+    - name: Run all tests for codecov (3.6 only)
       run: |
         python_version=`python -V`
         # TODO: As Python 3.6 works the most stably on GitHub Actions,

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -20,7 +20,7 @@ else
     black slack_bolt/ tests/ \
       && pytest \
       && pip install -e ".[adapter]" \
-      && pip install -U pytype \
+      && pip install -U pip setuptools wheel pytype \
       && pytype slack_bolt/
   else
     black slack_bolt/ tests/ && pytest

--- a/slack_bolt/adapter/aws_lambda/lambda_s3_oauth_flow.py
+++ b/slack_bolt/adapter/aws_lambda/lambda_s3_oauth_flow.py
@@ -62,7 +62,9 @@ class LambdaS3OAuthFlow(OAuthFlow):
         # the settings may already have pre-defined authorize.
         # In this case, the /slack/events endpoint doesn't work along with the OAuth flow.
         settings.authorize = InstallationStoreAuthorize(
-            logger=logger, installation_store=settings.installation_store
+            logger=logger,
+            installation_store=settings.installation_store,
+            bot_only=settings.installation_store_bot_only,
         )
 
         OAuthFlow.__init__(self, client=client, logger=logger, settings=settings)

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -79,6 +79,8 @@ class App:
         # for multi-workspace apps
         authorize: Optional[Callable[..., AuthorizeResult]] = None,
         installation_store: Optional[InstallationStore] = None,
+        # for v1.0.x compatibility
+        installation_store_bot_only: bool = False,
         # for the OAuth flow
         oauth_settings: Optional[OAuthSettings] = None,
         oauth_flow: Optional[OAuthFlow] = None,
@@ -96,6 +98,7 @@ class App:
         :param authorize: The function to authorize an incoming request from Slack
             by checking if there is a team/user in the installation data.
         :param installation_store: The module offering save/find operations of installation data
+        :param installation_store_bot_only: Use InstallationStore#find_bot if True (Default: False)
         :param oauth_settings: The settings related to Slack app installation flow (OAuth flow)
         :param oauth_flow: Manually instantiated slack_bolt.oauth.OAuthFlow.
             This is always prioritized over oauth_settings.
@@ -140,6 +143,7 @@ class App:
             self._authorize = InstallationStoreAuthorize(
                 installation_store=self._installation_store,
                 logger=self._framework_logger,
+                bot_only=installation_store_bot_only,
             )
 
         self._oauth_flow: Optional[OAuthFlow] = None

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -130,6 +130,10 @@ class App:
         else:
             self._client = create_web_client(token)  # NOTE: the token here can be None
 
+        # --------------------------------------
+        # Authorize & OAuthFlow initialization
+        # --------------------------------------
+
         self._authorize: Optional[Authorize] = None
         if authorize is not None:
             if oauth_settings is not None or oauth_flow is not None:
@@ -191,6 +195,13 @@ class App:
         ) and self._token is not None:
             self._token = None
             self._framework_logger.warning(warning_token_skipped())
+
+        # after setting bot_only here, __init__ cannot replace authorize function
+        self._authorize.bot_only = installation_store_bot_only
+
+        # --------------------------------------
+        # Middleware Initialization
+        # --------------------------------------
 
         self._middleware_list: List[Union[Callable, Middleware]] = []
         self._listeners: List[Listener] = []

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -197,7 +197,8 @@ class App:
             self._framework_logger.warning(warning_token_skipped())
 
         # after setting bot_only here, __init__ cannot replace authorize function
-        self._authorize.bot_only = installation_store_bot_only
+        if self._authorize is not None:
+            self._authorize.bot_only = installation_store_bot_only
 
         # --------------------------------------
         # Middleware Initialization

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -141,6 +141,10 @@ class AsyncApp:
             # NOTE: the token here can be None
             self._async_client = create_async_web_client(token)
 
+        # --------------------------------------
+        # Authorize & OAuthFlow initialization
+        # --------------------------------------
+
         self._async_authorize: Optional[AsyncAuthorize] = None
         if authorize is not None:
             if oauth_settings is not None or oauth_flow is not None:
@@ -213,6 +217,13 @@ class AsyncApp:
         ) and self._token is not None:
             self._token = None
             self._framework_logger.warning(warning_token_skipped())
+
+        # after setting bot_only here, __init__ cannot replace authorize function
+        self._async_authorize.bot_only = installation_store_bot_only
+
+        # --------------------------------------
+        # Middleware Initialization
+        # --------------------------------------
 
         self._async_middleware_list: List[Union[Callable, AsyncMiddleware]] = []
         self._async_listeners: List[AsyncListener] = []

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -219,7 +219,8 @@ class AsyncApp:
             self._framework_logger.warning(warning_token_skipped())
 
         # after setting bot_only here, __init__ cannot replace authorize function
-        self._async_authorize.bot_only = installation_store_bot_only
+        if self._async_authorize is not None:
+            self._async_authorize.bot_only = installation_store_bot_only
 
         # --------------------------------------
         # Middleware Initialization

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -90,6 +90,7 @@ class AsyncApp:
         client: Optional[AsyncWebClient] = None,
         # for multi-workspace apps
         installation_store: Optional[AsyncInstallationStore] = None,
+        installation_store_bot_only: bool = False,
         authorize: Optional[Callable[..., Awaitable[AuthorizeResult]]] = None,
         # for the OAuth flow
         oauth_settings: Optional[AsyncOAuthSettings] = None,
@@ -106,6 +107,7 @@ class AsyncApp:
         :param token: The bot access token required only for single-workspace app.
         :param client: The singleton slack_sdk.web.async_client.AsyncWebClient instance for this app.
         :param installation_store: The module offering save/find operations of installation data
+        :param installation_store_bot_only: Use InstallationStore#find_bot if True (Default: False)
         :param authorize: The function to authorize an incoming request from Slack
             by checking if there is a team/user in the installation data.
         :param oauth_settings: The settings related to Slack app installation flow (OAuth flow)
@@ -155,6 +157,7 @@ class AsyncApp:
             self._async_authorize = AsyncInstallationStoreAuthorize(
                 installation_store=self._async_installation_store,
                 logger=self._framework_logger,
+                bot_only=installation_store_bot_only,
             )
 
         self._async_oauth_flow: Optional[AsyncOAuthFlow] = None

--- a/slack_bolt/oauth/async_oauth_flow.py
+++ b/slack_bolt/oauth/async_oauth_flow.py
@@ -110,6 +110,7 @@ class AsyncOAuthFlow:
         # state parameter related configurations
         state_cookie_name: str = OAuthStateUtils.default_cookie_name,
         state_expiration_seconds: int = OAuthStateUtils.default_expiration_seconds,
+        installation_store_bot_only: bool = False,
         client: Optional[AsyncWebClient] = None,
         logger: Optional[Logger] = None,
     ) -> "AsyncOAuthFlow":
@@ -140,6 +141,7 @@ class AsyncOAuthFlow:
                 installation_store=SQLite3InstallationStore(
                     database=database, client_id=client_id, logger=logger,
                 ),
+                installation_store_bot_only=installation_store_bot_only,
                 # state parameter related configurations
                 state_store=SQLite3OAuthStateStore(
                     database=database,

--- a/slack_bolt/oauth/async_oauth_settings.py
+++ b/slack_bolt/oauth/async_oauth_settings.py
@@ -39,6 +39,7 @@ class AsyncOAuthSettings:
     authorization_url: str  # default: https://slack.com/oauth/v2/authorize
     # Installation Management
     installation_store: AsyncInstallationStore
+    installation_store_bot_only: bool
     authorize: AsyncAuthorize
     # state parameter related configurations
     state_store: AsyncOAuthStateStore
@@ -69,6 +70,7 @@ class AsyncOAuthSettings:
         authorization_url: Optional[str] = None,
         # Installation Management
         installation_store: Optional[AsyncInstallationStore] = None,
+        installation_store_bot_only: bool = False,
         # state parameter related configurations
         state_store: Optional[AsyncOAuthStateStore] = None,
         state_cookie_name: str = OAuthStateUtils.default_cookie_name,
@@ -90,6 +92,7 @@ class AsyncOAuthSettings:
         :param failure_url: Set a complete URL if you want to redirect end-users when an installation fails.
         :param authorization_url: Set a URL if you want to customize the URL https://slack.com/oauth/v2/authorize
         :param installation_store: Specify the instance of InstallationStore (Default: FileInstallationStore)
+        :param installation_store_bot_only: Use AsyncInstallationStore#find_bot if True (Default: False)
         :param state_store: Specify the instance of InstallationStore (Default: FileOAuthStateStore)
         :param state_cookie_name: The cookie name that is set for installers' browser. (Default: slack-app-oauth-state)
         :param state_expiration_seconds: The seconds that the state value is alive (Default: 600 seconds)
@@ -129,8 +132,11 @@ class AsyncOAuthSettings:
         self.installation_store = (
             installation_store or get_or_create_default_installation_store(client_id)
         )
+        self.installation_store_bot_only = installation_store_bot_only
         self.authorize = AsyncInstallationStoreAuthorize(
-            logger=logger, installation_store=self.installation_store,
+            logger=logger,
+            installation_store=self.installation_store,
+            bot_only=self.installation_store_bot_only,
         )
         # state parameter related configurations
         self.state_store = state_store or FileOAuthStateStore(

--- a/slack_bolt/oauth/oauth_flow.py
+++ b/slack_bolt/oauth/oauth_flow.py
@@ -105,6 +105,7 @@ class OAuthFlow:
         # state parameter related configurations
         state_cookie_name: str = OAuthStateUtils.default_cookie_name,
         state_expiration_seconds: int = OAuthStateUtils.default_expiration_seconds,
+        installation_store_bot_only: bool = False,
         client: Optional[WebClient] = None,
         logger: Optional[Logger] = None,
     ) -> "OAuthFlow":
@@ -135,6 +136,7 @@ class OAuthFlow:
                 installation_store=SQLite3InstallationStore(
                     database=database, client_id=client_id, logger=logger,
                 ),
+                installation_store_bot_only=installation_store_bot_only,
                 # state parameter related configurations
                 state_store=SQLite3OAuthStateStore(
                     database=database,

--- a/slack_bolt/oauth/oauth_settings.py
+++ b/slack_bolt/oauth/oauth_settings.py
@@ -34,6 +34,7 @@ class OAuthSettings:
     authorization_url: str  # default: https://slack.com/oauth/v2/authorize
     # Installation Management
     installation_store: InstallationStore
+    installation_store_bot_only: bool
     authorize: Authorize
     # state parameter related configurations
     state_store: OAuthStateStore
@@ -64,6 +65,7 @@ class OAuthSettings:
         authorization_url: Optional[str] = None,
         # Installation Management
         installation_store: Optional[InstallationStore] = None,
+        installation_store_bot_only: bool = False,
         # state parameter related configurations
         state_store: Optional[OAuthStateStore] = None,
         state_cookie_name: str = OAuthStateUtils.default_cookie_name,
@@ -85,6 +87,7 @@ class OAuthSettings:
         :param failure_url: Set a complete URL if you want to redirect end-users when an installation fails.
         :param authorization_url: Set a URL if you want to customize the URL https://slack.com/oauth/v2/authorize
         :param installation_store: Specify the instance of InstallationStore (Default: FileInstallationStore)
+        :param installation_store_bot_only: Use InstallationStore#find_bot if True (Default: False)
         :param state_store: Specify the instance of InstallationStore (Default: FileOAuthStateStore)
         :param state_cookie_name: The cookie name that is set for installers' browser. (Default: slack-app-oauth-state)
         :param state_expiration_seconds: The seconds that the state value is alive (Default: 600 seconds)
@@ -123,8 +126,11 @@ class OAuthSettings:
         self.installation_store = (
             installation_store or get_or_create_default_installation_store(client_id)
         )
+        self.installation_store_bot_only = installation_store_bot_only
         self.authorize = InstallationStoreAuthorize(
-            logger=logger, installation_store=self.installation_store,
+            logger=logger,
+            installation_store=self.installation_store,
+            bot_only=self.installation_store_bot_only,
         )
         # state parameter related configurations
         self.state_store = state_store or FileOAuthStateStore(

--- a/tests/slack_bolt/authorization/test_authorize.py
+++ b/tests/slack_bolt/authorization/test_authorize.py
@@ -76,6 +76,63 @@ class TestAuthorize:
         assert result.user_token is None
         assert self.mock_received_requests["/auth.test"] == 1  # cached
 
+    def test_installation_store_bot_only(self):
+        installation_store = MemoryInstallationStore()
+        authorize = InstallationStoreAuthorize(
+            logger=installation_store.logger,
+            installation_store=installation_store,
+            bot_only=True,
+        )
+        assert authorize.find_installation_available is True
+        assert authorize.bot_only is True
+        context = BoltContext()
+        context["client"] = WebClient(base_url=self.mock_api_server_base_url)
+        result = authorize(
+            context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111"
+        )
+        assert authorize.find_installation_available is True
+        assert result.bot_id == "BZYBOTHED"
+        assert result.bot_user_id == "W23456789"
+        assert result.user_token is None
+        assert self.mock_received_requests["/auth.test"] == 1
+
+        result = authorize(
+            context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111"
+        )
+        assert result.bot_id == "BZYBOTHED"
+        assert result.bot_user_id == "W23456789"
+        assert result.user_token is None
+        assert self.mock_received_requests["/auth.test"] == 2
+
+    def test_installation_store_cached_bot_only(self):
+        installation_store = MemoryInstallationStore()
+        authorize = InstallationStoreAuthorize(
+            logger=installation_store.logger,
+            installation_store=installation_store,
+            cache_enabled=True,
+            bot_only=True,
+        )
+        assert authorize.find_installation_available is True
+        assert authorize.bot_only is True
+        context = BoltContext()
+        context["client"] = WebClient(base_url=self.mock_api_server_base_url)
+        result = authorize(
+            context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111"
+        )
+        assert authorize.find_installation_available is True
+        assert result.bot_id == "BZYBOTHED"
+        assert result.bot_user_id == "W23456789"
+        assert result.user_token is None
+        assert self.mock_received_requests["/auth.test"] == 1
+
+        result = authorize(
+            context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111"
+        )
+        assert result.bot_id == "BZYBOTHED"
+        assert result.bot_user_id == "W23456789"
+        assert result.user_token is None
+        assert self.mock_received_requests["/auth.test"] == 1  # cached
+
     def test_installation_store(self):
         installation_store = MemoryInstallationStore()
         authorize = InstallationStoreAuthorize(

--- a/tests/slack_bolt/authorization/test_authorize.py
+++ b/tests/slack_bolt/authorization/test_authorize.py
@@ -77,7 +77,7 @@ class TestAuthorize:
         assert self.mock_received_requests["/auth.test"] == 1  # cached
 
     def test_installation_store_bot_only(self):
-        installation_store = MemoryInstallationStore()
+        installation_store = BotOnlyMemoryInstallationStore()
         authorize = InstallationStoreAuthorize(
             logger=installation_store.logger,
             installation_store=installation_store,
@@ -105,7 +105,7 @@ class TestAuthorize:
         assert self.mock_received_requests["/auth.test"] == 2
 
     def test_installation_store_cached_bot_only(self):
-        installation_store = MemoryInstallationStore()
+        installation_store = BotOnlyMemoryInstallationStore()
         authorize = InstallationStoreAuthorize(
             logger=installation_store.logger,
             installation_store=installation_store,
@@ -233,3 +233,15 @@ class MemoryInstallationStore(LegacyMemoryInstallationStore):
             user_scopes=["search:read"],
             installed_at=datetime.datetime.now().timestamp(),
         )
+
+
+class BotOnlyMemoryInstallationStore(LegacyMemoryInstallationStore):
+    def find_installation(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        user_id: Optional[str] = None,
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Installation]:
+        raise ValueError

--- a/tests/slack_bolt_async/authorization/test_async_authorize.py
+++ b/tests/slack_bolt_async/authorization/test_async_authorize.py
@@ -91,6 +91,65 @@ class TestAsyncAuthorize:
         assert self.mock_received_requests["/auth.test"] == 1  # cached
 
     @pytest.mark.asyncio
+    async def test_installation_store_bot_only(self):
+        installation_store = MemoryInstallationStore()
+        authorize = AsyncInstallationStoreAuthorize(
+            logger=installation_store.logger,
+            installation_store=installation_store,
+            bot_only=True,
+        )
+        assert authorize.find_installation_available is None
+        assert authorize.bot_only is True
+        context = AsyncBoltContext()
+        context["client"] = self.client
+        result = await authorize(
+            context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111"
+        )
+        assert authorize.find_installation_available is True
+        assert result.bot_id == "BZYBOTHED"
+        assert result.bot_user_id == "W23456789"
+        assert result.user_token is None
+        assert self.mock_received_requests["/auth.test"] == 1
+
+        result = await authorize(
+            context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111"
+        )
+        assert result.bot_id == "BZYBOTHED"
+        assert result.bot_user_id == "W23456789"
+        assert result.user_token is None
+        assert self.mock_received_requests["/auth.test"] == 2
+
+    @pytest.mark.asyncio
+    async def test_installation_store_cached_bot_only(self):
+        installation_store = MemoryInstallationStore()
+        authorize = AsyncInstallationStoreAuthorize(
+            logger=installation_store.logger,
+            installation_store=installation_store,
+            cache_enabled=True,
+            bot_only=True,
+        )
+        assert authorize.find_installation_available is None
+        assert authorize.bot_only is True
+        context = AsyncBoltContext()
+        context["client"] = self.client
+        result = await authorize(
+            context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111"
+        )
+        assert authorize.find_installation_available is True
+        assert result.bot_id == "BZYBOTHED"
+        assert result.bot_user_id == "W23456789"
+        assert result.user_token is None
+        assert self.mock_received_requests["/auth.test"] == 1
+
+        result = await authorize(
+            context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111"
+        )
+        assert result.bot_id == "BZYBOTHED"
+        assert result.bot_user_id == "W23456789"
+        assert result.user_token is None
+        assert self.mock_received_requests["/auth.test"] == 1  # cached
+
+    @pytest.mark.asyncio
     async def test_installation_store(self):
         installation_store = MemoryInstallationStore()
         authorize = AsyncInstallationStoreAuthorize(

--- a/tests/slack_bolt_async/authorization/test_async_authorize.py
+++ b/tests/slack_bolt_async/authorization/test_async_authorize.py
@@ -92,7 +92,7 @@ class TestAsyncAuthorize:
 
     @pytest.mark.asyncio
     async def test_installation_store_bot_only(self):
-        installation_store = MemoryInstallationStore()
+        installation_store = BotOnlyMemoryInstallationStore()
         authorize = AsyncInstallationStoreAuthorize(
             logger=installation_store.logger,
             installation_store=installation_store,
@@ -121,7 +121,7 @@ class TestAsyncAuthorize:
 
     @pytest.mark.asyncio
     async def test_installation_store_cached_bot_only(self):
-        installation_store = MemoryInstallationStore()
+        installation_store = BotOnlyMemoryInstallationStore()
         authorize = AsyncInstallationStoreAuthorize(
             logger=installation_store.logger,
             installation_store=installation_store,
@@ -253,3 +253,15 @@ class MemoryInstallationStore(LegacyMemoryInstallationStore):
             user_scopes=["search:read"],
             installed_at=datetime.datetime.now().timestamp(),
         )
+
+
+class BotOnlyMemoryInstallationStore(LegacyMemoryInstallationStore):
+    async def async_find_installation(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        user_id: Optional[str] = None,
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Installation]:
+        raise ValueError


### PR DESCRIPTION
This pull request adds a new option to OAuth flow supported apps. The option is `installation_store_bot_only: bool` on `App`/`AsyncApp` and `OAuthSettings`/`AsyncOAuthSettings`. 

The default is `False`. If the value is `False`, the `InstallationStore` uses only `#find_installation` method for fetching installation data for incoming requests as we changed since v1.1. If it's `True`, `#find_bot` method is used as with v1.0. The fallback to `#find_bot` method enables existing apps to successfully access the installation data generated by v1.0.x apps. 

Why is this needed? If an app uses Amazon S3 backend `InstallationStore`, the already stored data is not compatible with v1.1's default `authorize` logic and we are unable to make it compatible in an efficient way. That's why we need to add this compatibility mode. I've observed this situation with the Amazon S3 InstallationStore but any custom InstallationStore can be affected in the same way. It depends on how InstallationStore access the stored data.

With the change in this PR, those developers can easily switch to v1.0 compatibility mode just by having `installation_store_bot_only=True`. Also, this should be valuable not only for the v1.0 backward compatibility but also for developers that want to manage only bot related installation data.

ref: #148 

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
