### PR TITLE
Resolve #251 by correcting a duplicated response header

### DIFF
--- a/slack_bolt/oauth/async_oauth_flow.py
+++ b/slack_bolt/oauth/async_oauth_flow.py
@@ -172,7 +172,6 @@ class AsyncOAuthFlow:
                 body=html,
                 headers={
                     "Content-Type": "text/html; charset=utf-8",
-                    "Content-Length": len(bytes(html, "utf-8")),
                     "Set-Cookie": [set_cookie_value],
                 },
             )

--- a/slack_bolt/oauth/internals.py
+++ b/slack_bolt/oauth/internals.py
@@ -42,7 +42,6 @@ class CallbackResponseBuilder:
             status=200,
             headers={
                 "Content-Type": "text/html; charset=utf-8",
-                "Content-Length": len(bytes(html, "utf-8")),
                 "Set-Cookie": self._state_utils.build_set_cookie_for_deletion(),
             },
             body=html,
@@ -66,7 +65,6 @@ class CallbackResponseBuilder:
             status=status,
             headers={
                 "Content-Type": "text/html; charset=utf-8",
-                "Content-Length": len(bytes(html, "utf-8")),
                 "Set-Cookie": self._state_utils.build_set_cookie_for_deletion(),
             },
             body=html,

--- a/slack_bolt/oauth/oauth_flow.py
+++ b/slack_bolt/oauth/oauth_flow.py
@@ -167,7 +167,6 @@ class OAuthFlow:
                 body=html,
                 headers={
                     "Content-Type": "text/html; charset=utf-8",
-                    "Content-Length": len(bytes(html, "utf-8")),
                     "Set-Cookie": [set_cookie_value],
                 },
             )

--- a/tests/adapter_tests/aws/test_aws_chalice.py
+++ b/tests/adapter_tests/aws/test_aws_chalice.py
@@ -288,5 +288,4 @@ class TestAwsChalice:
         )
         assert response["statusCode"] == 200
         assert response["headers"]["content-type"] == "text/html; charset=utf-8"
-        assert response["headers"]["content-length"] == "565"
         assert "https://slack.com/oauth/v2/authorize?state=" in response.get("body")

--- a/tests/adapter_tests/aws/test_aws_lambda.py
+++ b/tests/adapter_tests/aws/test_aws_lambda.py
@@ -305,7 +305,6 @@ class TestAWSLambda:
         response = SlackRequestHandler(app).handle(event, self.context)
         assert response["statusCode"] == 200
         assert response["headers"]["content-type"] == "text/html; charset=utf-8"
-        assert response["headers"]["content-length"] == "565"
         assert response.get("body") is not None
 
         event = {
@@ -318,5 +317,4 @@ class TestAWSLambda:
         response = SlackRequestHandler(app).handle(event, self.context)
         assert response["statusCode"] == 200
         assert response["headers"]["content-type"] == "text/html; charset=utf-8"
-        assert response["headers"]["content-length"] == "565"
         assert "https://slack.com/oauth/v2/authorize?state=" in response.get("body")

--- a/tests/adapter_tests/django/test_django.py
+++ b/tests/adapter_tests/django/test_django.py
@@ -188,7 +188,6 @@ class TestDjango(TestCase):
         response = SlackRequestHandler(app).handle(request)
         assert response.status_code == 200
         assert response.get("content-type") == "text/html; charset=utf-8"
-        assert response.get("content-length") == "565"
         assert "https://slack.com/oauth/v2/authorize?state=" in response.content.decode(
             "utf-8"
         )

--- a/tests/adapter_tests/starlette/test_fastapi.py
+++ b/tests/adapter_tests/starlette/test_fastapi.py
@@ -213,5 +213,4 @@ class TestFastAPI:
         response = client.get("/slack/install", allow_redirects=False)
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert response.headers.get("content-length") == "565"
         assert "https://slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests/starlette/test_starlette.py
+++ b/tests/adapter_tests/starlette/test_starlette.py
@@ -222,5 +222,4 @@ class TestStarlette:
         response = client.get("/slack/install", allow_redirects=False)
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert response.headers.get("content-length") == "565"
         assert "https://slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/slack_bolt/oauth/test_oauth_flow.py
+++ b/tests/slack_bolt/oauth/test_oauth_flow.py
@@ -56,7 +56,6 @@ class TestOAuthFlow:
         resp = oauth_flow.handle_installation(req)
         assert resp.status == 200
         assert resp.headers.get("content-type") == ["text/html; charset=utf-8"]
-        assert resp.headers.get("content-length") == ["576"]
         assert "https://slack.com/oauth/v2/authorize?state=" in resp.body
 
     # https://github.com/slackapi/bolt-python/issues/183

--- a/tests/slack_bolt/oauth/test_oauth_flow_sqlite3.py
+++ b/tests/slack_bolt/oauth/test_oauth_flow_sqlite3.py
@@ -41,7 +41,6 @@ class TestOAuthFlowSQLite3:
         resp = oauth_flow.handle_installation(req)
         assert resp.status == 200
         assert resp.headers.get("content-type") == ["text/html; charset=utf-8"]
-        assert resp.headers.get("content-length") == ["565"]
         assert "https://slack.com/oauth/v2/authorize?state=" in resp.body
 
     def test_handle_callback(self):

--- a/tests/slack_bolt_async/oauth/test_async_oauth_flow.py
+++ b/tests/slack_bolt_async/oauth/test_async_oauth_flow.py
@@ -107,7 +107,6 @@ class TestAsyncOAuthFlow:
         resp = await oauth_flow.handle_installation(req)
         assert resp.status == 200
         assert resp.headers.get("content-type") == ["text/html; charset=utf-8"]
-        assert resp.headers.get("content-length") == ["565"]
         assert "https://slack.com/oauth/v2/authorize?state=" in resp.body
 
     @pytest.mark.asyncio

--- a/tests/slack_bolt_async/oauth/test_async_oauth_flow_sqlite3.py
+++ b/tests/slack_bolt_async/oauth/test_async_oauth_flow_sqlite3.py
@@ -55,7 +55,6 @@ class TestAsyncOAuthFlowSQLite3:
         resp = await oauth_flow.handle_installation(req)
         assert resp.status == 200
         assert resp.headers.get("content-type") == ["text/html; charset=utf-8"]
-        assert resp.headers.get("content-length") == ["565"]
         assert "https://slack.com/oauth/v2/authorize?state=" in resp.body
 
     @pytest.mark.asyncio


### PR DESCRIPTION
This pull request resolves #251 by correcting the set of response headers for OAuth flows. 

Before the changes in this PR, this library's OAuth flow handler has been having the `content-length` header **twice** in a response. In actual fact, the response works with major browsers anyway. However, Google Cloud Run's server-side has a bit strict format validation policies before delivering an HTTP response. Due to the validation, the OAuth flow fails in the way described in the issue.

If I remember correctly, there is no specific need to manually craft the header but I added the logic just for easily ensuring the compatibility with various adapters (sadly, it was not easy in this case...). As most web frameworks generates the header under the hood. 

For this reason, I'm sure it's safe enough to delete the one created by this library. Also, I've already verified all the adapters including the AWS Lambda adapter work with this change.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
