### PR TITLE
Add type hint updates missed in #148

### DIFF
--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -22,7 +22,7 @@ class AsyncAuthorize:
         *,
         context: AsyncBoltContext,
         enterprise_id: Optional[str],
-        team_id: str,
+        team_id: Optional[str],  # can be None for org-wide installed apps
         user_id: Optional[str],
     ) -> Optional[AuthorizeResult]:
         raise NotImplementedError()
@@ -41,7 +41,7 @@ class AsyncCallableAuthorize(AsyncAuthorize):
         *,
         context: AsyncBoltContext,
         enterprise_id: Optional[str],
-        team_id: str,
+        team_id: Optional[str],  # can be None for org-wide installed apps
         user_id: Optional[str],
     ) -> Optional[AuthorizeResult]:
         try:
@@ -116,7 +116,7 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
         *,
         context: AsyncBoltContext,
         enterprise_id: Optional[str],
-        team_id: str,
+        team_id: Optional[str],  # can be None for org-wide installed apps
         user_id: Optional[str],
     ) -> Optional[AuthorizeResult]:
 

--- a/slack_bolt/authorization/async_authorize_args.py
+++ b/slack_bolt/authorization/async_authorize_args.py
@@ -11,7 +11,7 @@ class AsyncAuthorizeArgs:
     logger: Logger
     client: AsyncWebClient
     enterprise_id: Optional[str]
-    team_id: str
+    team_id: Optional[str]
     user_id: Optional[str]
 
     def __init__(
@@ -19,7 +19,7 @@ class AsyncAuthorizeArgs:
         *,
         context: AsyncBoltContext,
         enterprise_id: Optional[str],
-        team_id: str,
+        team_id: Optional[str],  # can be None for org-wide installed apps
         user_id: Optional[str],
     ):
         """The whole arguments that are passed to Authorize functions.

--- a/slack_bolt/authorization/authorize.py
+++ b/slack_bolt/authorization/authorize.py
@@ -21,7 +21,7 @@ class Authorize:
         *,
         context: BoltContext,
         enterprise_id: Optional[str],
-        team_id: str,
+        team_id: Optional[str],  # can be None for org-wide installed apps
         user_id: Optional[str],
     ) -> Optional[AuthorizeResult]:
         raise NotImplementedError()
@@ -43,7 +43,7 @@ class CallableAuthorize(Authorize):
         *,
         context: BoltContext,
         enterprise_id: Optional[str],
-        team_id: str,
+        team_id: Optional[str],  # can be None for org-wide installed apps
         user_id: Optional[str],
     ) -> Optional[AuthorizeResult]:
         try:
@@ -121,7 +121,7 @@ class InstallationStoreAuthorize(Authorize):
         *,
         context: BoltContext,
         enterprise_id: Optional[str],
-        team_id: str,
+        team_id: Optional[str],  # can be None for org-wide installed apps
         user_id: Optional[str],
     ) -> Optional[AuthorizeResult]:
 

--- a/slack_bolt/authorization/authorize_args.py
+++ b/slack_bolt/authorization/authorize_args.py
@@ -11,7 +11,7 @@ class AuthorizeArgs:
     logger: Logger
     client: WebClient
     enterprise_id: Optional[str]
-    team_id: str
+    team_id: Optional[str]
     user_id: Optional[str]
 
     def __init__(
@@ -19,7 +19,7 @@ class AuthorizeArgs:
         *,
         context: BoltContext,
         enterprise_id: Optional[str],
-        team_id: str,
+        team_id: Optional[str],  # can be None for org-wide installed apps
         user_id: Optional[str],
     ):
         """The whole arguments that are passed to Authorize functions.


### PR DESCRIPTION
My pull request #148 for Org-wide app installation support missed some type hint updates for method argument `team_id`. I used to safely assume the `team_id` is always available in every single incoming request from Slack. But it is no longer true for Org-wide installed apps' cases. As this is a matter of type hints, it does not affect runtime behaviors at all.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
