### PR TITLE
Fix #158 by adding token_verification_enabled option to App

### DIFF
--- a/tests/scenario_tests/test_app.py
+++ b/tests/scenario_tests/test_app.py
@@ -67,6 +67,20 @@ class TestApp:
         with pytest.raises(BoltError):
             App(signing_secret="valid", token="")
 
+    def test_token_verification_enabled_False(self):
+        App(
+            signing_secret="valid",
+            client=self.web_client,
+            token_verification_enabled=False,
+        )
+        App(
+            signing_secret="valid",
+            token="xoxb-invalid",
+            token_verification_enabled=False,
+        )
+
+        assert self.mock_received_requests.get("/auth.test") is None
+
     # --------------------------
     # multi teams auth
     # --------------------------


### PR DESCRIPTION
This pull request adds a new option `token_verification_enabled: bool` to `App` constructor arguments. The default value of this option is `True`. If it's `True`, Bolt performs `auth.test` API call when instantiating an `App` instance. If `False`, the initial call will be postponed until the first execution of the single team authorization middleware. Regardless of the timing of the initial call, the API response is cached as before.

Due to the compatibility with async/await nature in Python, `AsyncApp` does not verify a given token when creating a new `AsyncApp` instance. Thus, this pull request does not apply any changes to `AsyncApp`.

Fixes #158 

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
