### PR TITLE
Fix #260 Enable to use respond utility in app.view listeners (only when response_urls exists)

### DIFF
--- a/slack_bolt/request/async_internals.py
+++ b/slack_bolt/request/async_internals.py
@@ -6,25 +6,34 @@ from slack_bolt.request.internals import (
     extract_team_id,
     extract_user_id,
     extract_channel_id,
+    debug_multiple_response_urls_detected,
 )
 
 
 def build_async_context(
     context: AsyncBoltContext,
-    payload: Dict[str, Any],
+    body: Dict[str, Any],
 ) -> AsyncBoltContext:
-    enterprise_id = extract_enterprise_id(payload)
+    enterprise_id = extract_enterprise_id(body)
     if enterprise_id:
         context["enterprise_id"] = enterprise_id
-    team_id = extract_team_id(payload)
+    team_id = extract_team_id(body)
     if team_id:
         context["team_id"] = team_id
-    user_id = extract_user_id(payload)
+    user_id = extract_user_id(body)
     if user_id:
         context["user_id"] = user_id
-    channel_id = extract_channel_id(payload)
+    channel_id = extract_channel_id(body)
     if channel_id:
         context["channel_id"] = channel_id
-    if "response_url" in payload:
-        context["response_url"] = payload["response_url"]
+    if "response_url" in body:
+        context["response_url"] = body["response_url"]
+    elif "response_urls" in body:
+        # In the case where response_url_enabled: true in a modal exists
+        response_urls = body["response_urls"]
+        if len(response_urls) >= 1:
+            if len(response_urls) > 1:
+                context.logger.debug(debug_multiple_response_urls_detected())
+            response_url = response_urls[0].get("response_url")
+            context["response_url"] = response_url
     return context

--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -143,6 +143,14 @@ def build_context(context: BoltContext, body: Dict[str, Any]) -> BoltContext:
         context["channel_id"] = channel_id
     if "response_url" in body:
         context["response_url"] = body["response_url"]
+    elif "response_urls" in body:
+        # In the case where response_url_enabled: true in a modal exists
+        response_urls = body["response_urls"]
+        if len(response_urls) >= 1:
+            if len(response_urls) > 1:
+                context.logger.debug(debug_multiple_response_urls_detected())
+            response_url = response_urls[0].get("response_url")
+            context["response_url"] = response_url
     return context
 
 
@@ -177,3 +185,11 @@ def error_message_raw_body_required_in_http_mode() -> str:
 
 def error_message_unknown_request_body_type() -> str:
     return "`body` must be either str or dict"
+
+
+def debug_multiple_response_urls_detected() -> str:
+    return (
+        "`response_urls` in the body has multiple URLs in it. "
+        "If you would like to use non-primary one, "
+        "please manually extract the one from body['response_urls']."
+    )

--- a/tests/mock_web_api_server.py
+++ b/tests/mock_web_api_server.py
@@ -92,6 +92,12 @@ class MockHandler(SimpleHTTPRequestHandler):
     def _handle(self):
         self.received_requests[self.path] = self.received_requests.get(self.path, 0) + 1
         try:
+            if self.path == "/webhook":
+                self.send_response(200)
+                self.set_common_headers()
+                self.wfile.write("OK".encode("utf-8"))
+                return
+
             if self.path == "/received_requests.json":
                 self.send_response(200)
                 self.set_common_headers()


### PR DESCRIPTION
This pull request resolves #260 by enabling `respond` utility in view_submission listeners. Check the issue for learning the goal.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
