### PR TITLE
Add Socket Mode adapter module documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status][build-image]][build-url]
 [![Codecov][codecov-image]][codecov-url]
 
-A Python framework to build Slack apps in a flash with the latest platform features. Read the [getting started guide](https://slack.dev/bolt-python/tutorial/getting-started) and look at our [code examples](https://github.com/slackapi/bolt-python/tree/main/examples) to learn how to build apps using Bolt.
+A Python framework to build Slack apps in a flash with the latest platform features. Read the [getting started guide](https://slack.dev/bolt-python/tutorial/getting-started) and look at our [code examples](https://github.com/slackapi/bolt-python/tree/main/examples) to learn how to build apps using Bolt. The Python module documents are available [here](https://slack.dev/bolt-python/api-docs/slack_bolt/).
 
 ## Setup
 
@@ -178,7 +178,7 @@ Apps can be run the same way as the syncronous example above. If you'd prefer an
 
 ## Getting Help
 
-[The documentation](https://slack.dev/bolt-python) has more information on basic and advanced concepts for Bolt for Python.
+[The documentation](https://slack.dev/bolt-python) has more information on basic and advanced concepts for Bolt for Python. Also, all the Python module documents of this library are available [here](https://slack.dev/bolt-python/api-docs/slack_bolt/).
 
 If you otherwise get stuck, we're here to help. The following are the best ways to get assistance working through your issue:
 

--- a/docs/api-docs/slack_bolt/adapter/index.html
+++ b/docs/api-docs/slack_bolt/adapter/index.html
@@ -76,7 +76,7 @@
 </dd>
 <dt><code class="name"><a title="slack_bolt.adapter.socket_mode" href="socket_mode/index.html">slack_bolt.adapter.socket_mode</a></code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Socket Mode adapter package provides the following implementations. If you don't have strong reasons to use 3rd party library based adapters, we …</p></div>
 </dd>
 <dt><code class="name"><a title="slack_bolt.adapter.starlette" href="starlette/index.html">slack_bolt.adapter.starlette</a></code></dt>
 <dd>

--- a/docs/api-docs/slack_bolt/adapter/socket_mode/aiohttp/index.html
+++ b/docs/api-docs/slack_bolt/adapter/socket_mode/aiohttp/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 <meta name="generator" content="pdoc 0.9.2" />
 <title>slack_bolt.adapter.socket_mode.aiohttp API documentation</title>
-<meta name="description" content="" />
+<meta name="description" content="[`aiohttp`](https://pypi.org/project/aiohttp/) based implementation / asyncio compatible" />
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
 <link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
@@ -22,11 +22,13 @@
 <h1 class="title">Module <code>slack_bolt.adapter.socket_mode.aiohttp</code></h1>
 </header>
 <section id="section-intro">
+<p><a href="https://pypi.org/project/aiohttp/"><code>aiohttp</code></a> based implementation / asyncio compatible</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">import os
+<pre><code class="python">&#34;&#34;&#34;[`aiohttp`](https://pypi.org/project/aiohttp/) based implementation / asyncio compatible&#34;&#34;&#34;
+import os
 from logging import Logger
 from time import time
 from typing import Optional
@@ -60,6 +62,16 @@ class SocketModeHandler(AsyncBaseSocketModeHandler):
         proxy: Optional[str] = None,
         ping_interval: float = 10,
     ):
+        &#34;&#34;&#34;Socket Mode adapter for Bolt apps
+
+        Args:
+            app: The Bolt app
+            app_token: App-level token starting with `xapp-`
+            logger: Custom logger
+            web_client: custom `slack_sdk.web.WebClient` instance
+            proxy: HTTP proxy URL
+            ping_interval: The ping-pong internal (seconds)
+        &#34;&#34;&#34;
         self.app = app
         self.app_token = app_token or os.environ[&#34;SLACK_APP_TOKEN&#34;]
         self.client = SocketModeClient(
@@ -176,31 +188,40 @@ class AsyncSocketModeHandler(AsyncBaseSocketModeHandler):
 <div class="desc"></div>
 </dd>
 </dl>
-<h3>Methods</h3>
-<dl>
-<dt id="slack_bolt.adapter.socket_mode.aiohttp.AsyncSocketModeHandler.handle"><code class="name flex">
-<span>async def <span class="ident">handle</span></span>(<span>self, client: slack_sdk.socket_mode.aiohttp.SocketModeClient, req: slack_sdk.socket_mode.request.SocketModeRequest) ‑> NoneType</span>
-</code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">async def handle(self, client: SocketModeClient, req: SocketModeRequest) -&gt; None:
-    start = time()
-    bolt_resp: BoltResponse = await run_async_bolt_app(self.app, req)
-    await send_async_response(client, req, bolt_resp, start)</code></pre>
-</details>
-</dd>
-</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler">AsyncBaseSocketModeHandler</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.close_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.close_async">close_async</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.connect_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.connect_async">connect_async</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.disconnect_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.disconnect_async">disconnect_async</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.handle" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.handle">handle</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.start_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.start_async">start_async</a></code></li>
+</ul>
+</li>
+</ul>
 </dd>
 <dt id="slack_bolt.adapter.socket_mode.aiohttp.SocketModeHandler"><code class="flex name class">
 <span>class <span class="ident">SocketModeHandler</span></span>
 <span>(</span><span>app: <a title="slack_bolt.app.app.App" href="../../../app/app.html#slack_bolt.app.app.App">App</a>, app_token: Optional[str] = None, logger: Optional[logging.Logger] = None, web_client: Optional[slack_sdk.web.async_client.AsyncWebClient] = None, proxy: Optional[str] = None, ping_interval: float = 10)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Socket Mode adapter for Bolt apps</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>app</code></strong></dt>
+<dd>The Bolt app</dd>
+<dt><strong><code>app_token</code></strong></dt>
+<dd>App-level token starting with <code>xapp-</code></dd>
+<dt><strong><code>logger</code></strong></dt>
+<dd>Custom logger</dd>
+<dt><strong><code>web_client</code></strong></dt>
+<dd>custom <code>slack_sdk.web.WebClient</code> instance</dd>
+<dt><strong><code>proxy</code></strong></dt>
+<dd>HTTP proxy URL</dd>
+<dt><strong><code>ping_interval</code></strong></dt>
+<dd>The ping-pong internal (seconds)</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -219,6 +240,16 @@ class AsyncSocketModeHandler(AsyncBaseSocketModeHandler):
         proxy: Optional[str] = None,
         ping_interval: float = 10,
     ):
+        &#34;&#34;&#34;Socket Mode adapter for Bolt apps
+
+        Args:
+            app: The Bolt app
+            app_token: App-level token starting with `xapp-`
+            logger: Custom logger
+            web_client: custom `slack_sdk.web.WebClient` instance
+            proxy: HTTP proxy URL
+            ping_interval: The ping-pong internal (seconds)
+        &#34;&#34;&#34;
         self.app = app
         self.app_token = app_token or os.environ[&#34;SLACK_APP_TOKEN&#34;]
         self.client = SocketModeClient(
@@ -254,24 +285,18 @@ class AsyncSocketModeHandler(AsyncBaseSocketModeHandler):
 <div class="desc"></div>
 </dd>
 </dl>
-<h3>Methods</h3>
-<dl>
-<dt id="slack_bolt.adapter.socket_mode.aiohttp.SocketModeHandler.handle"><code class="name flex">
-<span>async def <span class="ident">handle</span></span>(<span>self, client: slack_sdk.socket_mode.aiohttp.SocketModeClient, req: slack_sdk.socket_mode.request.SocketModeRequest) ‑> NoneType</span>
-</code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">async def handle(self, client: SocketModeClient, req: SocketModeRequest) -&gt; None:
-    start = time()
-    bolt_resp: BoltResponse = run_bolt_app(self.app, req)
-    await send_async_response(client, req, bolt_resp, start)</code></pre>
-</details>
-</dd>
-</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler">AsyncBaseSocketModeHandler</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.close_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.close_async">close_async</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.connect_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.connect_async">connect_async</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.disconnect_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.disconnect_async">disconnect_async</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.handle" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.handle">handle</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.start_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.start_async">start_async</a></code></li>
+</ul>
+</li>
+</ul>
 </dd>
 </dl>
 </section>
@@ -295,7 +320,6 @@ class AsyncSocketModeHandler(AsyncBaseSocketModeHandler):
 <li><code><a title="slack_bolt.adapter.socket_mode.aiohttp.AsyncSocketModeHandler.app" href="#slack_bolt.adapter.socket_mode.aiohttp.AsyncSocketModeHandler.app">app</a></code></li>
 <li><code><a title="slack_bolt.adapter.socket_mode.aiohttp.AsyncSocketModeHandler.app_token" href="#slack_bolt.adapter.socket_mode.aiohttp.AsyncSocketModeHandler.app_token">app_token</a></code></li>
 <li><code><a title="slack_bolt.adapter.socket_mode.aiohttp.AsyncSocketModeHandler.client" href="#slack_bolt.adapter.socket_mode.aiohttp.AsyncSocketModeHandler.client">client</a></code></li>
-<li><code><a title="slack_bolt.adapter.socket_mode.aiohttp.AsyncSocketModeHandler.handle" href="#slack_bolt.adapter.socket_mode.aiohttp.AsyncSocketModeHandler.handle">handle</a></code></li>
 </ul>
 </li>
 <li>
@@ -304,7 +328,6 @@ class AsyncSocketModeHandler(AsyncBaseSocketModeHandler):
 <li><code><a title="slack_bolt.adapter.socket_mode.aiohttp.SocketModeHandler.app" href="#slack_bolt.adapter.socket_mode.aiohttp.SocketModeHandler.app">app</a></code></li>
 <li><code><a title="slack_bolt.adapter.socket_mode.aiohttp.SocketModeHandler.app_token" href="#slack_bolt.adapter.socket_mode.aiohttp.SocketModeHandler.app_token">app_token</a></code></li>
 <li><code><a title="slack_bolt.adapter.socket_mode.aiohttp.SocketModeHandler.client" href="#slack_bolt.adapter.socket_mode.aiohttp.SocketModeHandler.client">client</a></code></li>
-<li><code><a title="slack_bolt.adapter.socket_mode.aiohttp.SocketModeHandler.handle" href="#slack_bolt.adapter.socket_mode.aiohttp.SocketModeHandler.handle">handle</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/api-docs/slack_bolt/adapter/socket_mode/async_base_handler.html
+++ b/docs/api-docs/slack_bolt/adapter/socket_mode/async_base_handler.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 <meta name="generator" content="pdoc 0.9.2" />
 <title>slack_bolt.adapter.socket_mode.async_base_handler API documentation</title>
-<meta name="description" content="" />
+<meta name="description" content="The base class of asyncio-based Socket Mode client implementation" />
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
 <link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
@@ -22,11 +22,13 @@
 <h1 class="title">Module <code>slack_bolt.adapter.socket_mode.async_base_handler</code></h1>
 </header>
 <section id="section-intro">
+<p>The base class of asyncio-based Socket Mode client implementation</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">import asyncio
+<pre><code class="python">&#34;&#34;&#34;The base class of asyncio-based Socket Mode client implementation&#34;&#34;&#34;
+import asyncio
 import logging
 from typing import Union
 
@@ -45,18 +47,31 @@ class AsyncBaseSocketModeHandler:
     async def handle(
         self, client: AsyncBaseSocketModeClient, req: SocketModeRequest
     ) -&gt; None:
+        &#34;&#34;&#34;Handles Socket Mode envelope requests through a WebSocket connection.
+
+        Args:
+            client: this Socket Mode client instance
+            req: the request data
+        &#34;&#34;&#34;
         raise NotImplementedError()
 
     async def connect_async(self):
+        &#34;&#34;&#34;Establishes a new connection with the Socket Mode server&#34;&#34;&#34;
         await self.client.connect()
 
     async def disconnect_async(self):
+        &#34;&#34;&#34;Disconnects the current WebSocket connection with the Socket Mode server&#34;&#34;&#34;
         await self.client.disconnect()
 
     async def close_async(self):
+        &#34;&#34;&#34;Disconnects from the Socket Mode server and cleans the resources this instance holds up&#34;&#34;&#34;
         await self.client.close()
 
     async def start_async(self):
+        &#34;&#34;&#34;Establishes a new connection and then starts infinite sleep
+        to prevent the termination of this process.
+        If you don&#39;t want to have the sleep, use `#connect()` method instead.
+        &#34;&#34;&#34;
         await self.connect_async()
         if self.app.logger.level &gt; logging.INFO:
             print(get_boot_message())
@@ -90,18 +105,31 @@ class AsyncBaseSocketModeHandler:
     async def handle(
         self, client: AsyncBaseSocketModeClient, req: SocketModeRequest
     ) -&gt; None:
+        &#34;&#34;&#34;Handles Socket Mode envelope requests through a WebSocket connection.
+
+        Args:
+            client: this Socket Mode client instance
+            req: the request data
+        &#34;&#34;&#34;
         raise NotImplementedError()
 
     async def connect_async(self):
+        &#34;&#34;&#34;Establishes a new connection with the Socket Mode server&#34;&#34;&#34;
         await self.client.connect()
 
     async def disconnect_async(self):
+        &#34;&#34;&#34;Disconnects the current WebSocket connection with the Socket Mode server&#34;&#34;&#34;
         await self.client.disconnect()
 
     async def close_async(self):
+        &#34;&#34;&#34;Disconnects from the Socket Mode server and cleans the resources this instance holds up&#34;&#34;&#34;
         await self.client.close()
 
     async def start_async(self):
+        &#34;&#34;&#34;Establishes a new connection and then starts infinite sleep
+        to prevent the termination of this process.
+        If you don&#39;t want to have the sleep, use `#connect()` method instead.
+        &#34;&#34;&#34;
         await self.connect_async()
         if self.app.logger.level &gt; logging.INFO:
             print(get_boot_message())
@@ -133,12 +161,13 @@ class AsyncBaseSocketModeHandler:
 <span>async def <span class="ident">close_async</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Disconnects from the Socket Mode server and cleans the resources this instance holds up</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">async def close_async(self):
+    &#34;&#34;&#34;Disconnects from the Socket Mode server and cleans the resources this instance holds up&#34;&#34;&#34;
     await self.client.close()</code></pre>
 </details>
 </dd>
@@ -146,12 +175,13 @@ class AsyncBaseSocketModeHandler:
 <span>async def <span class="ident">connect_async</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Establishes a new connection with the Socket Mode server</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">async def connect_async(self):
+    &#34;&#34;&#34;Establishes a new connection with the Socket Mode server&#34;&#34;&#34;
     await self.client.connect()</code></pre>
 </details>
 </dd>
@@ -159,12 +189,13 @@ class AsyncBaseSocketModeHandler:
 <span>async def <span class="ident">disconnect_async</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Disconnects the current WebSocket connection with the Socket Mode server</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">async def disconnect_async(self):
+    &#34;&#34;&#34;Disconnects the current WebSocket connection with the Socket Mode server&#34;&#34;&#34;
     await self.client.disconnect()</code></pre>
 </details>
 </dd>
@@ -172,7 +203,14 @@ class AsyncBaseSocketModeHandler:
 <span>async def <span class="ident">handle</span></span>(<span>self, client: slack_sdk.socket_mode.async_client.AsyncBaseSocketModeClient, req: slack_sdk.socket_mode.request.SocketModeRequest) ‑> NoneType</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Handles Socket Mode envelope requests through a WebSocket connection.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>client</code></strong></dt>
+<dd>this Socket Mode client instance</dd>
+<dt><strong><code>req</code></strong></dt>
+<dd>the request data</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -180,6 +218,12 @@ class AsyncBaseSocketModeHandler:
 <pre><code class="python">async def handle(
     self, client: AsyncBaseSocketModeClient, req: SocketModeRequest
 ) -&gt; None:
+    &#34;&#34;&#34;Handles Socket Mode envelope requests through a WebSocket connection.
+
+    Args:
+        client: this Socket Mode client instance
+        req: the request data
+    &#34;&#34;&#34;
     raise NotImplementedError()</code></pre>
 </details>
 </dd>
@@ -187,12 +231,18 @@ class AsyncBaseSocketModeHandler:
 <span>async def <span class="ident">start_async</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Establishes a new connection and then starts infinite sleep
+to prevent the termination of this process.
+If you don't want to have the sleep, use <code>#connect()</code> method instead.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">async def start_async(self):
+    &#34;&#34;&#34;Establishes a new connection and then starts infinite sleep
+    to prevent the termination of this process.
+    If you don&#39;t want to have the sleep, use `#connect()` method instead.
+    &#34;&#34;&#34;
     await self.connect_async()
     if self.app.logger.level &gt; logging.INFO:
         print(get_boot_message())

--- a/docs/api-docs/slack_bolt/adapter/socket_mode/async_handler.html
+++ b/docs/api-docs/slack_bolt/adapter/socket_mode/async_handler.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 <meta name="generator" content="pdoc 0.9.2" />
 <title>slack_bolt.adapter.socket_mode.async_handler API documentation</title>
-<meta name="description" content="" />
+<meta name="description" content="Default implementation is the aiohttp-based one." />
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
 <link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
@@ -22,11 +22,13 @@
 <h1 class="title">Module <code>slack_bolt.adapter.socket_mode.async_handler</code></h1>
 </header>
 <section id="section-intro">
+<p>Default implementation is the aiohttp-based one.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">from .aiohttp import AsyncSocketModeHandler  # noqa</code></pre>
+<pre><code class="python">&#34;&#34;&#34;Default implementation is the aiohttp-based one.&#34;&#34;&#34;
+from .aiohttp import AsyncSocketModeHandler  # noqa</code></pre>
 </details>
 </section>
 <section>

--- a/docs/api-docs/slack_bolt/adapter/socket_mode/async_internals.html
+++ b/docs/api-docs/slack_bolt/adapter/socket_mode/async_internals.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 <meta name="generator" content="pdoc 0.9.2" />
 <title>slack_bolt.adapter.socket_mode.async_internals API documentation</title>
-<meta name="description" content="" />
+<meta name="description" content="Internal functions" />
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
 <link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
@@ -22,11 +22,13 @@
 <h1 class="title">Module <code>slack_bolt.adapter.socket_mode.async_internals</code></h1>
 </header>
 <section id="section-intro">
+<p>Internal functions</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">import json
+<pre><code class="python">&#34;&#34;&#34;Internal functions&#34;&#34;&#34;
+import json
 import logging
 from time import time
 

--- a/docs/api-docs/slack_bolt/adapter/socket_mode/base_handler.html
+++ b/docs/api-docs/slack_bolt/adapter/socket_mode/base_handler.html
@@ -5,7 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 <meta name="generator" content="pdoc 0.9.2" />
 <title>slack_bolt.adapter.socket_mode.base_handler API documentation</title>
-<meta name="description" content="" />
+<meta name="description" content="The base class of Socket Mode client implementation.
+If you want to build asyncio-based ones, use `AsyncBaseSocketModeHandler` instead." />
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
 <link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
@@ -22,11 +23,16 @@
 <h1 class="title">Module <code>slack_bolt.adapter.socket_mode.base_handler</code></h1>
 </header>
 <section id="section-intro">
+<p>The base class of Socket Mode client implementation.
+If you want to build asyncio-based ones, use <code>AsyncBaseSocketModeHandler</code> instead.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">import logging
+<pre><code class="python">&#34;&#34;&#34;The base class of Socket Mode client implementation.
+If you want to build asyncio-based ones, use `AsyncBaseSocketModeHandler` instead.
+&#34;&#34;&#34;
+import logging
 import signal
 import sys
 from threading import Event
@@ -43,18 +49,31 @@ class BaseSocketModeHandler:
     client: BaseSocketModeClient
 
     def handle(self, client: BaseSocketModeClient, req: SocketModeRequest) -&gt; None:
+        &#34;&#34;&#34;Handles Socket Mode envelope requests through a WebSocket connection.
+
+        Args:
+            client: this Socket Mode client instance
+            req: the request data
+        &#34;&#34;&#34;
         raise NotImplementedError()
 
     def connect(self):
+        &#34;&#34;&#34;Establishes a new connection with the Socket Mode server&#34;&#34;&#34;
         self.client.connect()
 
     def disconnect(self):
+        &#34;&#34;&#34;Disconnects the current WebSocket connection with the Socket Mode server&#34;&#34;&#34;
         self.client.disconnect()
 
     def close(self):
+        &#34;&#34;&#34;Disconnects from the Socket Mode server and cleans the resources this instance holds up&#34;&#34;&#34;
         self.client.close()
 
     def start(self):
+        &#34;&#34;&#34;Establishes a new connection and then blocks the current thread
+        to prevent the termination of this process.
+        If you don&#39;t want to block the current thread, use `#connect()` method instead.
+        &#34;&#34;&#34;
         self.connect()
         if self.app.logger.level &gt; logging.INFO:
             print(get_boot_message())
@@ -92,18 +111,31 @@ class BaseSocketModeHandler:
     client: BaseSocketModeClient
 
     def handle(self, client: BaseSocketModeClient, req: SocketModeRequest) -&gt; None:
+        &#34;&#34;&#34;Handles Socket Mode envelope requests through a WebSocket connection.
+
+        Args:
+            client: this Socket Mode client instance
+            req: the request data
+        &#34;&#34;&#34;
         raise NotImplementedError()
 
     def connect(self):
+        &#34;&#34;&#34;Establishes a new connection with the Socket Mode server&#34;&#34;&#34;
         self.client.connect()
 
     def disconnect(self):
+        &#34;&#34;&#34;Disconnects the current WebSocket connection with the Socket Mode server&#34;&#34;&#34;
         self.client.disconnect()
 
     def close(self):
+        &#34;&#34;&#34;Disconnects from the Socket Mode server and cleans the resources this instance holds up&#34;&#34;&#34;
         self.client.close()
 
     def start(self):
+        &#34;&#34;&#34;Establishes a new connection and then blocks the current thread
+        to prevent the termination of this process.
+        If you don&#39;t want to block the current thread, use `#connect()` method instead.
+        &#34;&#34;&#34;
         self.connect()
         if self.app.logger.level &gt; logging.INFO:
             print(get_boot_message())
@@ -139,12 +171,13 @@ class BaseSocketModeHandler:
 <span>def <span class="ident">close</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Disconnects from the Socket Mode server and cleans the resources this instance holds up</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def close(self):
+    &#34;&#34;&#34;Disconnects from the Socket Mode server and cleans the resources this instance holds up&#34;&#34;&#34;
     self.client.close()</code></pre>
 </details>
 </dd>
@@ -152,12 +185,13 @@ class BaseSocketModeHandler:
 <span>def <span class="ident">connect</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Establishes a new connection with the Socket Mode server</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def connect(self):
+    &#34;&#34;&#34;Establishes a new connection with the Socket Mode server&#34;&#34;&#34;
     self.client.connect()</code></pre>
 </details>
 </dd>
@@ -165,12 +199,13 @@ class BaseSocketModeHandler:
 <span>def <span class="ident">disconnect</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Disconnects the current WebSocket connection with the Socket Mode server</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def disconnect(self):
+    &#34;&#34;&#34;Disconnects the current WebSocket connection with the Socket Mode server&#34;&#34;&#34;
     self.client.disconnect()</code></pre>
 </details>
 </dd>
@@ -178,12 +213,25 @@ class BaseSocketModeHandler:
 <span>def <span class="ident">handle</span></span>(<span>self, client: slack_sdk.socket_mode.client.BaseSocketModeClient, req: slack_sdk.socket_mode.request.SocketModeRequest) ‑> NoneType</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Handles Socket Mode envelope requests through a WebSocket connection.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>client</code></strong></dt>
+<dd>this Socket Mode client instance</dd>
+<dt><strong><code>req</code></strong></dt>
+<dd>the request data</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def handle(self, client: BaseSocketModeClient, req: SocketModeRequest) -&gt; None:
+    &#34;&#34;&#34;Handles Socket Mode envelope requests through a WebSocket connection.
+
+    Args:
+        client: this Socket Mode client instance
+        req: the request data
+    &#34;&#34;&#34;
     raise NotImplementedError()</code></pre>
 </details>
 </dd>
@@ -191,12 +239,18 @@ class BaseSocketModeHandler:
 <span>def <span class="ident">start</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Establishes a new connection and then blocks the current thread
+to prevent the termination of this process.
+If you don't want to block the current thread, use <code>#connect()</code> method instead.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def start(self):
+    &#34;&#34;&#34;Establishes a new connection and then blocks the current thread
+    to prevent the termination of this process.
+    If you don&#39;t want to block the current thread, use `#connect()` method instead.
+    &#34;&#34;&#34;
     self.connect()
     if self.app.logger.level &gt; logging.INFO:
         print(get_boot_message())

--- a/docs/api-docs/slack_bolt/adapter/socket_mode/builtin/index.html
+++ b/docs/api-docs/slack_bolt/adapter/socket_mode/builtin/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 <meta name="generator" content="pdoc 0.9.2" />
 <title>slack_bolt.adapter.socket_mode.builtin API documentation</title>
-<meta name="description" content="" />
+<meta name="description" content="The built-in implementation, which does not have any external dependencies" />
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
 <link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
@@ -22,11 +22,13 @@
 <h1 class="title">Module <code>slack_bolt.adapter.socket_mode.builtin</code></h1>
 </header>
 <section id="section-intro">
+<p>The built-in implementation, which does not have any external dependencies</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">import os
+<pre><code class="python">&#34;&#34;&#34;The built-in implementation, which does not have any external dependencies&#34;&#34;&#34;
+import os
 from logging import Logger
 from time import time
 from typing import Optional, Dict
@@ -62,6 +64,23 @@ class SocketModeHandler(BaseSocketModeHandler):
         receive_buffer_size: int = 1024,
         concurrency: int = 10,
     ):
+        &#34;&#34;&#34;Socket Mode adapter for Bolt apps
+
+        Args:
+            app: The Bolt app
+            app_token: App-level token starting with `xapp-`
+            logger: Custom logger
+            web_client: custom `slack_sdk.web.WebClient` instance
+            proxy: HTTP proxy URL
+            proxy_headers: Additional request header for proxy connections
+            auto_reconnect_enabled: True if the auto-reconnect logic works
+            trace_enabled: True if trace-level logging is enabled
+            all_message_trace_enabled: True if trace-logging for all received WebSocket messages is enabled
+            ping_pong_trace_enabled: True if trace-logging for all ping-pong communications
+            ping_interval: The ping-pong internal (seconds)
+            receive_buffer_size: The data length for a single socket recv operation
+            concurrency: The size of the underlying thread pool
+        &#34;&#34;&#34;
         self.app = app
         self.app_token = app_token or os.environ[&#34;SLACK_APP_TOKEN&#34;]
         self.client = SocketModeClient(
@@ -100,7 +119,36 @@ class SocketModeHandler(BaseSocketModeHandler):
 <span>(</span><span>app: <a title="slack_bolt.app.app.App" href="../../../app/app.html#slack_bolt.app.app.App">App</a>, app_token: Optional[str] = None, logger: Optional[logging.Logger] = None, web_client: Optional[slack_sdk.web.client.WebClient] = None, proxy: Optional[str] = None, proxy_headers: Optional[Dict[str, str]] = None, auto_reconnect_enabled: bool = True, trace_enabled: bool = False, all_message_trace_enabled: bool = False, ping_pong_trace_enabled: bool = False, ping_interval: float = 10, receive_buffer_size: int = 1024, concurrency: int = 10)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Socket Mode adapter for Bolt apps</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>app</code></strong></dt>
+<dd>The Bolt app</dd>
+<dt><strong><code>app_token</code></strong></dt>
+<dd>App-level token starting with <code>xapp-</code></dd>
+<dt><strong><code>logger</code></strong></dt>
+<dd>Custom logger</dd>
+<dt><strong><code>web_client</code></strong></dt>
+<dd>custom <code>slack_sdk.web.WebClient</code> instance</dd>
+<dt><strong><code>proxy</code></strong></dt>
+<dd>HTTP proxy URL</dd>
+<dt><strong><code>proxy_headers</code></strong></dt>
+<dd>Additional request header for proxy connections</dd>
+<dt><strong><code>auto_reconnect_enabled</code></strong></dt>
+<dd>True if the auto-reconnect logic works</dd>
+<dt><strong><code>trace_enabled</code></strong></dt>
+<dd>True if trace-level logging is enabled</dd>
+<dt><strong><code>all_message_trace_enabled</code></strong></dt>
+<dd>True if trace-logging for all received WebSocket messages is enabled</dd>
+<dt><strong><code>ping_pong_trace_enabled</code></strong></dt>
+<dd>True if trace-logging for all ping-pong communications</dd>
+<dt><strong><code>ping_interval</code></strong></dt>
+<dd>The ping-pong internal (seconds)</dd>
+<dt><strong><code>receive_buffer_size</code></strong></dt>
+<dd>The data length for a single socket recv operation</dd>
+<dt><strong><code>concurrency</code></strong></dt>
+<dd>The size of the underlying thread pool</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -126,6 +174,23 @@ class SocketModeHandler(BaseSocketModeHandler):
         receive_buffer_size: int = 1024,
         concurrency: int = 10,
     ):
+        &#34;&#34;&#34;Socket Mode adapter for Bolt apps
+
+        Args:
+            app: The Bolt app
+            app_token: App-level token starting with `xapp-`
+            logger: Custom logger
+            web_client: custom `slack_sdk.web.WebClient` instance
+            proxy: HTTP proxy URL
+            proxy_headers: Additional request header for proxy connections
+            auto_reconnect_enabled: True if the auto-reconnect logic works
+            trace_enabled: True if trace-level logging is enabled
+            all_message_trace_enabled: True if trace-logging for all received WebSocket messages is enabled
+            ping_pong_trace_enabled: True if trace-logging for all ping-pong communications
+            ping_interval: The ping-pong internal (seconds)
+            receive_buffer_size: The data length for a single socket recv operation
+            concurrency: The size of the underlying thread pool
+        &#34;&#34;&#34;
         self.app = app
         self.app_token = app_token or os.environ[&#34;SLACK_APP_TOKEN&#34;]
         self.client = SocketModeClient(
@@ -168,24 +233,18 @@ class SocketModeHandler(BaseSocketModeHandler):
 <div class="desc"></div>
 </dd>
 </dl>
-<h3>Methods</h3>
-<dl>
-<dt id="slack_bolt.adapter.socket_mode.builtin.SocketModeHandler.handle"><code class="name flex">
-<span>def <span class="ident">handle</span></span>(<span>self, client: slack_sdk.socket_mode.builtin.client.SocketModeClient, req: slack_sdk.socket_mode.request.SocketModeRequest) ‑> NoneType</span>
-</code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def handle(self, client: SocketModeClient, req: SocketModeRequest) -&gt; None:
-    start = time()
-    bolt_resp: BoltResponse = run_bolt_app(self.app, req)
-    send_response(client, req, bolt_resp, start)</code></pre>
-</details>
-</dd>
-</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler" href="../base_handler.html#slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler">BaseSocketModeHandler</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.close" href="../base_handler.html#slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.close">close</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.connect" href="../base_handler.html#slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.connect">connect</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.disconnect" href="../base_handler.html#slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.disconnect">disconnect</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.handle" href="../base_handler.html#slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.handle">handle</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.start" href="../base_handler.html#slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.start">start</a></code></li>
+</ul>
+</li>
+</ul>
 </dd>
 </dl>
 </section>
@@ -209,7 +268,6 @@ class SocketModeHandler(BaseSocketModeHandler):
 <li><code><a title="slack_bolt.adapter.socket_mode.builtin.SocketModeHandler.app" href="#slack_bolt.adapter.socket_mode.builtin.SocketModeHandler.app">app</a></code></li>
 <li><code><a title="slack_bolt.adapter.socket_mode.builtin.SocketModeHandler.app_token" href="#slack_bolt.adapter.socket_mode.builtin.SocketModeHandler.app_token">app_token</a></code></li>
 <li><code><a title="slack_bolt.adapter.socket_mode.builtin.SocketModeHandler.client" href="#slack_bolt.adapter.socket_mode.builtin.SocketModeHandler.client">client</a></code></li>
-<li><code><a title="slack_bolt.adapter.socket_mode.builtin.SocketModeHandler.handle" href="#slack_bolt.adapter.socket_mode.builtin.SocketModeHandler.handle">handle</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/api-docs/slack_bolt/adapter/socket_mode/index.html
+++ b/docs/api-docs/slack_bolt/adapter/socket_mode/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 <meta name="generator" content="pdoc 0.9.2" />
 <title>slack_bolt.adapter.socket_mode API documentation</title>
-<meta name="description" content="" />
+<meta name="description" content="Socket Mode adapter package provides the following implementations. If you don&#39;t have strong reasons to use 3rd party library based adapters, we …" />
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
 <link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
@@ -22,11 +22,26 @@
 <h1 class="title">Module <code>slack_bolt.adapter.socket_mode</code></h1>
 </header>
 <section id="section-intro">
+<p>Socket Mode adapter package provides the following implementations. If you don't have strong reasons to use 3rd party library based adapters, we recommend using the built-in client based one.</p>
+<ul>
+<li><code><a title="slack_bolt.adapter.socket_mode.builtin" href="builtin/index.html">slack_bolt.adapter.socket_mode.builtin</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.websocket_client" href="websocket_client/index.html">slack_bolt.adapter.socket_mode.websocket_client</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.aiohttp" href="aiohttp/index.html">slack_bolt.adapter.socket_mode.aiohttp</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.websockets" href="websockets/index.html">slack_bolt.adapter.socket_mode.websockets</a></code></li>
+</ul>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python"># Don&#39;t add async module imports here
+<pre><code class="python">&#34;&#34;&#34;Socket Mode adapter package provides the following implementations. If you don&#39;t have strong reasons to use 3rd party library based adapters, we recommend using the built-in client based one.
+
+* `slack_bolt.adapter.socket_mode.builtin`
+* `slack_bolt.adapter.socket_mode.websocket_client`
+* `slack_bolt.adapter.socket_mode.aiohttp`
+* `slack_bolt.adapter.socket_mode.websockets`
+&#34;&#34;&#34;
+
+# Don&#39;t add async module imports here
 from .builtin import SocketModeHandler  # noqa</code></pre>
 </details>
 </section>
@@ -35,39 +50,41 @@ from .builtin import SocketModeHandler  # noqa</code></pre>
 <dl>
 <dt><code class="name"><a title="slack_bolt.adapter.socket_mode.aiohttp" href="aiohttp/index.html">slack_bolt.adapter.socket_mode.aiohttp</a></code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p><a href="https://pypi.org/project/aiohttp/"><code>aiohttp</code></a> based implementation / asyncio compatible</p></div>
 </dd>
 <dt><code class="name"><a title="slack_bolt.adapter.socket_mode.async_base_handler" href="async_base_handler.html">slack_bolt.adapter.socket_mode.async_base_handler</a></code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>The base class of asyncio-based Socket Mode client implementation</p></div>
 </dd>
 <dt><code class="name"><a title="slack_bolt.adapter.socket_mode.async_handler" href="async_handler.html">slack_bolt.adapter.socket_mode.async_handler</a></code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Default implementation is the aiohttp-based one.</p></div>
 </dd>
 <dt><code class="name"><a title="slack_bolt.adapter.socket_mode.async_internals" href="async_internals.html">slack_bolt.adapter.socket_mode.async_internals</a></code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Internal functions</p></div>
 </dd>
 <dt><code class="name"><a title="slack_bolt.adapter.socket_mode.base_handler" href="base_handler.html">slack_bolt.adapter.socket_mode.base_handler</a></code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>The base class of Socket Mode client implementation.
+If you want to build asyncio-based ones, use <code>AsyncBaseSocketModeHandler</code> instead.</p></div>
 </dd>
 <dt><code class="name"><a title="slack_bolt.adapter.socket_mode.builtin" href="builtin/index.html">slack_bolt.adapter.socket_mode.builtin</a></code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>The built-in implementation, which does not have any external dependencies</p></div>
 </dd>
 <dt><code class="name"><a title="slack_bolt.adapter.socket_mode.internals" href="internals.html">slack_bolt.adapter.socket_mode.internals</a></code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Internal functions</p></div>
 </dd>
 <dt><code class="name"><a title="slack_bolt.adapter.socket_mode.websocket_client" href="websocket_client/index.html">slack_bolt.adapter.socket_mode.websocket_client</a></code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p><a href="https://pypi.org/project/websocket-client/"><code>websocket-client</code></a> based implementation</p></div>
 </dd>
 <dt><code class="name"><a title="slack_bolt.adapter.socket_mode.websockets" href="websockets/index.html">slack_bolt.adapter.socket_mode.websockets</a></code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p><a href="https://pypi.org/project/websockets/"><code>websockets</code></a> based implementation
+/ asyncio compatible</p></div>
 </dd>
 </dl>
 </section>

--- a/docs/api-docs/slack_bolt/adapter/socket_mode/internals.html
+++ b/docs/api-docs/slack_bolt/adapter/socket_mode/internals.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 <meta name="generator" content="pdoc 0.9.2" />
 <title>slack_bolt.adapter.socket_mode.internals API documentation</title>
-<meta name="description" content="" />
+<meta name="description" content="Internal functions" />
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
 <link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
@@ -22,11 +22,13 @@
 <h1 class="title">Module <code>slack_bolt.adapter.socket_mode.internals</code></h1>
 </header>
 <section id="section-intro">
+<p>Internal functions</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">import json
+<pre><code class="python">&#34;&#34;&#34;Internal functions&#34;&#34;&#34;
+import json
 import logging
 from time import time
 

--- a/docs/api-docs/slack_bolt/adapter/socket_mode/websocket_client/index.html
+++ b/docs/api-docs/slack_bolt/adapter/socket_mode/websocket_client/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 <meta name="generator" content="pdoc 0.9.2" />
 <title>slack_bolt.adapter.socket_mode.websocket_client API documentation</title>
-<meta name="description" content="" />
+<meta name="description" content="[`websocket-client`](https://pypi.org/project/websocket-client/) based implementation" />
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
 <link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
@@ -22,11 +22,13 @@
 <h1 class="title">Module <code>slack_bolt.adapter.socket_mode.websocket_client</code></h1>
 </header>
 <section id="section-intro">
+<p><a href="https://pypi.org/project/websocket-client/"><code>websocket-client</code></a> based implementation</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">import os
+<pre><code class="python">&#34;&#34;&#34;[`websocket-client`](https://pypi.org/project/websocket-client/) based implementation&#34;&#34;&#34;
+import os
 from logging import Logger
 from time import time
 from typing import Optional, Tuple
@@ -60,6 +62,21 @@ class SocketModeHandler(BaseSocketModeHandler):
         proxy_type: Optional[str] = None,
         trace_enabled: bool = False,
     ):
+        &#34;&#34;&#34;Socket Mode adapter for Bolt apps
+
+        Args:
+            app: The Bolt app
+            app_token: App-level token starting with `xapp-`
+            logger: Custom logger
+            web_client: custom `slack_sdk.web.WebClient` instance
+            ping_interval: The ping-pong internal (seconds)
+            concurrency: The size of the underlying thread pool
+            http_proxy_host: HTTP proxy host
+            http_proxy_port: HTTP proxy port
+            http_proxy_auth: HTTP proxy authentication (username, password)
+            proxy_type: Proxy type
+            trace_enabled: True if trace-level logging is enabled
+        &#34;&#34;&#34;
         self.app = app
         self.app_token = app_token or os.environ[&#34;SLACK_APP_TOKEN&#34;]
         self.client = SocketModeClient(
@@ -96,7 +113,32 @@ class SocketModeHandler(BaseSocketModeHandler):
 <span>(</span><span>app: <a title="slack_bolt.app.app.App" href="../../../app/app.html#slack_bolt.app.app.App">App</a>, app_token: Optional[str] = None, logger: Optional[logging.Logger] = None, web_client: Optional[slack_sdk.web.client.WebClient] = None, ping_interval: float = 10, concurrency: int = 10, http_proxy_host: Optional[str] = None, http_proxy_port: Optional[int] = None, http_proxy_auth: Optional[Tuple[str, str]] = None, proxy_type: Optional[str] = None, trace_enabled: bool = False)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Socket Mode adapter for Bolt apps</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>app</code></strong></dt>
+<dd>The Bolt app</dd>
+<dt><strong><code>app_token</code></strong></dt>
+<dd>App-level token starting with <code>xapp-</code></dd>
+<dt><strong><code>logger</code></strong></dt>
+<dd>Custom logger</dd>
+<dt><strong><code>web_client</code></strong></dt>
+<dd>custom <code>slack_sdk.web.WebClient</code> instance</dd>
+<dt><strong><code>ping_interval</code></strong></dt>
+<dd>The ping-pong internal (seconds)</dd>
+<dt><strong><code>concurrency</code></strong></dt>
+<dd>The size of the underlying thread pool</dd>
+<dt><strong><code>http_proxy_host</code></strong></dt>
+<dd>HTTP proxy host</dd>
+<dt><strong><code>http_proxy_port</code></strong></dt>
+<dd>HTTP proxy port</dd>
+<dt><strong><code>http_proxy_auth</code></strong></dt>
+<dd>HTTP proxy authentication (username, password)</dd>
+<dt><strong><code>proxy_type</code></strong></dt>
+<dd>Proxy type</dd>
+<dt><strong><code>trace_enabled</code></strong></dt>
+<dd>True if trace-level logging is enabled</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -120,6 +162,21 @@ class SocketModeHandler(BaseSocketModeHandler):
         proxy_type: Optional[str] = None,
         trace_enabled: bool = False,
     ):
+        &#34;&#34;&#34;Socket Mode adapter for Bolt apps
+
+        Args:
+            app: The Bolt app
+            app_token: App-level token starting with `xapp-`
+            logger: Custom logger
+            web_client: custom `slack_sdk.web.WebClient` instance
+            ping_interval: The ping-pong internal (seconds)
+            concurrency: The size of the underlying thread pool
+            http_proxy_host: HTTP proxy host
+            http_proxy_port: HTTP proxy port
+            http_proxy_auth: HTTP proxy authentication (username, password)
+            proxy_type: Proxy type
+            trace_enabled: True if trace-level logging is enabled
+        &#34;&#34;&#34;
         self.app = app
         self.app_token = app_token or os.environ[&#34;SLACK_APP_TOKEN&#34;]
         self.client = SocketModeClient(
@@ -160,24 +217,18 @@ class SocketModeHandler(BaseSocketModeHandler):
 <div class="desc"></div>
 </dd>
 </dl>
-<h3>Methods</h3>
-<dl>
-<dt id="slack_bolt.adapter.socket_mode.websocket_client.SocketModeHandler.handle"><code class="name flex">
-<span>def <span class="ident">handle</span></span>(<span>self, client: slack_sdk.socket_mode.websocket_client.SocketModeClient, req: slack_sdk.socket_mode.request.SocketModeRequest) ‑> NoneType</span>
-</code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def handle(self, client: SocketModeClient, req: SocketModeRequest) -&gt; None:
-    start = time()
-    bolt_resp: BoltResponse = run_bolt_app(self.app, req)
-    send_response(client, req, bolt_resp, start)</code></pre>
-</details>
-</dd>
-</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler" href="../base_handler.html#slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler">BaseSocketModeHandler</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.close" href="../base_handler.html#slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.close">close</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.connect" href="../base_handler.html#slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.connect">connect</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.disconnect" href="../base_handler.html#slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.disconnect">disconnect</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.handle" href="../base_handler.html#slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.handle">handle</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.start" href="../base_handler.html#slack_bolt.adapter.socket_mode.base_handler.BaseSocketModeHandler.start">start</a></code></li>
+</ul>
+</li>
+</ul>
 </dd>
 </dl>
 </section>
@@ -201,7 +252,6 @@ class SocketModeHandler(BaseSocketModeHandler):
 <li><code><a title="slack_bolt.adapter.socket_mode.websocket_client.SocketModeHandler.app" href="#slack_bolt.adapter.socket_mode.websocket_client.SocketModeHandler.app">app</a></code></li>
 <li><code><a title="slack_bolt.adapter.socket_mode.websocket_client.SocketModeHandler.app_token" href="#slack_bolt.adapter.socket_mode.websocket_client.SocketModeHandler.app_token">app_token</a></code></li>
 <li><code><a title="slack_bolt.adapter.socket_mode.websocket_client.SocketModeHandler.client" href="#slack_bolt.adapter.socket_mode.websocket_client.SocketModeHandler.client">client</a></code></li>
-<li><code><a title="slack_bolt.adapter.socket_mode.websocket_client.SocketModeHandler.handle" href="#slack_bolt.adapter.socket_mode.websocket_client.SocketModeHandler.handle">handle</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/api-docs/slack_bolt/adapter/socket_mode/websockets/index.html
+++ b/docs/api-docs/slack_bolt/adapter/socket_mode/websockets/index.html
@@ -5,7 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 <meta name="generator" content="pdoc 0.9.2" />
 <title>slack_bolt.adapter.socket_mode.websockets API documentation</title>
-<meta name="description" content="" />
+<meta name="description" content="[`websockets`](https://pypi.org/project/websockets/) based implementation
+/ asyncio compatible" />
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
 <link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
@@ -22,11 +23,14 @@
 <h1 class="title">Module <code>slack_bolt.adapter.socket_mode.websockets</code></h1>
 </header>
 <section id="section-intro">
+<p><a href="https://pypi.org/project/websockets/"><code>websockets</code></a> based implementation
+/ asyncio compatible</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">import os
+<pre><code class="python">&#34;&#34;&#34;[`websockets`](https://pypi.org/project/websockets/) based implementation  / asyncio compatible&#34;&#34;&#34;
+import os
 from logging import Logger
 from time import time
 from typing import Optional
@@ -59,6 +63,19 @@ class SocketModeHandler(AsyncBaseSocketModeHandler):
         web_client: Optional[AsyncWebClient] = None,
         ping_interval: float = 10,
     ):
+        &#34;&#34;&#34;Socket Mode adapter for Bolt apps.
+
+        Please note that this adapter does not support proxy configuration
+        as the underlying websockets module does not support proxy-wired connections.
+        If you use proxy, consider using one of the other Socket Mode adapters.
+
+        Args:
+            app: The Bolt app
+            app_token: App-level token starting with `xapp-`
+            logger: Custom logger
+            web_client: custom `slack_sdk.web.WebClient` instance
+            ping_interval: The ping-pong internal (seconds)
+        &#34;&#34;&#34;
         self.app = app
         self.app_token = app_token or os.environ[&#34;SLACK_APP_TOKEN&#34;]
         self.client = SocketModeClient(
@@ -170,31 +187,41 @@ class AsyncSocketModeHandler(AsyncBaseSocketModeHandler):
 <div class="desc"></div>
 </dd>
 </dl>
-<h3>Methods</h3>
-<dl>
-<dt id="slack_bolt.adapter.socket_mode.websockets.AsyncSocketModeHandler.handle"><code class="name flex">
-<span>async def <span class="ident">handle</span></span>(<span>self, client: slack_sdk.socket_mode.websockets.SocketModeClient, req: slack_sdk.socket_mode.request.SocketModeRequest) ‑> NoneType</span>
-</code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">async def handle(self, client: SocketModeClient, req: SocketModeRequest) -&gt; None:
-    start = time()
-    bolt_resp: BoltResponse = await run_async_bolt_app(self.app, req)
-    await send_async_response(client, req, bolt_resp, start)</code></pre>
-</details>
-</dd>
-</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler">AsyncBaseSocketModeHandler</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.close_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.close_async">close_async</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.connect_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.connect_async">connect_async</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.disconnect_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.disconnect_async">disconnect_async</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.handle" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.handle">handle</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.start_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.start_async">start_async</a></code></li>
+</ul>
+</li>
+</ul>
 </dd>
 <dt id="slack_bolt.adapter.socket_mode.websockets.SocketModeHandler"><code class="flex name class">
 <span>class <span class="ident">SocketModeHandler</span></span>
 <span>(</span><span>app: <a title="slack_bolt.app.app.App" href="../../../app/app.html#slack_bolt.app.app.App">App</a>, app_token: Optional[str] = None, logger: Optional[logging.Logger] = None, web_client: Optional[slack_sdk.web.async_client.AsyncWebClient] = None, ping_interval: float = 10)</span>
 </code></dt>
 <dd>
-<div class="desc"></div>
+<div class="desc"><p>Socket Mode adapter for Bolt apps.</p>
+<p>Please note that this adapter does not support proxy configuration
+as the underlying websockets module does not support proxy-wired connections.
+If you use proxy, consider using one of the other Socket Mode adapters.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>app</code></strong></dt>
+<dd>The Bolt app</dd>
+<dt><strong><code>app_token</code></strong></dt>
+<dd>App-level token starting with <code>xapp-</code></dd>
+<dt><strong><code>logger</code></strong></dt>
+<dd>Custom logger</dd>
+<dt><strong><code>web_client</code></strong></dt>
+<dd>custom <code>slack_sdk.web.WebClient</code> instance</dd>
+<dt><strong><code>ping_interval</code></strong></dt>
+<dd>The ping-pong internal (seconds)</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -212,6 +239,19 @@ class AsyncSocketModeHandler(AsyncBaseSocketModeHandler):
         web_client: Optional[AsyncWebClient] = None,
         ping_interval: float = 10,
     ):
+        &#34;&#34;&#34;Socket Mode adapter for Bolt apps.
+
+        Please note that this adapter does not support proxy configuration
+        as the underlying websockets module does not support proxy-wired connections.
+        If you use proxy, consider using one of the other Socket Mode adapters.
+
+        Args:
+            app: The Bolt app
+            app_token: App-level token starting with `xapp-`
+            logger: Custom logger
+            web_client: custom `slack_sdk.web.WebClient` instance
+            ping_interval: The ping-pong internal (seconds)
+        &#34;&#34;&#34;
         self.app = app
         self.app_token = app_token or os.environ[&#34;SLACK_APP_TOKEN&#34;]
         self.client = SocketModeClient(
@@ -246,24 +286,18 @@ class AsyncSocketModeHandler(AsyncBaseSocketModeHandler):
 <div class="desc"></div>
 </dd>
 </dl>
-<h3>Methods</h3>
-<dl>
-<dt id="slack_bolt.adapter.socket_mode.websockets.SocketModeHandler.handle"><code class="name flex">
-<span>async def <span class="ident">handle</span></span>(<span>self, client: slack_sdk.socket_mode.websockets.SocketModeClient, req: slack_sdk.socket_mode.request.SocketModeRequest) ‑> NoneType</span>
-</code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">async def handle(self, client: SocketModeClient, req: SocketModeRequest) -&gt; None:
-    start = time()
-    bolt_resp: BoltResponse = run_bolt_app(self.app, req)
-    await send_async_response(client, req, bolt_resp, start)</code></pre>
-</details>
-</dd>
-</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler">AsyncBaseSocketModeHandler</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.close_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.close_async">close_async</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.connect_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.connect_async">connect_async</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.disconnect_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.disconnect_async">disconnect_async</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.handle" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.handle">handle</a></code></li>
+<li><code><a title="slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.start_async" href="../async_base_handler.html#slack_bolt.adapter.socket_mode.async_base_handler.AsyncBaseSocketModeHandler.start_async">start_async</a></code></li>
+</ul>
+</li>
+</ul>
 </dd>
 </dl>
 </section>
@@ -287,7 +321,6 @@ class AsyncSocketModeHandler(AsyncBaseSocketModeHandler):
 <li><code><a title="slack_bolt.adapter.socket_mode.websockets.AsyncSocketModeHandler.app" href="#slack_bolt.adapter.socket_mode.websockets.AsyncSocketModeHandler.app">app</a></code></li>
 <li><code><a title="slack_bolt.adapter.socket_mode.websockets.AsyncSocketModeHandler.app_token" href="#slack_bolt.adapter.socket_mode.websockets.AsyncSocketModeHandler.app_token">app_token</a></code></li>
 <li><code><a title="slack_bolt.adapter.socket_mode.websockets.AsyncSocketModeHandler.client" href="#slack_bolt.adapter.socket_mode.websockets.AsyncSocketModeHandler.client">client</a></code></li>
-<li><code><a title="slack_bolt.adapter.socket_mode.websockets.AsyncSocketModeHandler.handle" href="#slack_bolt.adapter.socket_mode.websockets.AsyncSocketModeHandler.handle">handle</a></code></li>
 </ul>
 </li>
 <li>
@@ -296,7 +329,6 @@ class AsyncSocketModeHandler(AsyncBaseSocketModeHandler):
 <li><code><a title="slack_bolt.adapter.socket_mode.websockets.SocketModeHandler.app" href="#slack_bolt.adapter.socket_mode.websockets.SocketModeHandler.app">app</a></code></li>
 <li><code><a title="slack_bolt.adapter.socket_mode.websockets.SocketModeHandler.app_token" href="#slack_bolt.adapter.socket_mode.websockets.SocketModeHandler.app_token">app_token</a></code></li>
 <li><code><a title="slack_bolt.adapter.socket_mode.websockets.SocketModeHandler.client" href="#slack_bolt.adapter.socket_mode.websockets.SocketModeHandler.client">client</a></code></li>
-<li><code><a title="slack_bolt.adapter.socket_mode.websockets.SocketModeHandler.handle" href="#slack_bolt.adapter.socket_mode.websockets.SocketModeHandler.handle">handle</a></code></li>
 </ul>
 </li>
 </ul>

--- a/slack_bolt/adapter/socket_mode/__init__.py
+++ b/slack_bolt/adapter/socket_mode/__init__.py
@@ -1,2 +1,10 @@
+"""Socket Mode adapter package provides the following implementations. If you don't have strong reasons to use 3rd party library based adapters, we recommend using the built-in client based one.
+
+* `slack_bolt.adapter.socket_mode.builtin`
+* `slack_bolt.adapter.socket_mode.websocket_client`
+* `slack_bolt.adapter.socket_mode.aiohttp`
+* `slack_bolt.adapter.socket_mode.websockets`
+"""
+
 # Don't add async module imports here
 from .builtin import SocketModeHandler  # noqa

--- a/slack_bolt/adapter/socket_mode/aiohttp/__init__.py
+++ b/slack_bolt/adapter/socket_mode/aiohttp/__init__.py
@@ -1,3 +1,4 @@
+"""[`aiohttp`](https://pypi.org/project/aiohttp/) based implementation / asyncio compatible"""
 import os
 from logging import Logger
 from time import time
@@ -32,6 +33,16 @@ class SocketModeHandler(AsyncBaseSocketModeHandler):
         proxy: Optional[str] = None,
         ping_interval: float = 10,
     ):
+        """Socket Mode adapter for Bolt apps
+
+        Args:
+            app: The Bolt app
+            app_token: App-level token starting with `xapp-`
+            logger: Custom logger
+            web_client: custom `slack_sdk.web.WebClient` instance
+            proxy: HTTP proxy URL
+            ping_interval: The ping-pong internal (seconds)
+        """
         self.app = app
         self.app_token = app_token or os.environ["SLACK_APP_TOKEN"]
         self.client = SocketModeClient(

--- a/slack_bolt/adapter/socket_mode/async_base_handler.py
+++ b/slack_bolt/adapter/socket_mode/async_base_handler.py
@@ -1,3 +1,4 @@
+"""The base class of asyncio-based Socket Mode client implementation"""
 import asyncio
 import logging
 from typing import Union
@@ -17,18 +18,31 @@ class AsyncBaseSocketModeHandler:
     async def handle(
         self, client: AsyncBaseSocketModeClient, req: SocketModeRequest
     ) -> None:
+        """Handles Socket Mode envelope requests through a WebSocket connection.
+
+        Args:
+            client: this Socket Mode client instance
+            req: the request data
+        """
         raise NotImplementedError()
 
     async def connect_async(self):
+        """Establishes a new connection with the Socket Mode server"""
         await self.client.connect()
 
     async def disconnect_async(self):
+        """Disconnects the current WebSocket connection with the Socket Mode server"""
         await self.client.disconnect()
 
     async def close_async(self):
+        """Disconnects from the Socket Mode server and cleans the resources this instance holds up"""
         await self.client.close()
 
     async def start_async(self):
+        """Establishes a new connection and then starts infinite sleep
+        to prevent the termination of this process.
+        If you don't want to have the sleep, use `#connect()` method instead.
+        """
         await self.connect_async()
         if self.app.logger.level > logging.INFO:
             print(get_boot_message())

--- a/slack_bolt/adapter/socket_mode/async_handler.py
+++ b/slack_bolt/adapter/socket_mode/async_handler.py
@@ -1,1 +1,2 @@
+"""Default implementation is the aiohttp-based one."""
 from .aiohttp import AsyncSocketModeHandler  # noqa

--- a/slack_bolt/adapter/socket_mode/async_internals.py
+++ b/slack_bolt/adapter/socket_mode/async_internals.py
@@ -1,3 +1,4 @@
+"""Internal functions"""
 import json
 import logging
 from time import time

--- a/slack_bolt/adapter/socket_mode/base_handler.py
+++ b/slack_bolt/adapter/socket_mode/base_handler.py
@@ -1,3 +1,6 @@
+"""The base class of Socket Mode client implementation.
+If you want to build asyncio-based ones, use `AsyncBaseSocketModeHandler` instead.
+"""
 import logging
 import signal
 import sys
@@ -15,18 +18,31 @@ class BaseSocketModeHandler:
     client: BaseSocketModeClient
 
     def handle(self, client: BaseSocketModeClient, req: SocketModeRequest) -> None:
+        """Handles Socket Mode envelope requests through a WebSocket connection.
+
+        Args:
+            client: this Socket Mode client instance
+            req: the request data
+        """
         raise NotImplementedError()
 
     def connect(self):
+        """Establishes a new connection with the Socket Mode server"""
         self.client.connect()
 
     def disconnect(self):
+        """Disconnects the current WebSocket connection with the Socket Mode server"""
         self.client.disconnect()
 
     def close(self):
+        """Disconnects from the Socket Mode server and cleans the resources this instance holds up"""
         self.client.close()
 
     def start(self):
+        """Establishes a new connection and then blocks the current thread
+        to prevent the termination of this process.
+        If you don't want to block the current thread, use `#connect()` method instead.
+        """
         self.connect()
         if self.app.logger.level > logging.INFO:
             print(get_boot_message())

--- a/slack_bolt/adapter/socket_mode/builtin/__init__.py
+++ b/slack_bolt/adapter/socket_mode/builtin/__init__.py
@@ -1,3 +1,4 @@
+"""The built-in implementation, which does not have any external dependencies"""
 import os
 from logging import Logger
 from time import time
@@ -34,6 +35,23 @@ class SocketModeHandler(BaseSocketModeHandler):
         receive_buffer_size: int = 1024,
         concurrency: int = 10,
     ):
+        """Socket Mode adapter for Bolt apps
+
+        Args:
+            app: The Bolt app
+            app_token: App-level token starting with `xapp-`
+            logger: Custom logger
+            web_client: custom `slack_sdk.web.WebClient` instance
+            proxy: HTTP proxy URL
+            proxy_headers: Additional request header for proxy connections
+            auto_reconnect_enabled: True if the auto-reconnect logic works
+            trace_enabled: True if trace-level logging is enabled
+            all_message_trace_enabled: True if trace-logging for all received WebSocket messages is enabled
+            ping_pong_trace_enabled: True if trace-logging for all ping-pong communications
+            ping_interval: The ping-pong internal (seconds)
+            receive_buffer_size: The data length for a single socket recv operation
+            concurrency: The size of the underlying thread pool
+        """
         self.app = app
         self.app_token = app_token or os.environ["SLACK_APP_TOKEN"]
         self.client = SocketModeClient(

--- a/slack_bolt/adapter/socket_mode/internals.py
+++ b/slack_bolt/adapter/socket_mode/internals.py
@@ -1,3 +1,4 @@
+"""Internal functions"""
 import json
 import logging
 from time import time

--- a/slack_bolt/adapter/socket_mode/websocket_client/__init__.py
+++ b/slack_bolt/adapter/socket_mode/websocket_client/__init__.py
@@ -1,3 +1,4 @@
+"""[`websocket-client`](https://pypi.org/project/websocket-client/) based implementation"""
 import os
 from logging import Logger
 from time import time
@@ -32,6 +33,21 @@ class SocketModeHandler(BaseSocketModeHandler):
         proxy_type: Optional[str] = None,
         trace_enabled: bool = False,
     ):
+        """Socket Mode adapter for Bolt apps
+
+        Args:
+            app: The Bolt app
+            app_token: App-level token starting with `xapp-`
+            logger: Custom logger
+            web_client: custom `slack_sdk.web.WebClient` instance
+            ping_interval: The ping-pong internal (seconds)
+            concurrency: The size of the underlying thread pool
+            http_proxy_host: HTTP proxy host
+            http_proxy_port: HTTP proxy port
+            http_proxy_auth: HTTP proxy authentication (username, password)
+            proxy_type: Proxy type
+            trace_enabled: True if trace-level logging is enabled
+        """
         self.app = app
         self.app_token = app_token or os.environ["SLACK_APP_TOKEN"]
         self.client = SocketModeClient(

--- a/slack_bolt/adapter/socket_mode/websockets/__init__.py
+++ b/slack_bolt/adapter/socket_mode/websockets/__init__.py
@@ -1,3 +1,4 @@
+"""[`websockets`](https://pypi.org/project/websockets/) based implementation  / asyncio compatible"""
 import os
 from logging import Logger
 from time import time
@@ -31,6 +32,19 @@ class SocketModeHandler(AsyncBaseSocketModeHandler):
         web_client: Optional[AsyncWebClient] = None,
         ping_interval: float = 10,
     ):
+        """Socket Mode adapter for Bolt apps.
+
+        Please note that this adapter does not support proxy configuration
+        as the underlying websockets module does not support proxy-wired connections.
+        If you use proxy, consider using one of the other Socket Mode adapters.
+
+        Args:
+            app: The Bolt app
+            app_token: App-level token starting with `xapp-`
+            logger: Custom logger
+            web_client: custom `slack_sdk.web.WebClient` instance
+            ping_interval: The ping-pong internal (seconds)
+        """
         self.app = app
         self.app_token = app_token or os.environ["SLACK_APP_TOKEN"]
         self.client = SocketModeClient(


### PR DESCRIPTION
This pull request updates the module documents for `slack_bolt.adapter.socket_mode` classes and adds links to the document pages.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
