### PR TITLE
Improve the warning message in App/AsyncApp constructor #256

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -44,6 +44,7 @@ from slack_bolt.logger.messages import (
     error_authorize_conflicts,
     warning_bot_only_conflicts,
     debug_return_listener_middleware_response,
+    info_default_oauth_settings_loaded,
 )
 from slack_bolt.middleware import (
     Middleware,
@@ -174,7 +175,11 @@ class App:
             # initialize with the default settings
             oauth_settings = OAuthSettings()
 
-        if oauth_flow:
+            if oauth_flow is None and installation_store is None:
+                # show info-level log for avoiding confusions
+                self._framework_logger.info(info_default_oauth_settings_loaded())
+
+        if oauth_flow is not None:
             self._oauth_flow = oauth_flow
             installation_store = select_consistent_installation_store(
                 client_id=self._oauth_flow.client_id,

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -45,6 +45,7 @@ from slack_bolt.logger.messages import (
     error_oauth_flow_invalid_type_async,
     warning_bot_only_conflicts,
     debug_return_listener_middleware_response,
+    info_default_oauth_settings_loaded,
 )
 from slack_bolt.lazy_listener.asyncio_runner import AsyncioLazyListenerRunner
 from slack_bolt.listener.async_listener import AsyncListener, AsyncCustomListener
@@ -183,6 +184,10 @@ class AsyncApp:
         ):
             # initialize with the default settings
             oauth_settings = AsyncOAuthSettings()
+
+            if oauth_flow is None and installation_store is None:
+                # show info-level log for avoiding confusions
+                self._framework_logger.info(info_default_oauth_settings_loaded())
 
         if oauth_flow:
             if not isinstance(oauth_flow, AsyncOAuthFlow):

--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -69,7 +69,8 @@ def warning_client_prioritized_and_token_skipped() -> str:
 
 def warning_token_skipped() -> str:
     return (
-        "As you gave `installation_store`/`authorize` as well, `token` will be unused."
+        "As either `installation_store` or `authorize` is enabled, "
+        "`token` (or SLACK_BOT_TOKEN env variable) will be unused."
     )
 
 
@@ -102,6 +103,16 @@ def warning_skip_uncommon_arg_name(arg_name: str) -> str:
 # -------------------------------
 # Info
 # -------------------------------
+
+
+def info_default_oauth_settings_loaded() -> str:
+    return (
+        "As you've set SLACK_CLIENT_ID and SLACK_CLIENT_SECRET env variables, "
+        "Bolt enabled file-based InstallationStore/OAuthStateStore for you. "
+        "Note that the file based ones are for local development. "
+        "If you want to use a different datastore, set oauth_settings argument in App constructor. "
+        "Refer to https://slack.dev/bolt-python/concepts#authenticating-oauth for more details."
+    )
 
 
 # -------------------------------

--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -69,8 +69,8 @@ def warning_client_prioritized_and_token_skipped() -> str:
 
 def warning_token_skipped() -> str:
     return (
-        "As either `installation_store` or `authorize` is enabled, "
-        "`token` (or SLACK_BOT_TOKEN env variable) will be unused."
+        "As `installation_store` or `authorize` has been used, "
+        "`token` (or SLACK_BOT_TOKEN env variable) will be ignored."
     )
 
 
@@ -108,10 +108,10 @@ def warning_skip_uncommon_arg_name(arg_name: str) -> str:
 def info_default_oauth_settings_loaded() -> str:
     return (
         "As you've set SLACK_CLIENT_ID and SLACK_CLIENT_SECRET env variables, "
-        "Bolt enabled file-based InstallationStore/OAuthStateStore for you. "
-        "Note that the file based ones are for local development. "
-        "If you want to use a different datastore, set oauth_settings argument in App constructor. "
-        "Refer to https://slack.dev/bolt-python/concepts#authenticating-oauth for more details."
+        "Bolt has enabled the file-based InstallationStore/OAuthStateStore for you. "
+        "Note that these file-based stores are for local development. "
+        "If you'd like to use a different data store, set the oauth_settings argument in the App constructor. "
+        "Please refer to https://slack.dev/bolt-python/concepts#authenticating-oauth for more details."
     )
 
 


### PR DESCRIPTION
This pull request improves the warning messages in `App` / `AsyncApp` constructor, that tells that both SLACK_BOT_TOKEN and authorize/installation_store are unexpectedly enabled. Refer to #256 for the context.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
