### PR TITLE
Set Werkzeug major version to 1 for Flask compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setuptools.setup(
             "falcon>=2,<3",
             "fastapi<1",
             "Flask>=1,<2",
+            "Werkzeug<2",  # Flask is not yet compatible with the major version
             "pyramid>=1,<2",
             "sanic>=20,<21",
             "starlette>=0.13,<1",

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ test_dependencies = [
     "pytest-asyncio<1",  # for async
     "aiohttp>=3,<4",  # for async
     "Flask-Sockets>=0.2,<1",
+    "Werkzeug<2",  # Flask-Sockets is not yet compatible with the major version
     "black==20.8b1",
 ]
 


### PR DESCRIPTION
Continued work after https://github.com/slackapi/bolt-python/pull/339

Werkzeug v2 was just released and Flask-Sockets, the package we use for Socket Mode testing is not yet compatible with the major version. This pull request updates the build settings to set Werkzeug's major version to 1.

see also: https://pypi.org/project/Werkzeug/#history

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
