### PR TITLE
Fix an issue where different user's token may exist in context

### DIFF
--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -131,6 +131,8 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
         if not self.bot_only and self.find_installation_available:
             # since v1.1, this is the default way
             try:
+                # Note that this is the latest information for the org/workspace.
+                # The installer may not be the user associated with this incoming request.
                 installation: Optional[
                     Installation
                 ] = await self.installation_store.async_find_installation(
@@ -143,6 +145,10 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
                     return None
 
                 if installation.user_id != user_id:
+                    # First off, remove the user token as the installer is a different user
+                    installation.user_token = None
+                    installation.user_scopes = []
+
                     # try to fetch the request user's installation
                     # to reflect the user's access token if exists
                     user_installation = (
@@ -154,6 +160,7 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
                         )
                     )
                     if user_installation is not None:
+                        # Overwrite the installation with the one for this user
                         installation = user_installation
 
                 bot_token, user_token = installation.bot_token, installation.user_token

--- a/slack_bolt/authorization/authorize.py
+++ b/slack_bolt/authorization/authorize.py
@@ -131,6 +131,8 @@ class InstallationStoreAuthorize(Authorize):
         if not self.bot_only and self.find_installation_available:
             # since v1.1, this is the default way
             try:
+                # Note that this is the latest information for the org/workspace.
+                # The installer may not be the user associated with this incoming request.
                 installation: Optional[
                     Installation
                 ] = self.installation_store.find_installation(
@@ -143,6 +145,10 @@ class InstallationStoreAuthorize(Authorize):
                     return None
 
                 if installation.user_id != user_id:
+                    # First off, remove the user token as the installer is a different user
+                    installation.user_token = None
+                    installation.user_scopes = []
+
                     # try to fetch the request user's installation
                     # to reflect the user's access token if exists
                     user_installation = self.installation_store.find_installation(
@@ -152,6 +158,7 @@ class InstallationStoreAuthorize(Authorize):
                         is_enterprise_install=context.is_enterprise_install,
                     )
                     if user_installation is not None:
+                        # Overwrite the installation with the one for this user
                         installation = user_installation
 
                 bot_token, user_token = installation.bot_token, installation.user_token


### PR DESCRIPTION
This pull request resolves a bug where different user's user token (`xoxp-` prefixed token) may exist in `context.user_token` while `context.user_id` is consistent with an incoming request. This issue affects only when an app uses an `InstallationStore`. As this issue can be critical in some situations, I will release a patch version shortly.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
