### PR TITLE
Add 'channel_join' and 'group_join' to "kept" subtypes

### DIFF
--- a/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
@@ -33,18 +33,25 @@ class IgnoringSelfEvents(Middleware):
     # but the user ID might match our own app. Filter these out.
     # However, some events still must be fired, because they can make sense.
     events_that_should_be_kept = ["member_joined_channel", "member_left_channel"]
+    message_subtypes_that_should_be_kept = ["channel_join", "group_join"]
 
     @classmethod
     def _is_self_event(
         cls, auth_result: AuthorizeResult, user_id: str, body: Dict[str, Any]
     ):
-        return (
+        self_event = (
             auth_result is not None
             and user_id is not None
             and user_id == auth_result.bot_user_id
             and body.get("event") is not None
-            and body.get("event", {}).get("type") not in cls.events_that_should_be_kept
         )
+        event = body.get("event", {})
+        keep = (
+            event.get("type") in cls.events_that_should_be_kept
+            or event.get("type", "") == "message"
+            and event.get("subtype") in cls.message_subtypes_that_should_be_kept
+        )
+        return self_event and not keep
 
     def _debug_log(self, body: dict):
         if self.logger.level <= logging.DEBUG:


### PR DESCRIPTION
These are useful with the Events API since there are no explicit `channel_joined` or `group_joined` events like there are when using the RTM interface.

(Describe the goal of this PR. Mention any related Issue numbers)

### Category (place an `x` in each of the `[ ]`)

* [X] `slack_bolt.App` and/or its core components
* [X] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [X] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
