### PR TITLE
Improvement related to #199: add event type name validation

### DIFF
--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -50,6 +50,14 @@ def error_authorize_conflicts() -> str:
     return "`authorize` in the top-level arguments is not allowed when you pass either `oauth_settings` or `oauth_flow`"
 
 
+def error_message_event_type(event_type: str) -> str:
+    return (
+        f'Although the document mentions "{event_type}", '
+        'it is not a valid event type. Use "message" instead. '
+        "If you want to filter message events, you can use `event.channel_type` for it."
+    )
+
+
 # -------------------------------
 # Warning
 # -------------------------------

--- a/tests/scenario_tests_async/test_events.py
+++ b/tests/scenario_tests_async/test_events.py
@@ -561,6 +561,37 @@ class TestAsyncEvents:
         response = await app.async_dispatch(request)
         assert response.status == 200
 
+    # https://github.com/slackapi/bolt-python/issues/199
+    @pytest.mark.asyncio
+    async def test_invalid_message_events(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+
+        async def handle():
+            pass
+
+        # valid
+        app.event("message")(handle)
+
+        with pytest.raises(ValueError):
+            app.event("message.channels")(handle)
+        with pytest.raises(ValueError):
+            app.event("message.groups")(handle)
+        with pytest.raises(ValueError):
+            app.event("message.im")(handle)
+        with pytest.raises(ValueError):
+            app.event("message.mpim")(handle)
+
+        with pytest.raises(ValueError):
+            app.event(re.compile("message\\..*"))(handle)
+
+        with pytest.raises(ValueError):
+            app.event({"type": "message.channels"})(handle)
+        with pytest.raises(ValueError):
+            app.event({"type": re.compile("message\\..*")})(handle)
+
 
 app_mention_body = {
     "token": "verification_token",


### PR DESCRIPTION
This pull request improves the event listener registration in the aim of helping developers easily understand what's wrong with `message.*` values for event types. ref #199 

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
