### PR TITLE
Fix #273 Enable developers to customize the way to handle unmatched requests

### DIFF
--- a/slack_bolt/error/__init__.py
+++ b/slack_bolt/error/__init__.py
@@ -1,5 +1,25 @@
 """Bolt specific error types."""
+from typing import Optional, Union
 
 
 class BoltError(Exception):
     """General class in a Bolt app"""
+
+
+class BoltUnhandledRequestError(BoltError):
+    request: "BoltRequest"  # type: ignore
+    body: dict
+    current_response: Optional["BoltResponse"]  # type: ignore
+    last_global_middleware_name: Optional[str]
+
+    def __init__(  # type: ignore
+        self,
+        *,
+        request: Union["BoltRequest", "AsyncBoltRequest"],  # type: ignore
+        current_response: Optional["BoltResponse"],  # type: ignore
+        last_global_middleware_name: Optional[str] = None,
+    ):
+        self.request = request
+        self.body = request.body if request is not None else {}
+        self.current_response = current_response
+        self.last_global_middleware_name = last_global_middleware_name

--- a/slack_bolt/listener/listener_error_handler.py
+++ b/slack_bolt/listener/listener_error_handler.py
@@ -31,7 +31,7 @@ class ListenerErrorHandler(metaclass=ABCMeta):
 
 
 class CustomListenerErrorHandler(ListenerErrorHandler):
-    def __init__(self, logger: Logger, func: Callable[..., None]):
+    def __init__(self, logger: Logger, func: Callable[..., Optional[BoltResponse]]):
         self.func = func
         self.logger = logger
         self.arg_names = inspect.getfullargspec(func).args
@@ -53,7 +53,13 @@ class CustomListenerErrorHandler(ListenerErrorHandler):
             arg_names=self.arg_names,
             logger=self.logger,
         )
-        self.func(**kwargs)
+        returned_response = self.func(**kwargs)
+        if returned_response is not None and isinstance(
+            returned_response, BoltResponse
+        ):
+            response.status = returned_response.status
+            response.headers = returned_response.headers
+            response.body = returned_response.body
 
 
 class DefaultListenerErrorHandler(ListenerErrorHandler):

--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -85,7 +85,18 @@ def warning_installation_store_conflicts() -> str:
     return "As you gave both `installation_store` and `oauth_settings`/`auth_flow`, the top level one is unused."
 
 
-def warning_unhandled_request(req: Union[BoltRequest, "AsyncBoltRequest"]) -> str:  # type: ignore
+def warning_unhandled_by_global_middleware(  # type: ignore
+    name: str, req: Union[BoltRequest, "AsyncBoltRequest"]  # type: ignore
+) -> str:  # type: ignore
+    return (
+        f"A global middleware ({name}) skipped calling `next()` "
+        f"without providing a response for the request ({req.body})"
+    )
+
+
+def warning_unhandled_request(  # type: ignore
+    req: Union[BoltRequest, "AsyncBoltRequest"],  # type: ignore
+) -> str:  # type: ignore
     return f"Unhandled request ({req.body})"
 
 


### PR DESCRIPTION
This pull request resolves #273 by introducing a new option to enable using `@app.error` handlers for unmatched requests. The default is set to False, which is fully backward compatible.

If the option is True, Bolt raises a `BoltUnhandledRequestError` with sufficient information. `@app.error` handler can customize the behavior for the patterns (e.g., having custom logging, changing HTTP status from 404 to something else).

```python
app = App(
    token=os.environ["SLACK_BOT_TOKEN"],
    signing_secret=os.environ["SLACK_SIGNING_SECRET"],
)

# The default behavior won't be changed at all
response = app.dispatch(request)
assert response.status == 404
assert response.body == '{"error": "unhandled request"}'

app = App(
    token=os.environ["SLACK_BOT_TOKEN"],
    signing_secret=os.environ["SLACK_SIGNING_SECRET"],
    # enable @app.error handler to catch the patterns
    raise_error_for_unhandled_request=True,
)

@app.error
def handle_errors(error):
    if isinstance(error, BoltUnhandledRequestError):
        return BoltResponse(status=503, body="TODO")
    else:
        # other error patterns
        pass

response = app.dispatch(request)
assert response.status == 503
assert response.body == "TODO"
```

See the added unit tests for verifying the behavior.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
