### PR TITLE
Enable installation_store authorize to fallback to bots (prep for #254)

### DIFF
--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -93,6 +93,7 @@ class AsyncCallableAuthorize(AsyncAuthorize):
 class AsyncInstallationStoreAuthorize(AsyncAuthorize):
     authorize_result_cache: Dict[str, AuthorizeResult]
     find_installation_available: Optional[bool]
+    find_bot_available: Optional[bool]
 
     def __init__(
         self,
@@ -110,6 +111,7 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
         self.cache_enabled = cache_enabled
         self.authorize_result_cache = {}
         self.find_installation_available = None
+        self.find_bot_available = None
 
     async def __call__(
         self,
@@ -124,12 +126,15 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
             self.find_installation_available = hasattr(
                 self.installation_store, "async_find_installation"
             )
+        if self.find_bot_available is None:
+            self.find_bot_available = hasattr(self.installation_store, "async_find_bot")
 
         bot_token: Optional[str] = None
         user_token: Optional[str] = None
 
         if not self.bot_only and self.find_installation_available:
-            # since v1.1, this is the default way
+            # Since v1.1, this is the default way.
+            # If you want to use find_bot / delete_bot only, you can set bot_only as True.
             try:
                 # Note that this is the latest information for the org/workspace.
                 # The installer may not be the user associated with this incoming request.
@@ -140,47 +145,64 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
                     team_id=team_id,
                     is_enterprise_install=context.is_enterprise_install,
                 )
-                if installation is None:
-                    self._debug_log_for_not_found(enterprise_id, team_id)
-                    return None
 
-                if installation.user_id != user_id:
-                    # First off, remove the user token as the installer is a different user
-                    installation.user_token = None
-                    installation.user_scopes = []
+                if installation is not None:
+                    if installation.user_id != user_id:
+                        # First off, remove the user token as the installer is a different user
+                        installation.user_token = None
+                        installation.user_scopes = []
 
-                    # try to fetch the request user's installation
-                    # to reflect the user's access token if exists
-                    user_installation = (
-                        await self.installation_store.async_find_installation(
-                            enterprise_id=enterprise_id,
-                            team_id=team_id,
-                            user_id=user_id,
-                            is_enterprise_install=context.is_enterprise_install,
+                        # try to fetch the request user's installation
+                        # to reflect the user's access token if exists
+                        user_installation = (
+                            await self.installation_store.async_find_installation(
+                                enterprise_id=enterprise_id,
+                                team_id=team_id,
+                                user_id=user_id,
+                                is_enterprise_install=context.is_enterprise_install,
+                            )
                         )
-                    )
-                    if user_installation is not None:
-                        # Overwrite the installation with the one for this user
-                        installation = user_installation
+                        if user_installation is not None:
+                            # Overwrite the installation with the one for this user
+                            installation = user_installation
 
-                bot_token, user_token = installation.bot_token, installation.user_token
+                    bot_token, user_token = (
+                        installation.bot_token,
+                        installation.user_token,
+                    )
+
             except NotImplementedError as _:
                 self.find_installation_available = False
 
-        if self.bot_only or not self.find_installation_available:
-            # Use find_bot to get bot value (legacy)
-            bot: Optional[Bot] = await self.installation_store.async_find_bot(
-                enterprise_id=enterprise_id,
-                team_id=team_id,
-                is_enterprise_install=context.is_enterprise_install,
+        if (
+            # If you intentionally use only find_bot / delete_bot,
+            self.bot_only
+            # If find_installation method is not available,
+            or not self.find_installation_available
+            # If find_installation did not return data and find_bot method is available,
+            or (
+                self.find_bot_available is True
+                and bot_token is None
+                and user_token is None
             )
-            if bot is None:
-                self._debug_log_for_not_found(enterprise_id, team_id)
-                return None
-            bot_token, user_token = bot.bot_token, None
+        ):
+            try:
+                bot: Optional[Bot] = await self.installation_store.async_find_bot(
+                    enterprise_id=enterprise_id,
+                    team_id=team_id,
+                    is_enterprise_install=context.is_enterprise_install,
+                )
+                if bot is not None:
+                    bot_token = bot.bot_token
+            except NotImplementedError as _:
+                self.find_bot_available = False
+            except Exception as e:
+                self.logger.info(f"Failed to call find_bot method: {e}")
 
         token: Optional[str] = bot_token or user_token
         if token is None:
+            # No valid token was found
+            self._debug_log_for_not_found(enterprise_id, team_id)
             return None
 
         # Check cache to see if the bot object already exists

--- a/tests/scenario_tests/test_installation_store_authorize.py
+++ b/tests/scenario_tests/test_installation_store_authorize.py
@@ -1,0 +1,150 @@
+import json
+from time import time
+from typing import Optional
+from urllib.parse import quote
+
+from slack_sdk import WebClient
+from slack_sdk.oauth import InstallationStore
+from slack_sdk.oauth.installation_store import Installation, Bot
+from slack_sdk.signature import SignatureVerifier
+
+from slack_bolt import BoltRequest
+from slack_bolt.app import App
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+    assert_auth_test_count,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+valid_token = "xoxb-valid"
+valid_user_token = "xoxp-valid"
+
+
+class MyInstallationStore(InstallationStore):
+    def find_bot(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Bot]:
+        return Bot(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            bot_token=valid_token,
+            bot_id="B111",
+            bot_user_id="W111",
+            bot_scopes=["commands"],
+            installed_at=time(),
+        )
+
+    def find_installation(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        user_id: Optional[str] = None,
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Installation]:
+        return None
+
+
+class TestInstallationStoreAuthorize:
+    signing_secret = "secret"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = WebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    def setup_method(self):
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body,
+            timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        return {
+            "content-type": ["application/x-www-form-urlencoded"],
+            "x-slack-signature": [self.generate_signature(body, timestamp)],
+            "x-slack-request-timestamp": [timestamp],
+        }
+
+    def build_valid_request(self) -> BoltRequest:
+        timestamp = str(int(time()))
+        return BoltRequest(
+            body=raw_body, headers=self.build_headers(timestamp, raw_body)
+        )
+
+    def test_success(self):
+        app = App(
+            client=self.web_client,
+            installation_store=MyInstallationStore(),
+            signing_secret=self.signing_secret,
+        )
+        app.action("a")(simple_listener)
+
+        request = self.build_valid_request()
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert response.body == ""
+        assert_auth_test_count(self, 1)
+
+
+body = {
+    "type": "block_actions",
+    "user": {
+        "id": "W99999",
+        "username": "primary-owner",
+        "name": "primary-owner",
+        "team_id": "T111",
+    },
+    "api_app_id": "A111",
+    "token": "verification_token",
+    "container": {
+        "type": "message",
+        "message_ts": "111.222",
+        "channel_id": "C111",
+        "is_ephemeral": True,
+    },
+    "trigger_id": "111.222.valid",
+    "team": {
+        "id": "T111",
+        "domain": "workspace-domain",
+        "enterprise_id": "E111",
+        "enterprise_name": "Sandbox Org",
+    },
+    "channel": {"id": "C111", "name": "test-channel"},
+    "response_url": "https://hooks.slack.com/actions/T111/111/random-value",
+    "actions": [
+        {
+            "action_id": "a",
+            "block_id": "b",
+            "text": {"type": "plain_text", "text": "Button", "emoji": True},
+            "value": "click_me_123",
+            "type": "button",
+            "action_ts": "1596530385.194939",
+        }
+    ],
+}
+
+raw_body = f"payload={quote(json.dumps(body))}"
+
+
+def simple_listener(ack, body, payload, action):
+    assert body["trigger_id"] == "111.222.valid"
+    assert body["actions"][0] == payload
+    assert payload == action
+    assert action["action_id"] == "a"
+    ack()

--- a/tests/scenario_tests_async/test_installation_store_authorize.py
+++ b/tests/scenario_tests_async/test_installation_store_authorize.py
@@ -1,0 +1,159 @@
+import asyncio
+import json
+from time import time
+from typing import Optional
+from urllib.parse import quote
+
+import pytest
+from slack_sdk.oauth.installation_store import Installation, Bot
+from slack_sdk.oauth.installation_store.async_installation_store import (
+    AsyncInstallationStore,
+)
+from slack_sdk.signature import SignatureVerifier
+from slack_sdk.web.async_client import AsyncWebClient
+
+from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.request.async_request import AsyncBoltRequest
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+    assert_auth_test_count_async,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+valid_token = "xoxb-valid"
+valid_user_token = "xoxp-valid"
+
+
+class MyInstallationStore(AsyncInstallationStore):
+    async def async_find_bot(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Bot]:
+        return Bot(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            bot_token=valid_token,
+            bot_id="B111",
+            bot_user_id="W111",
+            bot_scopes=["commands"],
+            installed_at=time(),
+        )
+
+    async def async_find_installation(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        user_id: Optional[str] = None,
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Installation]:
+        return None
+
+
+class TestAsyncInstallationStoreAuthorize:
+    signing_secret = "secret"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = AsyncWebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    @pytest.fixture
+    def event_loop(self):
+        old_os_env = remove_os_env_temporarily()
+        try:
+            setup_mock_web_api_server(self)
+            loop = asyncio.get_event_loop()
+            yield loop
+            loop.close()
+            cleanup_mock_web_api_server(self)
+        finally:
+            restore_os_env(old_os_env)
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body,
+            timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        return {
+            "content-type": ["application/x-www-form-urlencoded"],
+            "x-slack-signature": [self.generate_signature(body, timestamp)],
+            "x-slack-request-timestamp": [timestamp],
+        }
+
+    def build_valid_request(self) -> AsyncBoltRequest:
+        timestamp = str(int(time()))
+        return AsyncBoltRequest(
+            body=raw_body, headers=self.build_headers(timestamp, raw_body)
+        )
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        app = AsyncApp(
+            client=self.web_client,
+            installation_store=MyInstallationStore(),
+            signing_secret=self.signing_secret,
+        )
+        app.action("a")(simple_listener)
+
+        request = self.build_valid_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert response.body == ""
+        await assert_auth_test_count_async(self, 1)
+
+
+body = {
+    "type": "block_actions",
+    "user": {
+        "id": "W99999",
+        "username": "primary-owner",
+        "name": "primary-owner",
+        "team_id": "T111",
+    },
+    "api_app_id": "A111",
+    "token": "verification_token",
+    "container": {
+        "type": "message",
+        "message_ts": "111.222",
+        "channel_id": "C111",
+        "is_ephemeral": True,
+    },
+    "trigger_id": "111.222.valid",
+    "team": {
+        "id": "T111",
+        "domain": "workspace-domain",
+        "enterprise_id": "E111",
+        "enterprise_name": "Sandbox Org",
+    },
+    "channel": {"id": "C111", "name": "test-channel"},
+    "response_url": "https://hooks.slack.com/actions/T111/111/random-value",
+    "actions": [
+        {
+            "action_id": "a",
+            "block_id": "b",
+            "text": {"type": "plain_text", "text": "Button", "emoji": True},
+            "value": "click_me_123",
+            "type": "button",
+            "action_ts": "1596530385.194939",
+        }
+    ],
+}
+
+raw_body = f"payload={quote(json.dumps(body))}"
+
+
+async def simple_listener(ack, body, payload, action):
+    assert body["trigger_id"] == "111.222.valid"
+    assert body["actions"][0] == payload
+    assert payload == action
+    assert action["action_id"] == "a"
+    await ack()


### PR DESCRIPTION
This pull request improves `InstallationStoreAuthorize` and `AsyncInstallationStoreAuthorize` for better installation data resolution as part of #254 feature addition.

Even when all user installations are revoked, bot scope installation should exist as long as the app is not uninstalled in the workspace. This is the reason why this SDK recommends having two data tables - bots and user installations. This pull request improves the authorize functions to be capable to resolve bot installation regardless of the behavior of find_installation method in `InstallationStore` / `AsyncInstallationStore`. Refer to the test code for learning what the use case is.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
