### PR TITLE
Fix #261 SocketModeHandler#start() does not terminate on Windows

### DIFF
--- a/slack_bolt/adapter/socket_mode/base_handler.py
+++ b/slack_bolt/adapter/socket_mode/base_handler.py
@@ -1,4 +1,6 @@
 import logging
+import signal
+import sys
 from threading import Event
 
 from slack_sdk.socket_mode.client import BaseSocketModeClient
@@ -30,4 +32,10 @@ class BaseSocketModeHandler:
             print(get_boot_message())
         else:
             self.app.logger.info(get_boot_message())
+
+        if sys.platform == "win32":
+            # Ctrl+C etc does not work on Windows OS
+            # see https://bugs.python.org/issue35935 for details
+            signal.signal(signal.SIGINT, signal.SIG_DFL)
+
         Event().wait()


### PR DESCRIPTION
This pull request resolves #261 by adding an extra logic for Windows OS. Refer to https://bugs.python.org/issue35935 for details.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
