### PR TITLE
Add Japanese version of Basic Concepts documents

### DIFF
--- a/docs/_advanced/async.md
+++ b/docs/_advanced/async.md
@@ -1,5 +1,5 @@
 ---
-title: Using async
+title: Using async (asyncio)
 lang: en
 slug: async
 order: 2

--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -7,9 +7,9 @@ order: 15
 
 <div class="section-content">
 
-Slack apps installed on multiple workspaces will need to implement OAuth, then store installation information (like access tokens) securely. By providing `client_id`, `client_secret`, `scopes`, `installation_store`, and `state_store` when initializing App, Bolt for Python will handle the work of setting up OAuth routes and verifying state. If you’re implementing a custom adapter, you can make use of our [OAuth library](https://slack.dev/python-slack-sdk/oauth/), which is what Bolt for Python uses under the hood.
+Slack apps installed on multiple workspaces will need to implement OAuth, then store installation information (like access tokens) securely. By providing `client_id`, `client_secret`, `scopes`, `installation_store`, and `state_store` when initializing App, Bolt for Python will handle the work of setting up OAuth routes and verifying state. If you're implementing a custom adapter, you can make use of our [OAuth library](https://slack.dev/python-slack-sdk/oauth/), which is what Bolt for Python uses under the hood.
 
-Bolt for Python will create a **Redirect URL** `slack/oauth_redirect`, which Slack uses to redirect users after they complete your app’s installation flow. You will need to add this **Redirect URL** in your app configuration settings under **OAuth and Permissions**. This path can be configured in the `OAuthSettings` argument described below.
+Bolt for Python will create a **Redirect URL** `slack/oauth_redirect`, which Slack uses to redirect users after they complete your app's installation flow. You will need to add this **Redirect URL** in your app configuration settings under **OAuth and Permissions**. This path can be configured in the `OAuthSettings` argument described below.
 
 Bolt for Python will also create a `slack/install` route, where you can find an **Add to Slack** button for your app to perform direct installs of your app. If you need any additional authorizations (user tokens) from users inside a team when your app is already installed or a reason to dynamically generate an install URL, you can pass your own custom URL generator to `oauth_settings` as `authorize_url_generator`.
 

--- a/docs/_basic/ja_acknowledging_events.md
+++ b/docs/_basic/ja_acknowledging_events.md
@@ -1,0 +1,33 @@
+---
+title: イベントの確認
+lang: ja-jp
+slug: acknowledge
+order: 7
+---
+
+<div class="section-content">
+
+アクション（action）、コマンド（command）、およびオプション（options）の各イベントは、**必ず** `ack()` 関数を使って確認を行う必要があります。これによってイベントが受信されたことが Slack に認識され、Slack のユーザーインターフェイスが適切に更新されます。
+
+イベントの種類によっては、確認で通知方法が異なる場合があります。例えば、外部データソースを使用する選択メニューのオプションのリクエストに対する確認では、適切な[オプション](https://api.slack.com/reference/block-kit/composition-objects#option)のリストとともに `ack()` を呼び出します。
+
+確認までの猶予は 3 秒しかないため、新しいメッセージの送信や、データベースからの情報の取得は、`ack()` を呼び出した後で行うことをおすすめします。
+
+</div>
+
+```python
+# 外部データを使用する選択メニューオプションに応答するサンプル
+@app.options("menu_selection")
+def show_menu_options(ack):
+    options = [
+        {
+            "text": {"type": "plain_text", "text":"Option 1"},
+            "value":"1-1",
+        },
+        {
+            "text": {"type": "plain_text", "text":"Option 2"},
+            "value":"1-2",
+        },
+    ]
+    ack(options=options)
+```

--- a/docs/_basic/ja_authenticating_oauth.md
+++ b/docs/_basic/ja_authenticating_oauth.md
@@ -1,0 +1,103 @@
+---
+title: OAuth を使った認証
+lang: ja-jp
+slug: authenticating-oauth
+order: 15
+---
+
+<div class="section-content">
+
+Slack アプリを複数のワークスペースにインストールできるようにするためには、OAuth フローを実装した上で、アクセストークンなどのインストールに関する情報をセキュアな方法で保存する必要があります。アプリを初期化する際に `client_id`、`client_secret`、`scopes`、`installation_store`、`state_store` を指定することで、OAuth のエンドポイントのルート情報や stateパラメーターの検証をBolt for Python にハンドリングさせることができます。カスタムのアダプターを実装する場合は、SDK が提供する組み込みの[OAuth ライブラリ](https://slack.dev/python-slack-sdk/oauth/)を利用するのが便利です。これは Slack が開発したモジュールで、Bolt for Python 内部でも利用しています。
+
+Bolt for Python によって `slack/oauth_redirect` という**リダイレクト URL** が生成されます。Slack はアプリのインストールフローを完了させたユーザーをこの URL にリダイレクトします。この**リダイレクト URL** は、アプリの設定の「**OAuth and Permissions**」であらかじめ追加しておく必要があります。この URL は、後ほど説明するように `OAuthSettings` というコンストラクタの引数で指定することもできます。
+
+Bolt for Python は `slack/install` というルートも生成します。これはアプリを直接インストールするための「**Add to Slack**」ボタンを表示するために使われます。すでにワークスペースへのアプリのインストールが済んでいる場合に追加で各ユーザーのユーザートークンなどの情報を取得する場合や、カスタムのインストール用の URL を動的に生成したい場合などは、`oauth_settings` の `authorize_url_generator` でカスタムの URL ジェネレーターを指定することができます。
+
+バージョン 1.1.0 以降の Bolt for Python では、[OrG 全体へのインストール](https://api.slack.com/enterprise/apps)がデフォルトでサポートされています。OrG 全体へのインストールは、アプリの設定の「**Org Level Apps**」で有効化できます。
+
+Slack での OAuth を使ったインストールフローについて詳しくは、[API ドキュメントを参照してください](https://api.slack.com/authentication/oauth-v2)。
+
+</div>
+
+```python
+import os
+from slack_bolt import App
+from slack_bolt.oauth.oauth_settings import OAuthSettings
+from slack_sdk.oauth.installation_store import FileInstallationStore
+from slack_sdk.oauth.state_store import FileOAuthStateStore
+
+oauth_settings = OAuthSettings(
+    client_id=os.environ["SLACK_CLIENT_ID"],
+    client_secret=os.environ["SLACK_CLIENT_SECRET"],
+    scopes=["channels:read", "groups:read", "chat:write"],
+    installation_store=FileInstallationStore(base_dir="./data"),
+    state_store=FileOAuthStateStore(expiration_seconds=600, base_dir="./data")
+)
+
+app = App(
+    signing_secret=os.environ["SIGNING_SECRET"],
+    oauth_settings=oauth_settings
+)
+```
+
+<details class="secondary-wrapper">
+<summary class="section-head" markdown="0">
+<h4 class="section-head">OAuth デフォルト設定をカスタマイズ</h4>
+</summary>
+
+<div class="secondary-content" markdown="0">
+`oauth_settings` を使って OAuth モジュールのデフォルト設定を上書きすることができます。このカスタマイズされた設定は App の初期化時に渡します。以下の情報を変更可能です:
+
+- `install_path` : 「Add to Slack」ボタンのデフォルトのパスを上書きするために使用
+- `redirect_uri` : リダイレクト URL のデフォルトのパスを上書きするために使用
+- `callback_options` : OAuth フローの最後に表示するカスタムの成功ページと失敗ページの表示処理を提供するために使用
+- `state_store` : 組み込みの `FileOAuthStateStore` に代わる、カスタムの stateに関するデータストアを指定するために使用
+- `installation_store` : 組み込みの `FileInstallationStore` に代わる、カスタムのデータストアを指定するために使用
+
+</div>
+
+```python
+from slack_bolt.oauth.callback_options import CallbackOptions, SuccessArgs, FailureArgs
+from slack_bolt.response import BoltResponse
+
+def success(args:SuccessArgs) -> BoltResponse:
+    assert args.request is not None
+    return BoltResponse(
+        status=200,  # ユーザーをリダイレクトすることも可能
+        body="Your own response to end-users here"
+    )
+
+def failure(args:FailureArgs) -> BoltResponse:
+    assert args.request is not None
+    assert args.reason is not None
+    return BoltResponse(
+        status=args.suggested_status_code,
+        body="Your own response to end-users here"
+    )
+
+callback_options = CallbackOptions(success=success, failure=failure)
+
+import os
+from slack_bolt import App
+from slack_bolt.oauth.oauth_settings import OAuthSettings
+from slack_sdk.oauth.installation_store import FileInstallationStore
+from slack_sdk.oauth.state_store import FileOAuthStateStore
+
+app = App(
+    signing_secret=os.environ.get("SLACK_SIGNING_SECRET"),
+    installation_store=FileInstallationStore(base_dir="./data"),
+    oauth_settings=OAuthSettings(
+        client_id=os.environ.get("SLACK_CLIENT_ID"),
+        client_secret=os.environ.get("SLACK_CLIENT_SECRET"),
+        scopes=["app_mentions:read", "channels:history", "im:history", "chat:write"],
+        user_scopes=[],
+        redirect_uri=None,
+        install_path="/slack/install",
+        redirect_uri_path="/slack/oauth_redirect",
+        state_store=FileOAuthStateStore(expiration_seconds=600, base_dir="./data"),
+        callback_options=callback_options,
+    ),
+)
+```
+
+</details>

--- a/docs/_basic/ja_listening_actions.md
+++ b/docs/_basic/ja_listening_actions.md
@@ -1,0 +1,54 @@
+---
+title: アクションのリスニング
+lang: ja-jp
+slug: action-listening
+order: 5
+---
+
+<div class="section-content">
+Bolt アプリは `action` メソッドを用いて、ボタンのクリック、メニューの選択、メッセージショートカットなどのユーザーのアクションをリッスンすることができます。
+
+アクションは `str` 型または `re.Pattern` 型の `action_id` でフィルタリングできます。`action_id` は、Slack プラットフォーム上のインタラクティブコンポーネントを区別する一意の識別子として機能します。
+
+`action()` を使ったすべての例で `ack()` が使用されていることに注目してください。アクションのリスナー内では、Slack からのイベントを受信したことを確認するために、`ack()` 関数を呼び出す必要があります。これについては、[イベントの確認](#acknowledge)セクションで説明しています。
+
+</div>
+
+```python
+# 'approve_button' という action_id のブロックエレメントがトリガーされるたびに、このリスナーが呼び出させれる
+@app.action("approve_button")
+def update_message(ack):
+    ack()
+    # アクションへの反応としてメッセージを更新
+```
+
+<details class="secondary-wrapper">
+<summary class="section-head" markdown="0">
+<h4 class="section-head">制約付きオブジェクトを使用したアクションのリスニング</h4>
+</summary>
+
+<div class="secondary-content" markdown="0">
+
+制約付きのオブジェクトを使用すると、`callback_id`、`block_id`、および `action_id` をそれぞれ、または任意に組み合わせてリッスンできます。オブジェクト内の制約は、`str` 型または `re.Pattern` 型で指定できます。
+
+</div>
+
+```python
+# この関数は、block_id が 'assign_ticket' に一致し
+# かつ action_id が 'select_user' に一致する場合にのみ呼び出される
+@app.action({
+    "block_id": "assign_ticket",
+    "action_id": "select_user"
+})
+def update_message(ack, body, client):
+    ack()
+
+    if "container" in body and "message_ts" in body["container"]:
+        client.reactions_add(
+            name="white_check_mark",
+            channel=body["channel"]["id"],
+            timestamp=body["container"]["message_ts"],
+        )
+```
+
+</details>

--- a/docs/_basic/ja_listening_events.md
+++ b/docs/_basic/ja_listening_events.md
@@ -1,0 +1,49 @@
+---
+title: イベントのリスニング
+lang: ja-jp
+slug: event-listening
+order: 3
+---
+
+<div class="section-content">
+
+`event()` メソッドを使うと、[Events API](https://api.slack.com/events) の任意のイベントをリッスンできます。リッスンするイベントは、アプリの設定であらかじめサブスクライブしておく必要があります。これを利用することで、アプリがインストールされたワークスペースで何らかのイベント（例：ユーザーがメッセージにリアクションをつけた、ユーザーがチャンネルに参加した）が発生したときに、アプリに何らかのアクションを実行させることができます。
+
+`event()` メソッドには `str` 型の `eventType` を指定する必要があります。
+
+</div>
+
+```python
+# ユーザーがワークスペースに参加した際に、自己紹介を促すメッセージを指定のチャンネルに送信
+@app.event("team_join")
+def ask_for_introduction(event, say):
+    welcome_channel_id = "C12345"
+    user_id = event["user"]
+    text = f"Welcome to the team, <@{user_id}>! 🎉 You can introduce yourself in this channel."
+    say(text=text, channel=welcome_channel_id)
+```
+
+<details class="secondary-wrapper" >
+  
+<summary class="section-head" markdown="0">
+  <h4 class="section-head">メッセージのサブタイプのフィルタリング</h4>
+</summary>
+
+<div class="secondary-content" markdown="0">
+`message()` リスナーは `event("message")` と等価の機能を提供します。
+
+`subtype` という追加のキーを指定して、イベントのサブタイプでフィルタリングすることもできます。よく使われるサブタイプには、`bot_message` や `message_replied` があります。詳しくは[メッセージイベントページ](https://api.slack.com/events/message#message_subtypes)を参照してください。
+
+</div>
+
+```python
+# 変更されたすべてのメッセージに一致
+@app.event({
+    "type": "message",
+    "subtype": "message_changed"
+})
+def log_message_change(logger, event):
+    user, text = event["user"], event["text"]
+    logger.info(f"The user {user} changed the message to {text}")
+```
+</details>

--- a/docs/_basic/ja_listening_messages.md
+++ b/docs/_basic/ja_listening_messages.md
@@ -1,0 +1,45 @@
+---
+title: メッセージのリスニング
+lang: ja-jp
+slug: message-listening
+order: 1
+---
+
+<div class="section-content">
+
+[あなたのアプリがアクセス権限を持つ](https://api.slack.com/messaging/retrieving#permissions)メッセージの投稿イベントをリッスンするには `message()` メソッドを利用します。このメソッドは `type` が `message` ではないイベントを処理対象から除外します。
+
+`message()` の引数には `str` 型または `re.Pattern` オブジェクトを指定できます。この条件のパターンに一致しないメッセージは除外されます。
+
+</div>
+
+```python
+# '👋' が含まれるすべてのメッセージに一致
+@app.message(":wave:")
+def say_hello(message, say):
+    user = message['user']
+    say(f"Hi there, <@{user}>!")
+```
+
+<details class="secondary-wrapper">
+<summary markdown="0">
+<h4 class="secondary-header">正規表現パターンの使用</h4>
+</summary>
+
+<div class="secondary-content" markdown="0">
+
+文字列の代わりに `re.compile()` メソッドを使用すれば、より細やかな条件指定ができます。
+
+</div>
+
+```python
+import re
+
+@app.message(re.compile("(hi|hello|hey)"))
+def say_hello_regex(say, context):
+    # 正規表現のマッチ結果は context.matches に設定される
+    greeting = context['matches'][0]
+    say(f"{greeting}, how are you?")
+```
+
+</details>

--- a/docs/_basic/ja_listening_modals.md
+++ b/docs/_basic/ja_listening_modals.md
@@ -1,0 +1,48 @@
+---
+title: モーダルの送信のリスニング
+lang: ja-jp
+slug: view_submissions
+order: 12
+---
+
+<div class="section-content">
+
+<a href="https://api.slack.com/reference/block-kit/views">モーダルのペイロード</a>に input ブロックを含める場合、その入力値を受け取るために`view_submission` イベントをリッスンする必要があります。`view_submission` イベントのリッスンには、組み込みの`view()` メソッドを利用することができます。`view()` の引数には、`str` 型または `re.Pattern` 型の `callback_id` を指定します。
+
+`input` ブロックの値にアクセスするには `state` オブジェクトを参照します。`state` 内には `values` というオブジェクトがあり、`block_id` と一意の `action_id` に紐づける形で入力値を保持しています。
+
+モーダルの送信について詳しくは、<a href="https://api.slack.com/surfaces/modals/using#interactions">API ドキュメント</a>を参照してください。
+
+</div>
+
+```python
+# view_submission イベントを処理
+@app.view("view_1")
+def handle_submission(ack, body, client, view):
+    # `block_c`という block_id に `dreamy_input` を持つ input ブロックがある場合
+    hopes_and_dreams = view["state"]["values"]["block_c"]["dreamy_input"]
+    user = body["user"]["id"]
+    # 入力値を検証
+    errors = {}
+    if hopes_and_dreams is not None and len(hopes_and_dreams) <= 5:
+        errors["block_c"] = "The value must be longer than 5 characters"
+    if len(errors) > 0:
+        ack(response_action="errors", errors=errors)
+        return
+    # view_submission イベントの確認を行い、モーダルを閉じる
+    ack()
+    # 入力されたデータを使った処理を実行。このサンプルでは DB に保存する処理を行う
+    # そして入力値の検証結果をユーザーに送信
+
+    # ユーザーに送信するメッセージ
+    msg = ""
+    try:
+        # DB に保存
+        msg = f"Your submission of {hopes_and_dreams} was successful"
+    except Exception as e:
+        # エラーをハンドリング
+        msg = "There was an error with your submission"
+    finally:
+        # ユーザーにメッセージを送信
+        client.chat_postMessage(channel=user, text=msg)
+```

--- a/docs/_basic/ja_listening_responding_commands.md
+++ b/docs/_basic/ja_listening_responding_commands.md
@@ -1,0 +1,27 @@
+---
+title: コマンドのリスニングと応答
+lang: ja-jp
+slug: commands
+order: 9
+---
+
+<div class="section-content">
+
+スラッシュコマンドが実行されたイベントをリッスンするには、`command()` メソッドを使用します。このメソッドでは `str` 型の `command_name` の指定が必要です。
+
+コマンドイベントをアプリが受信し確認したことを Slack に通知するため、`ack()` を呼び出す必要があります。
+
+スラッシュコマンドに応答する方法は 2 つあります。1 つ目は `say()` を使う方法で、文字列または JSON のペイロードを渡すことができます。2 つ目は `respond()` を使う方法です。これは `response_url` がある場合に活躍します。これらの方法は[アクションへの応答](#action-respond)セクションで詳しく説明しています。
+
+アプリの設定でコマンドを登録するときは、リクエスト URL の末尾に `/slack/events` をつけます。
+
+</div>
+
+```python
+# echoコマンドは受け取ったコマンドをそのまま返す
+@app.command("/echo")
+def repeat_text(ack, say, command):
+    # command リクエストを確認
+    ack()
+    say(f"{command['text']}")
+```

--- a/docs/_basic/ja_listening_responding_options.md
+++ b/docs/_basic/ja_listening_responding_options.md
@@ -1,0 +1,34 @@
+---
+title: オプションのリスニングと応答
+lang: ja-jp
+slug: options
+order: 14
+---
+
+<div class="section-content">
+`options()` メソッドは、Slack からのオプション（セレクトメニュー内の動的な選択肢）をリクエストするペイロードをリッスンします。 [`action()` と同様に](#action-listening)、文字列型の `action_id` または制約付きオブジェクトが必要です。
+
+外部データソースを使って選択メニューをロードするためには、末部に `/slack/events` が付加された URL を Options Load URL として予め設定しておく必要があります。
+
+`external_select` メニューでは `action_id` を指定することをおすすめしています。ただし、ダイアログを利用している場合、ダイアログが Block Kit に対応していないため、`callback_id` をフィルタリングするための制約オブジェクトを使用する必要があります。
+
+オプションのリクエストに応答するときは、有効なオプションを含む `options` または `option_groups` のリストとともに `ack()` を呼び出す必要があります。API サイトにある[外部データを使用する選択メニューに応答するサンプル例](https://api.slack.com/reference/messaging/block-elements#external-select)と、[ダイアログでの応答例](https://api.slack.com/dialogs#dynamic_select_elements_external)を参考にしてください。
+
+</div>
+
+```python
+# 外部データを使用する選択メニューオプションに応答するサンプル例
+@app.options("external_action")
+def show_options(ack):
+    options = [
+        {
+            "text": {"type": "plain_text", "text":"Option 1"},
+            "value":"1-1",
+        },
+        {
+            "text": {"type": "plain_text", "text":"Option 2"},
+            "value":"1-2",
+        },
+    ]
+    ack(options=options)
+```

--- a/docs/_basic/ja_listening_responding_shortcuts.md
+++ b/docs/_basic/ja_listening_responding_shortcuts.md
@@ -1,0 +1,107 @@
+---
+title: ショートカットのリスニングと応答
+lang: ja-jp
+slug: shortcuts
+order: 8
+---
+
+<div class="section-content">
+
+`shortcut()` メソッドは、[グローバルショートカット](https://api.slack.com/interactivity/shortcuts/using#global_shortcuts)と[メッセージショートカット](https://api.slack.com/interactivity/shortcuts/using#message_shortcuts)の 2 つをサポートしています。
+
+ショートカットは、いつでも呼び出せるアプリのエントリーポイントを提供するものです。グローバルショートカットは Slack のテキスト入力エリアや検索ウィンドウからアクセスできます。メッセージショートカットはメッセージのコンテキストメニューからアクセスできます。アプリは、ショートカットイベントをリッスンするために `shortcut()` メソッドを使用します。このメソッドには `str` 型または `re.Pattern` 型の `callback_id` パラメーターを指定します。
+
+ショートカットイベントがアプリによって確認されたことを Slack に伝えるため、`ack()` を呼び出す必要があります。
+
+ショートカットのペイロードには `trigger_id` が含まれます。アプリはこれを使って、ユーザーにやろうとしていることを確認するための[モーダルを開く](#creating-modals)ことができます。
+
+アプリの設定でショートカットを登録する際は、他の URL と同じように、リクエスト URL の末尾に `/slack/events` をつけます。
+
+⚠️ グローバルショートカットのペイロードにはチャンネル ID が **含まれません**。アプリでチャンネル ID を取得する必要がある場合は、モーダル内に [`conversations_select`](https://api.slack.com/reference/block-kit/block-elements#conversation_select) エレメントを配置します。メッセージショートカットにはチャンネル ID が含まれます。
+
+</div>
+
+```python
+
+# 'open_modal' という callback_id のショートカットをリッスン
+@app.shortcut("open_modal")
+def open_modal(ack, shortcut, client):
+    # ショートカットのリクエストを確認
+    ack()
+    # 組み込みのクライアントを使って views_open メソッドを呼び出す
+    client.views_open(
+        trigger_id=shortcut["trigger_id"],
+        # モーダルで表示するシンプルなビューのペイロード
+        view={
+            "type": "modal",
+            "title": {"type": "plain_text", "text":"My App"},
+            "close": {"type": "plain_text", "text":"Close"},
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text":"About the simplest modal you could conceive of :smile:\n\nMaybe <https://api.slack.com/reference/block-kit/interactive-components|*make the modal interactive*> or <https://api.slack.com/surfaces/modals/using#modifying|*learn more advanced modal use cases*>."
+                    }
+                },
+                {
+                    "type": "context",
+                    "elements": [
+                        {
+                            "type": "mrkdwn",
+                            "text":"Psssst this modal was designed using <https://api.slack.com/tools/block-kit-builder|*Block Kit Builder*>"
+                        }
+                    ]
+                }
+            ]
+        }
+    )
+```
+
+<details class="secondary-wrapper">
+<summary class="section-head" markdown="0">
+<h4 class="section-head">制約付きオブジェクトを使用したショートカットのリスニング</h4>
+</summary>
+
+<div class="secondary-content" markdown="0">
+制約付きオブジェクトを使って `callback_id` や `type` によるリッスンできます。オブジェクト内の制約は `str` 型または `re.Pattern` オブジェクトを使用できます。
+</div>
+
+```python
+
+# このリスナーが呼び出されるのは、callback_id が 'open_modal' と一致し
+# かつ type が 'message_action' と一致するときのみ
+@app.shortcut({"callback_id": "open_modal", "type": "message_action"})
+def open_modal(ack, shortcut, client):
+    # ショートカットのリクエストを確認
+    ack()
+    # 組み込みのクライアントを使って views_open メソッドを呼び出す
+    client.views_open(
+        trigger_id=shortcut["trigger_id"],
+        view={
+            "type": "modal",
+            "title": {"type": "plain_text", "text":"My App"},
+            "close": {"type": "plain_text", "text":"Close"},
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text":"About the simplest modal you could conceive of :smile:\n\nMaybe <https://api.slack.com/reference/block-kit/interactive-components|*make the modal interactive*> or <https://api.slack.com/surfaces/modals/using#modifying|*learn more advanced modal use cases*>."
+                    }
+                },
+                {
+                    "type": "context",
+                    "elements": [
+                        {
+                            "type": "mrkdwn",
+                            "text":"Psssst this modal was designed using <https://api.slack.com/tools/block-kit-builder|*Block Kit Builder*>"
+                        }
+                    ]
+                }
+            ]
+        }
+    )
+```
+
+</details>

--- a/docs/_basic/ja_opening_modals.md
+++ b/docs/_basic/ja_opening_modals.md
@@ -1,0 +1,58 @@
+---
+title: モーダルの開始
+lang: ja-jp
+slug: opening-modals
+order: 10
+---
+
+<div class="section-content">
+
+<a href="https://api.slack.com/block-kit/surfaces/modals">モーダル</a>は、ユーザーからのデータの入力を受け付けたり、動的な情報を表示したりするためのインターフェイスです。組み込みの APIクライアントの <a href="https://api.slack.com/methods/views.open">`views.open`</a> メソッドに、有効な `trigger_id` と<a href="https://api.slack.com/reference/block-kit/views">ビューのペイロード</a>を指定してモーダルを開始します。
+
+ショートカットの実行、ボタンを押下、選択メニューの操作などの操作の場合、Request URL に送信されるペイロードには `trigger_id` が含まれます。
+
+モーダルの生成方法についての詳細は、<a href="https://api.slack.com/surfaces/modals/using#composing_views">API ドキュメント</a>を参照してください。
+
+</div>
+
+```python
+# ショートカットの呼び出しをリッスン
+@app.shortcut("open_modal")
+def open_modal(ack, body, client):
+    # コマンドのリクエストを確認
+    ack()
+    # 組み込みのクライアントで views_open を呼び出し
+    client.views_open(
+        # 受け取りから 3 秒以内に有効な trigger_id を渡す
+        trigger_id=body["trigger_id"],
+        # ビューのペイロード
+        view={
+            "type": "modal",
+            # ビューの識別子
+            "callback_id": "view_1",
+            "title": {"type": "plain_text", "text":"My App"},
+            "submit": {"type": "plain_text", "text":"Submit"},
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text":"Welcome to a modal with _blocks_"},
+                    "accessory": {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text":"Click me!"},
+                        "action_id": "button_abc"
+                    }
+                },
+                {
+                    "type": "input",
+                    "block_id": "input_c",
+                    "label": {"type": "plain_text", "text":"What are your hopes and dreams?"},
+                    "element": {
+                        "type": "plain_text_input",
+                        "action_id": "dreamy_input",
+                        "multiline":True
+                    }
+                }
+            ]
+        }
+    )
+```

--- a/docs/_basic/ja_publishing_views.md
+++ b/docs/_basic/ja_publishing_views.md
@@ -1,0 +1,46 @@
+---
+title: ホームタブの更新
+lang: ja-jp
+slug: app-home
+order: 13
+---
+
+<div class="section-content">
+<a href="https://api.slack.com/surfaces/tabs/using">ホームタブ</a>は、サイドバーや検索画面からアクセス可能なサーフェスエリアです。アプリはこのエリアを使ってユーザーごとのビューを表示することができます。アプリ設定ページで App Home の機能を有効にすると、<a href="https://api.slack.com/methods/views.publish">`views.publish`</a> API メソッドの呼び出しで `user_id` と[ビューのペイロード](https://api.slack.com/reference/block-kit/views)を指定して、ホームタブを公開・更新することができるようになります。
+
+<a href="https://api.slack.com/events/app_home_opened">`app_home_opened`</a> イベントをサブスクライブすると、ユーザーが App Home を開く操作をリッスンできます。
+</div>
+
+```python
+@app.event("app_home_opened")
+def update_home_tab(client, event, logger):
+    try:
+        # 組み込みのクライアントを使って views.publish を呼び出す
+        client.views_publish(
+            # イベントに関連づけられたユーザー ID を使用
+            user_id=event["user"],
+            # アプリの設定で予めホームタブが有効になっている必要がある
+            view={
+                "type": "home",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*Welcome home, <@" + event["user"] + "> :house:*"
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text":"Learn how home tabs can be more useful and interactive <https://api.slack.com/surfaces/tabs/using|*in the documentation*>."
+                        }
+                    }
+                ]
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error publishing home tab: {e}")
+```

--- a/docs/_basic/ja_responding_actions.md
+++ b/docs/_basic/ja_responding_actions.md
@@ -1,0 +1,44 @@
+---
+title: アクションへの応答
+lang: ja-jp
+slug: action-respond
+order: 6
+---
+
+<div class="section-content">
+
+アクションへの応答には、主に 2 つの方法があります。1 つ目の最も一般的なやり方は `say()` を使用する方法です。そのイベントが発生した会話（チャンネルや DM）にメッセージを返します。
+
+2 つ目は、`respond()` を使用する方法です。これは、アクションに関連づけられた `response_url` を使ったメッセージ送信を行うためのユーティリティです。
+
+</div>
+
+```python
+# 'approve_button' という action_id のインタラクティブコンポーネントがトリガーされると、このリスナーが呼ばれる
+@app.action("approve_button")
+def approve_request(ack, say):
+    # アクションのリクエストを確認
+    ack()
+    say("Request approved 👍")
+```
+
+<details class="secondary-wrapper">
+<summary class="section-head" markdown="0">
+<h4 class="section-head">respond() の使用</h4>
+</summary>
+
+<div class="secondary-content" markdown="0">
+
+`respond()` は `response_url` を使って送信するときに便利なメソッドで、これらと同じような動作をします。投稿するメッセージのペイロードには JSON オブジェクトを渡すことができ、メッセージはやり取りの発生元に反映されます。オプションのプロパティとして `response_type`（値は `in_channel` または `ephemeral`）、`replace_original`、`delete_original` などを指定できます。
+
+</div>
+
+```python
+# 'user_select' という action_id を持つアクションのトリガーをリッスン
+@app.action("user_select")
+def select_user(ack, action, respond):
+    ack()
+    respond(f"You selected <@{action['selected_user']}>")
+```
+
+</details>

--- a/docs/_basic/ja_sending_messages.md
+++ b/docs/_basic/ja_sending_messages.md
@@ -1,0 +1,57 @@
+---
+title: メッセージの送信
+lang: ja-jp
+slug: message-sending
+order: 2
+---
+
+<div class="section-content">
+
+リスナー関数内では、関連づけられた会話（例：リスナー実行のトリガーとなったイベントまたはアクションの発生元の会話）がある場合はいつでも `say()` を使用できます。`say()` には文字列または JSON ペイロードを指定できます。文字列の場合、送信できるのはテキストベースの単純なメッセージです。より複雑なメッセージを送信するには JSON ペイロードを指定します。指定したメッセージのペイロードは、関連づけられた会話内のメッセージとして送信されます。
+
+リスナー関数の外でメッセージを送信したい場合や、より高度な処理（特定のエラーの処理など）を実行したい場合は、[Bolt インスタンスにアタッチされたクライアント](#web-api)の `client.chat_postMessage` を呼び出します。
+
+</div>
+
+```python
+# 'knock knock' が含まれるメッセージをリッスンし、イタリック体で 'Who's there?' と返信
+@app.message("knock knock")
+def ask_who(message, say):
+    say("_Who's there?_")
+```
+
+<details class="secondary-wrapper">
+<summary markdown="0">
+<h4 class="secondary-header">ブロックを用いたメッセージの送信</h4>
+</summary>
+
+<div class="secondary-content" markdown="0">
+`say()` は、より複雑なメッセージペイロードを受け付けるので、メッセージに機能やリッチな構造を与えることが容易です。
+
+リッチなメッセージレイアウトをアプリに追加する方法については、[API サイトのガイド](https://api.slack.com/messaging/composing/layouts)を参照してください。また、[Block Kit ビルダー](https://api.slack.com/tools/block-kit-builder?template=1)の一般的なアプリフローのテンプレートも見てみてください。
+
+</div>
+
+```python
+# ユーザーが 📅 のリアクションをつけたら、日付ピッカーのついた section ブロックを送信
+@app.event("reaction_added")
+def show_datepicker(event, say):
+    reaction = event["reaction"]
+    if reaction == "calendar":
+        blocks = [{
+          "type": "section",
+          "text": {"type": "mrkdwn", "text":"Pick a date for me to remind you"},
+          "accessory": {
+              "type": "datepicker",
+              "action_id": "datepicker_remind",
+              "initial_date":"2020-05-04",
+              "placeholder": {"type": "plain_text", "text":"Select a date"}
+          }
+        }]
+        say(
+            blocks=blocks,
+            text="Pick a date for me to remind you"
+        )
+```
+
+</details>

--- a/docs/_basic/ja_socket_mode.md
+++ b/docs/_basic/ja_socket_mode.md
@@ -1,0 +1,72 @@
+---
+title: ソケットモードの使用
+lang: ja-jp
+slug: socket-mode
+order: 16
+---
+
+<div class="section-content">
+[ソケットモード](https://api.slack.com/apis/connections/socket)は、アプリに WebSocket での接続と、そのコネクション経由でのデータ受信を可能とします。Bolt for Python は、バージョン 1.2.0 からこれに対応しています。
+
+ソケットモードでは、Slack からのペイロード送信を受け付けるエンドポイントをホストする HTTP サーバーを起動する代わりに WebSocket で Slack に接続し、そのコネクション経由でデータを受信します。ソケットモードを使う前に、アプリの管理画面でソケットモードの機能が有効になっているコオを確認しておいてください。
+
+ソケットモードを使用するには、環境変数に `SLACK_APP_TOKEN` を追加します。アプリのトークン（App-Level Token）は、アプリの設定の「**Basic Information**」セクションで確認できます。 
+
+[組み込みのソケットモードアダプター](https://github.com/slackapi/bolt-python/tree/main/slack_bolt/adapter/socket_mode/builtin)を使用するのがおすすめですが、サードパーティ製ライブラリを使ったアダプターの実装もいくつか存在しています。利用可能なアダプターの一覧です。
+
+|PyPI プロジェクト|Bolt アダプター|
+|-|-|
+|[slack_sdk](https://pypi.org/project/slack-sdk/)|[slack_bolt.adapter.socket_mode](https://github.com/slackapi/bolt-python/tree/main/slack_bolt/adapter/socket_mode/builtin)|
+|[websocket_client](https://pypi.org/project/websocket_client/)|[slack_bolt.adapter.socket_mode.websocket_client](https://github.com/slackapi/bolt-python/tree/main/slack_bolt/adapter/socket_mode/websocket_client)|
+|[aiohttp](https://pypi.org/project/aiohttp/) (asyncio-based)|[slack_bolt.adapter.socket_mode.aiohttp](https://github.com/slackapi/bolt-python/tree/main/slack_bolt/adapter/socket_mode/aiohttp)|
+|[websockets](https://pypi.org/project/websockets/) (asyncio-based)|[slack_bolt.adapter.socket_mode.websockets](https://github.com/slackapi/bolt-python/tree/main/slack_bolt/adapter/socket_mode/websockets)|
+
+</div>
+
+```python
+import os
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+
+# 事前に Slack アプリをインストールし 'xoxb-' で始まるトークンを入手
+app = App(token=os.environ["SLACK_BOT_TOKEN"])
+
+# ここでミドルウェアとリスナーの追加を行います
+
+if __name__ == "__main__":
+    # export SLACK_APP_TOKEN=xapp-***
+    # export SLACK_BOT_TOKEN=xoxb-***
+    handler = SocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])
+    handler.start()
+```
+
+<details class="secondary-wrapper">
+<summary markdown="0">
+<h4 class="secondary-header">Async (asyncio) の利用</h4>
+</summary>
+
+<div class="secondary-content" markdown="0">
+aiohttp のような asyncio をベースとしたアダプターを使う場合、アプリケーション全体が asyncio の async/await プログラミングモデルで実装されている必要があります。`AsyncApp` を動作させるためには `AsyncSocketModeHandler` とその async なミドルウェアやリスナーを利用します。
+
+`AsyncApp` の使い方についての詳細は、[Usin async (asyncio)](https://slack.dev/bolt-python/concepts#async)トや、関連する[サンプルコード例](https://github.com/slackapi/bolt-python/tree/main/examples)を参考にしてください。
+</div>
+
+```python
+from slack_bolt.app.async_app import AsyncApp
+# デフォルトは aiohttp を使った実装
+from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
+
+app = AsyncApp(token=os.environ["SLACK_BOT_TOKEN"])
+
+# ここでミドルウェアとリスナーの追加を行います
+
+async def main():
+    handler = AsyncSocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])
+    await handler.start_async()
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())
+```
+
+</details>

--- a/docs/_basic/ja_updating_pushing_modals.md
+++ b/docs/_basic/ja_updating_pushing_modals.md
@@ -1,0 +1,53 @@
+---
+title: モーダルの更新と多重表示
+lang: ja-jp
+slug: updating-pushing-views
+order: 11
+---
+
+<div class="section-content">
+
+モーダル内では、複数のモーダルをスタックのように重ねることができます。<a href="https://api.slack.com/methods/views.open">`views_open`</a> という APIを呼び出すと、親となるとなるモーダルビューが追加されます。この最初の呼び出しの後、<a href="https://api.slack.com/methods/views.update">`views_update`</a> を呼び出すことでそのビューを更新することができます。また、<a href="https://api.slack.com/methods/views.push">`views_push`</a> を呼び出すと、親のモーダルの上にさらに新しいモーダルビューを重ねることもできます。
+
+**`views_update`**<br>
+モーダルの更新は、組み込みのクライアントで `views_update` API を呼び出します。この API呼び出しでは、ビューを開いた時に生成された `view_id` と、更新後の `blocks` のリストを含む新しい `view` を指定します。既存のモーダルに含まれるエレメントをユーザーが操作した時にビューを更新する場合は、リクエストの `body` に含まれる `view_id` が利用できます。
+
+**`views_push`**<br>
+既存のモーダルの上に新しいモーダルをスタックのように追加する場合は、組み込みのクライアントで `views_push` API を呼び出します。この API 呼び出しでは、有効な `trigger_id` と新しい<a href="https://api.slack.com/reference/block-kit/views">ビューのペイロード</a>を指定します。`views_push` の引数は <a href="#creating-modals">モーダルの開始</a> と同じです。モーダルを開いた後、このモーダルのスタックに追加できるモーダルビューは 2 つまでです。
+
+モーダルの更新と多重表示に関する詳細は、<a href="https://api.slack.com/surfaces/modals/using#modifying">API ドキュメント</a>を参照してください。
+
+</div>
+
+```python
+# モーダルに含まれる、`button_abc` という action_id のボタンの呼び出しをリッスン
+@app.action("button_abc")
+def update_modal(ack, body, client):
+    # ボタンのリクエストを確認
+    ack()
+    # 組み込みのクライアントで views_update を呼び出し
+    client.views_update(
+        # view_id を渡すこと
+        view_id=body["view"]["id"],
+        # 競合状態を防ぐためのビューの状態を示す文字列
+        hash=body["view"]["hash"],
+        # 更新後の blocks を含むビューのペイロード
+        view={
+            "type": "modal",
+            # ビューの識別子
+            "callback_id": "view_1",
+            "title": {"type": "plain_text", "text":"Updated modal"},
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {"type": "plain_text", "text":"You updated the modal!"}
+                },
+                {
+                    "type": "image",
+                    "image_url": "https://media.giphy.com/media/SVZGEcYt7brkFUyU90/giphy.gif",
+                    "alt_text":"Yay!The modal was updated"
+                }
+            ]
+        }
+    )
+```

--- a/docs/_basic/ja_web_api.md
+++ b/docs/_basic/ja_web_api.md
@@ -1,0 +1,26 @@
+---
+title: Web API の使い方
+lang: ja-jp
+slug: web-api
+order: 4
+---
+
+<div class="section-content">
+`app.client`、またはミドルウェア・リスナーの引数 `client` として Bolt アプリに提供されている [`WebClient`](https://slack.dev/python-slack-sdk/basic_usage.html) は必要な権限を付与されており、これを利用することで[あらゆる Web API メソッド](https://api.slack.com/methods)を呼び出すことができます。このクライアントのメソッドを呼び出すと `SlackResponse` という Slack からの応答情報を含むオブジェクトが返されます。
+
+Bolt の初期化に使用するトークンは `context` オブジェクトに設定されます。このトークンは、多くの Web API メソッドを呼び出す際に必要となります。
+
+</div>
+
+```python
+@app.message("wake me up")
+def say_hello(client, message):
+    # 2020 年 9 月 30 日午後 11:59:59 を示す Unix エポック秒
+    when_september_ends = 1601510399
+    channel_id = message["channel"]
+    client.chat_scheduleMessage(
+        channel=channel_id,
+        post_at=when_september_ends,
+        text="Summer has come and passed"
+    )
+```

--- a/docs/_basic/listening_actions.md
+++ b/docs/_basic/listening_actions.md
@@ -10,7 +10,7 @@ Your app can listen to user actions, like button clicks, and menu selects, using
 
 Actions can be filtered on an `action_id` of type `str` or `re.Pattern`. `action_id`s act as unique identifiers for interactive components on the Slack platform.
 
-You’ll notice in all `action()` examples, `ack()` is used. It is required to call the `ack()` function within an action listener to acknowledge that the event was received from Slack. This is discussed in the [acknowledging events section](#acknowledge).
+You'll notice in all `action()` examples, `ack()` is used. It is required to call the `ack()` function within an action listener to acknowledge that the event was received from Slack. This is discussed in the [acknowledging events section](#acknowledge).
 
 </div>
 

--- a/docs/_basic/listening_messages.md
+++ b/docs/_basic/listening_messages.md
@@ -9,7 +9,7 @@ order: 1
 
 To listen to messages that [your app has access to receive](https://api.slack.com/messaging/retrieving#permissions), you can use the `message()` method which filters out events that aren't of type `message`.
 
-`message()` accepts an argument of type `str` or `re.Pattern` object that filters out any messages that don’t match the pattern.
+`message()` accepts an argument of type `str` or `re.Pattern` object that filters out any messages that don't match the pattern.
 
 </div>
 

--- a/docs/_basic/listening_responding_shortcuts.md
+++ b/docs/_basic/listening_responding_shortcuts.md
@@ -9,7 +9,7 @@ order: 8
 
 The `shortcut()` method supports both [global shortcuts](https://api.slack.com/interactivity/shortcuts/using#global_shortcuts) and [message shortcuts](https://api.slack.com/interactivity/shortcuts/using#message_shortcuts).
 
-Shortcuts are invokable entry points to apps. Global shortcuts are available from within search in Slack. Message shortcuts are available in the context menus of messages. Your app can use the `shortcut()` method to listen to incoming shortcut events. The method requires a `callback_id` parameter of type `str` or `re.Pattern`.
+Shortcuts are invokable entry points to apps. Global shortcuts are available from within search and text composer area in Slack. Message shortcuts are available in the context menus of messages. Your app can use the `shortcut()` method to listen to incoming shortcut events. The method requires a `callback_id` parameter of type `str` or `re.Pattern`.
 
 Shortcuts must be acknowledged with `ack()` to inform Slack that your app has received the event.
 

--- a/docs/_basic/sending_messages.md
+++ b/docs/_basic/sending_messages.md
@@ -9,7 +9,7 @@ order: 2
 
 Within your listener function, `say()` is available whenever there is an associated conversation (for example, a conversation where the event or action which triggered the listener occurred). `say()` accepts a string to post simple messages and JSON payloads to send more complex messages. The message payload you pass in will be sent to the associated conversation.
 
-In the case that you’d like to send a message outside of a listener or you want to do something more advanced (like handle specific errors), you can call `client.chat_postMessage` [using the client attached to your Bolt instance](#web-api).
+In the case that you'd like to send a message outside of a listener or you want to do something more advanced (like handle specific errors), you can call `client.chat_postMessage` [using the client attached to your Bolt instance](#web-api).
 
 </div>
 

--- a/docs/_basic/socket_mode.md
+++ b/docs/_basic/socket_mode.md
@@ -40,11 +40,11 @@ if __name__ == "__main__":
 
 <details class="secondary-wrapper">
 <summary markdown="0">
-<h4 class="secondary-header">Using Async</h4>
+<h4 class="secondary-header">Using Async (asyncio)</h4>
 </summary>
 
 <div class="secondary-content" markdown="0">
-To use the asyncio-based adapters such as aiohttp, your app needs to be compatible with asyncio's async/await programming model. `AsyncSocketModeHandler` is available for running `AsyncApp` and its async middleware and listeners. 
+To use the asyncio-based adapters such as aiohttp, your whole app needs to be compatible with asyncio's async/await programming model. `AsyncSocketModeHandler` is available for running `AsyncApp` and its async middleware and listeners. 
 
 To learn how to use `AsyncApp`, checkout the [Using Async](https://slack.dev/bolt-python/concepts#async) document and relevant [examples](https://github.com/slackapi/bolt-python/tree/main/examples).
 </div>

--- a/docs/_basic/web_api.md
+++ b/docs/_basic/web_api.md
@@ -6,7 +6,7 @@ order: 4
 ---
 
 <div class="section-content">
-You can call [any Web API method](https://api.slack.com/methods) using the [`WebClient`](https://slack.dev/python-slack-sdk/basic_usage.html) provided to your Bolt app as `app.client` (given that your app has the appropriate scopes). When you call one the client’s methods, it returns a `SlackResponse` which contains the response from Slack.
+You can call [any Web API method](https://api.slack.com/methods) using the [`WebClient`](https://slack.dev/python-slack-sdk/basic_usage.html) provided to your Bolt app as either `app.client` or `client` in middleware/listener arguments (given that your app has the appropriate scopes). When you call one the client's methods, it returns a `SlackResponse` which contains the response from Slack.
 
 The token used to initialize Bolt can be found in the `context` object, which is required to call most Web API methods.
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,7 +36,7 @@ t:
     start: Getting started
     contribute: Contributing
   ja-jp:
-#    basic: 基本的な概念
+    basic: 基本的な概念
 #    steps: ワークフローステップ
 #    advanced: 応用コンセプト
     start: Bolt 入門ガイド

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -23,7 +23,7 @@
     <a href="{{ site.url | append: site.baseurl | append: localized_base_url  }}/tutorial/getting-started">
       <li class="title">{{ site.t[page.lang].start }}</li>
     </a>
-    <a href="{{ site.url | append: site.baseurl | append: localized_base_url  }}/api-docs/slack_bolt/" target="_blank">
+    <a href="{{ site.url | append: site.baseurl }}/api-docs/slack_bolt/" target="_blank">
       <li class="title">API Documents</li>
     </a>
   </ul>

--- a/docs/_tutorials/ja_getting_started.md
+++ b/docs/_tutorials/ja_getting_started.md
@@ -43,7 +43,7 @@ Slack アプリで使用できるトークンには、ユーザートークン�
 
 左サイドバーの「**OAuth & Permissions**」をクリックし、「**Bot Token Scopes**」セクションまで下にスクロールします。「**Add an OAuth Scope**」をクリックします。
 
-ここでは「[`chat:write`](https://api.slack.com/scopes/chat:write)」というスコープのみを追加します。このスコープは、アプリが参加しているチャンネルにメッセージを投稿することを許可します。
+ここでは [`chat:write`](https://api.slack.com/scopes/chat:write) というスコープのみを追加します。このスコープは、アプリが参加しているチャンネルにメッセージを投稿することを許可します。
 
 OAuth & Permissions ページの一番上までスクロールし、「**Install App to Workspace**」をクリックします。Slack の OAuth 確認画面 が表示されます。この画面で開発用ワークスペースへのアプリのインストールを承認します。
 
@@ -173,7 +173,7 @@ app = App(
     signing_secret=os.environ.get("SLACK_SIGNING_SECRET")
 )
 
-# 「hello」を含むメッセージをリッスンします
+# 'hello' を含むメッセージをリッスンします
 @app.message("hello")
 def message_hello(message, say):
     # イベントがトリガーされたチャンネルへ say() でメッセージを送信します
@@ -214,7 +214,7 @@ app = App(
     signing_secret=os.environ.get("SLACK_SIGNING_SECRET")
 )
 
-# 「hello」を含むメッセージをリッスンします
+# 'hello' を含むメッセージをリッスンします
 @app.message("hello")
 def message_hello(message, say):
     # イベントがトリガーされたチャンネルへ say() でメッセージを送信します
@@ -238,9 +238,9 @@ if __name__ == "__main__":
     app.start(port=int(os.environ.get("PORT", 3000)))
 ```
 
-`say()` の中の値を、「`blocks`」という配列のオブジェクトに変えました。ブロックは Slack メッセージを構成するコンポーネントであり、テキストや画像、日付ピッカーなど、さまざまなタイプのブロックがあります。この例では、「accessory」に「button」を持たせた「section」のブロックを、アプリからの応答に含めています。「`blocks`」を使用する場合、「`text`」は通知やアクセシビリティのためのフォールバックとなります。
+`say()` の中の値を `blocks` という配列のオブジェクトに変えました。ブロックは Slack メッセージを構成するコンポーネントであり、テキストや画像、日付ピッカーなど、さまざまなタイプのブロックがあります。この例では `accessory` に `button` を持たせた「section」のブロックを、アプリからの応答に含めています。`blocks` を使用する場合、`text` は通知やアクセシビリティのためのフォールバックとなります。
 
-ボタンを含む「`accessory`」オブジェクトでは、「`action_id`」を指定していることがわかります。これは、ボタンを一意に示す識別子として機能します。これを使って、アプリをどのアクションに応答させるかを指定できます。
+ボタンを含む `accessory` オブジェクトでは、`action_id` を指定していることがわかります。これは、ボタンを一意に示す識別子として機能します。これを使って、アプリをどのアクションに応答させるかを指定できます。
 
 > 💡 [Block Kit Builder](https://app.slack.com/block-kit-builder) を使用すると、インタラクティブなメッセージのプロトタイプを簡単に作成できます。自分自身やチームメンバーがメッセージのモックアップを作成し、生成される JSON をアプリに直接貼りつけることができます。
 
@@ -258,7 +258,7 @@ app = App(
     signing_secret=os.environ.get("SLACK_SIGNING_SECRET")
 )
 
-# 「hello」を含むメッセージをリッスンします
+# 'hello' を含むメッセージをリッスンします
 @app.message("hello")
 def message_hello(message, say):
     # イベントがトリガーされたチャンネルへ say() でメッセージを送信します
@@ -289,7 +289,7 @@ if __name__ == "__main__":
     app.start(port=int(os.environ.get("PORT", 3000)))
 ```
 
-`app.action()` を使って、先ほど命名した「`button_click`」という `action_id` をリッスンしています。アプリを再起動し、ボタンをクリックすると、アプリからの「clicked the button」というメッセージが新たに表示されるでしょう。
+`app.action()` を使って、先ほど命名した `button_click` という `action_id` をリッスンしています。アプリを再起動し、ボタンをクリックすると、アプリからの「clicked the button」というメッセージが新たに表示されるでしょう。
 
 ---
 


### PR DESCRIPTION
This pull request adds Japanese version of "Basic Concepts" documents.

<img width="600" src="https://user-images.githubusercontent.com/19658/112922722-f25fc400-9147-11eb-87c9-5f858d67b50e.png">

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
