### PR TITLE
Fix #206 Add error handling to view submission code snippet in docs

### DIFF
--- a/docs/_basic/ja_listening_modals.md
+++ b/docs/_basic/ja_listening_modals.md
@@ -18,7 +18,7 @@ order: 12
 ```python
 # view_submission イベントを処理
 @app.view("view_1")
-def handle_submission(ack, body, client, view):
+def handle_submission(ack, body, client, view, logger):
     # `block_c`という block_id に `dreamy_input` を持つ input ブロックがある場合
     hopes_and_dreams = view["state"]["values"]["block_c"]["dreamy_input"]
     user = body["user"]["id"]
@@ -42,7 +42,11 @@ def handle_submission(ack, body, client, view):
     except Exception as e:
         # エラーをハンドリング
         msg = "There was an error with your submission"
-    finally:
-        # ユーザーにメッセージを送信
+
+    # ユーザーにメッセージを送信
+    try:
         client.chat_postMessage(channel=user, text=msg)
+    except e:
+        logger.exception(f"Failed to post a message {e}")
+
 ```

--- a/docs/_basic/listening_modals.md
+++ b/docs/_basic/listening_modals.md
@@ -18,7 +18,7 @@ Read more about view submissions in our <a href="https://api.slack.com/surfaces/
 ```python
 # Handle a view_submission event
 @app.view("view_1")
-def handle_submission(ack, body, client, view):
+def handle_submission(ack, body, client, view, logger):
     # Assume there's an input block with `block_c` as the block_id and `dreamy_input`
     hopes_and_dreams = view["state"]["values"]["block_c"]["dreamy_input"]
     user = body["user"]["id"]
@@ -42,7 +42,10 @@ def handle_submission(ack, body, client, view):
     except Exception as e:
         # Handle error
         msg = "There was an error with your submission"
-    finally:
-        # Message the user
+
+    # Message the user
+    try:
         client.chat_postMessage(channel=user, text=msg)
+    except e:
+        logger.exception(f"Failed to post a message {e}")
 ```


### PR DESCRIPTION
This pull request fixes #206 by updating the documents.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
