### PR TITLE
Upgrade the minimum slack-sdk version to 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
         exclude=["examples", "integration_tests", "tests", "tests.*",]
     ),
     include_package_data=True,  # MANIFEST.in
-    install_requires=["slack_sdk>=3.3.2,<3.4",],
+    install_requires=["slack_sdk>=3.4,<4",],
     setup_requires=["pytest-runner==5.2"],
     tests_require=test_dependencies,
     test_suite="tests",
@@ -52,8 +52,7 @@ setuptools.setup(
             "moto<=2", # For AWS tests
             "bottle>=0.12,<1",
             "boddle>=0.2,<0.3",  # For Bottle app tests
-            # TODO: https://github.com/aws/chalice/issues/1627
-            "chalice>=1.22,<2",
+            "chalice>=1.22.1,<2",
             "click>=7,<8",  # for chalice
             "CherryPy>=18,<19",
             "Django>=3,<4",


### PR DESCRIPTION
As we have improvements for proxy supports and stability of built-in SocketModeClient in slack-sdk v3.4, we set the minimum required version to the minor version. Also, we stop limiting the usage of newer minor versions since this version.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
