### PR TITLE
Fix #330 Potentially request.body can be None when using a custom adapter

### DIFF
--- a/slack_bolt/request/async_request.py
+++ b/slack_bolt/request/async_request.py
@@ -9,7 +9,6 @@ from slack_bolt.request.internals import (
     build_normalized_headers,
     extract_content_type,
     error_message_raw_body_required_in_http_mode,
-    error_message_unknown_request_body_type,
 )
 
 
@@ -45,7 +44,7 @@ class AsyncBoltRequest:
 
         if mode == "http":
             # HTTP Mode
-            if not isinstance(body, str):
+            if body is not None and not isinstance(body, str):
                 raise BoltError(error_message_raw_body_required_in_http_mode())
             self.raw_body = body if body is not None else ""
         else:
@@ -60,12 +59,14 @@ class AsyncBoltRequest:
         self.query = parse_query(query)
         self.headers = build_normalized_headers(headers)
         self.content_type = extract_content_type(self.headers)
+
         if isinstance(body, str):
             self.body = parse_body(self.raw_body, self.content_type)
         elif isinstance(body, dict):
             self.body = body
         else:
-            raise BoltError(error_message_unknown_request_body_type())
+            self.body = {}
+
         self.context = build_async_context(
             AsyncBoltContext(context if context else {}), self.body
         )

--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -183,10 +183,6 @@ def error_message_raw_body_required_in_http_mode() -> str:
     return "`body` must be a raw string data when running in the HTTP server mode"
 
 
-def error_message_unknown_request_body_type() -> str:
-    return "`body` must be either str or dict"
-
-
 def debug_multiple_response_urls_detected() -> str:
     return (
         "`response_urls` in the body has multiple URLs in it. "

--- a/slack_bolt/request/request.py
+++ b/slack_bolt/request/request.py
@@ -9,7 +9,6 @@ from slack_bolt.request.internals import (
     build_context,
     extract_content_type,
     error_message_raw_body_required_in_http_mode,
-    error_message_unknown_request_body_type,
 )
 
 
@@ -44,7 +43,7 @@ class BoltRequest:
         """
         if mode == "http":
             # HTTP Mode
-            if not isinstance(body, str):
+            if body is not None and not isinstance(body, str):
                 raise BoltError(error_message_raw_body_required_in_http_mode())
             self.raw_body = body if body is not None else ""
         else:
@@ -59,12 +58,13 @@ class BoltRequest:
         self.query = parse_query(query)
         self.headers = build_normalized_headers(headers)
         self.content_type = extract_content_type(self.headers)
+
         if isinstance(body, str):
             self.body = parse_body(self.raw_body, self.content_type)
         elif isinstance(body, dict):
             self.body = body
         else:
-            raise BoltError(error_message_unknown_request_body_type())
+            self.body = {}
 
         self.context = build_context(BoltContext(context if context else {}), self.body)
         self.lazy_only = bool(self.headers.get("x-slack-bolt-lazy-only", [False])[0])

--- a/tests/slack_bolt/request/test_request.py
+++ b/tests/slack_bolt/request/test_request.py
@@ -1,0 +1,23 @@
+from slack_bolt.request.request import BoltRequest
+
+
+class TestRequest:
+    def setup_method(self):
+        pass
+
+    def teardown_method(self):
+        pass
+
+    def test_all_none_inputs_http(self):
+        req = BoltRequest(body=None, headers=None, query=None, context=None)
+        assert req is not None
+        assert req.raw_body == ""
+        assert req.body == {}
+
+    def test_all_none_inputs_socket_mode(self):
+        req = BoltRequest(
+            body=None, headers=None, query=None, context=None, mode="socket_mode"
+        )
+        assert req is not None
+        assert req.raw_body == ""
+        assert req.body == {}

--- a/tests/slack_bolt_async/request/test_async_request.py
+++ b/tests/slack_bolt_async/request/test_async_request.py
@@ -1,0 +1,21 @@
+import pytest
+
+from slack_bolt.request.async_request import AsyncBoltRequest
+
+
+class TestAsyncRequest:
+    @pytest.mark.asyncio
+    async def test_all_none_values_http(self):
+        req = AsyncBoltRequest(body=None, headers=None, query=None, context=None)
+        assert req is not None
+        assert req.raw_body == ""
+        assert req.body == {}
+
+    @pytest.mark.asyncio
+    async def test_all_none_values_socket_mode(self):
+        req = AsyncBoltRequest(
+            body=None, headers=None, query=None, context=None, mode="socket_mode"
+        )
+        assert req is not None
+        assert req.raw_body == ""
+        assert req.body == {}


### PR DESCRIPTION
This pull request resolves #330 by updating the request parsers.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
