### PR TITLE
Update Sanic adapter unit tests to be compatible with the latest version

### DIFF
--- a/tests/adapter_tests_async/test_async_sanic.py
+++ b/tests/adapter_tests_async/test_async_sanic.py
@@ -29,6 +29,10 @@ class TestSanic:
         base_url=mock_api_server_base_url,
     )
 
+    @staticmethod
+    def unique_sanic_app_name() -> str:
+        return f"awesome-slack-app-{time()}"
+
     @pytest.fixture
     def event_loop(self):
         old_os_env = remove_os_env_temporarily()
@@ -93,7 +97,7 @@ class TestSanic:
         }
         timestamp, body = str(int(time())), json.dumps(input)
 
-        api = Sanic(name="awesome-slack-app")
+        api = Sanic(name=self.unique_sanic_app_name())
         app_handler = AsyncSlackRequestHandler(app)
 
         @api.post("/slack/events")
@@ -137,7 +141,7 @@ class TestSanic:
 
         timestamp, body = str(int(time())), f"payload={quote(json.dumps(input))}"
 
-        api = Sanic(name="awesome-slack-app")
+        api = Sanic(name=self.unique_sanic_app_name())
         app_handler = AsyncSlackRequestHandler(app)
 
         @api.post("/slack/events")
@@ -181,7 +185,7 @@ class TestSanic:
         )
         timestamp, body = str(int(time())), input
 
-        api = Sanic(name="awesome-slack-app")
+        api = Sanic(name=self.unique_sanic_app_name())
         app_handler = AsyncSlackRequestHandler(app)
 
         @api.post("/slack/events")
@@ -207,7 +211,7 @@ class TestSanic:
                 scopes=["chat:write", "commands"],
             ),
         )
-        api = Sanic(name="awesome-slack-app")
+        api = Sanic(name=self.unique_sanic_app_name())
         app_handler = AsyncSlackRequestHandler(app)
 
         @api.get("/slack/install")


### PR DESCRIPTION
The latest version of Sanic web framework verifies if Sanic app names are duplicated in the same Python process. 

```python
$ pip install -U sanic
Installing collected packages: sanic
  Attempting uninstall: sanic
    Found existing installation: sanic 20.9.1
    Uninstalling sanic-20.9.1:
      Successfully uninstalled sanic-20.9.1
Successfully installed sanic-20.12.0

$ ./scripts/run_tests.sh tests/adapter_tests_async/test_async_sanic.py

tests/adapter_tests_async/test_async_sanic.py .FFF                                                                                             [100%]
====================================================================== FAILURES ======================================================================
______________________________________________________________ TestSanic.test_shortcuts ______________________________________________________________

self = <tests.adapter_tests_async.test_async_sanic.TestSanic object at 0x10a2c6c10>

    @pytest.mark.asyncio
    async def test_shortcuts(self):
        app = AsyncApp(
            client=self.web_client,
            signing_secret=self.signing_secret,
        )

        async def shortcut_handler(ack):
            await ack()

        app.shortcut("test-shortcut")(shortcut_handler)

        input = {
            "type": "shortcut",
            "token": "verification_token",
            "action_ts": "111.111",
            "team": {
                "id": "T111",
                "domain": "workspace-domain",
                "enterprise_id": "E111",
                "enterprise_name": "Org Name",
            },
            "user": {"id": "W111", "username": "primary-owner", "team_id": "T111"},
            "callback_id": "test-shortcut",
            "trigger_id": "111.111.xxxxxx",
        }

        timestamp, body = str(int(time())), f"payload={quote(json.dumps(input))}"

>       api = Sanic(name="awesome-slack-app")

tests/adapter_tests_async/test_async_sanic.py:140:
```

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others (tests)

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
