### PR TITLE
Fix #208 by updating AsyncOAuthFlow

### DIFF
--- a/slack_bolt/oauth/async_oauth_flow.py
+++ b/slack_bolt/oauth/async_oauth_flow.py
@@ -308,6 +308,9 @@ class AsyncOAuthFlow:
             installed_enterprise: Dict[str, str] = (
                 oauth_response.get("enterprise") or {}
             )
+            is_enterprise_install: bool = (
+                oauth_response.get("is_enterprise_install") or False
+            )
             installed_team: Dict[str, str] = oauth_response.get("team") or {}
             installer: Dict[str, str] = oauth_response.get("authed_user") or {}
             incoming_webhook: Dict[str, str] = (
@@ -317,14 +320,20 @@ class AsyncOAuthFlow:
             bot_token: Optional[str] = oauth_response.get("access_token")
             # NOTE: oauth.v2.access doesn't include bot_id in response
             bot_id: Optional[str] = None
+            enterprise_url: Optional[str] = None
             if bot_token is not None:
                 auth_test = await self.client.auth_test(token=bot_token)
                 bot_id = auth_test["bot_id"]
+            if is_enterprise_install is True:
+                enterprise_url = auth_test.get("url")
 
             return Installation(
                 app_id=oauth_response.get("app_id"),
                 enterprise_id=installed_enterprise.get("id"),
+                enterprise_name=installed_enterprise.get("name"),
+                enterprise_url=enterprise_url,
                 team_id=installed_team.get("id"),
+                team_name=installed_team.get("name"),
                 bot_token=bot_token,
                 bot_id=bot_id,
                 bot_user_id=oauth_response.get("bot_user_id"),
@@ -333,10 +342,13 @@ class AsyncOAuthFlow:
                 user_token=installer.get("access_token"),
                 user_scopes=installer.get("scope"),  # comma-separated string
                 incoming_webhook_url=incoming_webhook.get("url"),
+                incoming_webhook_channel=incoming_webhook.get("channel"),
                 incoming_webhook_channel_id=incoming_webhook.get("channel_id"),
                 incoming_webhook_configuration_url=incoming_webhook.get(
-                    "configuration_url", None
+                    "configuration_url"
                 ),
+                is_enterprise_install=is_enterprise_install,
+                token_type=oauth_response.get("token_type"),
             )
 
         except SlackApiError as e:

--- a/slack_bolt/oauth/oauth_flow.py
+++ b/slack_bolt/oauth/oauth_flow.py
@@ -340,7 +340,7 @@ class OAuthFlow:
                 incoming_webhook_channel=incoming_webhook.get("channel"),
                 incoming_webhook_channel_id=incoming_webhook.get("channel_id"),
                 incoming_webhook_configuration_url=incoming_webhook.get(
-                    "configuration_url", None
+                    "configuration_url"
                 ),
                 is_enterprise_install=is_enterprise_install,
                 token_type=oauth_response.get("token_type"),


### PR DESCRIPTION
This pull request fixes #208 by updating `AsyncOAuthFlow` to new attributes introduced by #148. This bug has been affecting only `AsyncApp` (asyncio compatible version).

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
