### PR TITLE
Fix #267 Mention the necessity of lambda:InvokeFunction permission in lazy listener document

### DIFF
--- a/docs/_advanced/lazy_listener.md
+++ b/docs/_advanced/lazy_listener.md
@@ -54,7 +54,8 @@ pip install slack_bolt
 # https://pypi.org/project/python-lambda/
 pip install python-lambda
 
-# Configure config.yml properly (AWSLambdaFullAccess required)
+# Configure config.yml properly
+# lambda:InvokeFunction & lambda:GetFunction are required for running lazy listeners
 export SLACK_SIGNING_SECRET=***
 export SLACK_BOT_TOKEN=xoxb-***
 echo 'slack_bolt' > requirements.txt
@@ -89,5 +90,24 @@ app.command("/start-process")(
 def handler(event, context):
     slack_handler = SlackRequestHandler(app=app)
     return slack_handler.handle(event, context)
+```
+
+Please note that the followig IAM permissions would be required for running this example app.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "lambda:InvokeFunction",
+                "lambda:GetFunction"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
 ```
 </details>

--- a/examples/aws_lambda/lazy_aws_lambda_config.yaml
+++ b/examples/aws_lambda/lazy_aws_lambda_config.yaml
@@ -5,7 +5,8 @@ handler: lazy_aws_lambda.handler
 description: My first lambda function
 runtime: python3.8
 # role: lambda_basic_execution
-role: bolt_python_lambda_invocation #  AWSLambdaFullAccess
+# Have lambda:InvokeFunction & lambda:GetFunction in the allowed actions
+role: bolt_python_lambda_invocation 
 
 # S3 upload requires appropriate role with s3:PutObject permission
 # (ex. basic_s3_upload), a destination bucket, and the key prefix


### PR DESCRIPTION
This pull request resolves #267 

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
