### PR TITLE
Fix #210 by correcting a type hint in async OAuth classes

### DIFF
--- a/slack_bolt/oauth/async_oauth_settings.py
+++ b/slack_bolt/oauth/async_oauth_settings.py
@@ -19,8 +19,8 @@ from slack_bolt.authorization.async_authorize import (
     AsyncAuthorize,
 )
 from slack_bolt.error import BoltError
+from slack_bolt.oauth.async_callback_options import AsyncCallbackOptions
 from slack_bolt.oauth.async_internals import get_or_create_default_installation_store
-from slack_bolt.oauth.callback_options import CallbackOptions
 
 
 class AsyncOAuthSettings:
@@ -34,7 +34,7 @@ class AsyncOAuthSettings:
     install_path: str
     install_page_rendering_enabled: bool
     redirect_uri_path: str
-    callback_options: Optional[CallbackOptions] = None
+    callback_options: Optional[AsyncCallbackOptions] = None
     success_url: Optional[str]
     failure_url: Optional[str]
     authorization_url: str  # default: https://slack.com/oauth/v2/authorize
@@ -66,7 +66,7 @@ class AsyncOAuthSettings:
         install_path: str = "/slack/install",
         install_page_rendering_enabled: bool = True,
         redirect_uri_path: str = "/slack/oauth_redirect",
-        callback_options: Optional[CallbackOptions] = None,
+        callback_options: Optional[AsyncCallbackOptions] = None,
         success_url: Optional[str] = None,
         failure_url: Optional[str] = None,
         authorization_url: Optional[str] = None,


### PR DESCRIPTION
This pull request fixes #210 - this issue does not affect anything runtime. It's just an error for type hint users.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
