### PR TITLE
Fix errors in documents

### DIFF
--- a/docs/_basic/listening_actions.md
+++ b/docs/_basic/listening_actions.md
@@ -15,7 +15,7 @@ You’ll notice in all `action()` examples, `ack()` is used. It is required to c
 </div>
 
 ```python
-# Your middleware will be called every time an interactive component with the action_id "approve_button" is triggered
+# Your listener will be called every time a block element with the action_id "approve_button" is triggered
 @app.action("approve_button")
 def update_message(ack):
     ack()

--- a/docs/_basic/listening_events.md
+++ b/docs/_basic/listening_events.md
@@ -14,7 +14,7 @@ The `event()` method requires an `eventType` of type `str`.
 </div>
 
 ```python
-# When a user joins the team, send a message in a predefined channel asking them to introduce themselves
+# When a user joins the workspace, send a message in a predefined channel asking them to introduce themselves
 @app.event("team_join")
 def ask_for_introduction(event, say):
     welcome_channel_id = "C12345"
@@ -37,7 +37,7 @@ You can filter on subtypes of events by passing in the additional key `subtype`.
 </div>
 
 ```python
-# Matches all messages from bot users
+# Matches all modified messages
 @app.event({
     "type": "message",
     "subtype": "message_changed"

--- a/docs/_basic/listening_responding_shortcuts.md
+++ b/docs/_basic/listening_responding_shortcuts.md
@@ -22,13 +22,12 @@ When setting up shortcuts within your app configuration, as with other URLs, you
 </div>
 
 ```python
-
 # The open_modal shortcut listens to a shortcut with the callback_id "open_modal"
 @app.shortcut("open_modal")
 def open_modal(ack, shortcut, client):
     # Acknowledge the shortcut request
     ack()
-    # Call the views_open method using one of the built-in WebClients
+    # Call the views_open method using the built-in WebClient
     client.views_open(
         trigger_id=shortcut["trigger_id"],
         # A simple view payload for a modal
@@ -68,8 +67,7 @@ def open_modal(ack, shortcut, client):
   </div>
 
 ```python
-
-# Your middleware will only be called when the callback_id matches 'open_modal' AND the type matches 'message_action'
+# Your listener will only be called when the callback_id matches 'open_modal' AND the type matches 'message_action'
 @app.shortcut({"callback_id": "open_modal", "type": "message_action"})
 def open_modal(ack, shortcut, client):
     # Acknowledge the shortcut request

--- a/docs/_basic/responding_actions.md
+++ b/docs/_basic/responding_actions.md
@@ -14,7 +14,7 @@ The second way to respond to actions is using `respond()`, which is a utility to
 </div>
 
 ```python
-# Your middleware will be called every time an interactive component with the action_id “approve_button” is triggered
+# Your listener will be called every time an interactive component with the action_id “approve_button” is triggered
 @app.action("approve_button")
 def approve_request(ack, say):
     # Acknowledge action request


### PR DESCRIPTION
I found a few minor errors in the document while reviewing Japanese translation drafts.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
