### PR TITLE
Update install page to avoid favicon downloads

### DIFF
--- a/slack_bolt/oauth/internals.py
+++ b/slack_bolt/oauth/internals.py
@@ -74,6 +74,7 @@ class CallbackResponseBuilder:
 def _build_default_install_page_html(url: str) -> str:
     return f"""<html>
 <head>
+<link rel="icon" href="data:,">
 <style>
 body {{
   padding: 10px 15px;

--- a/tests/adapter_tests_async/test_async_fastapi.py
+++ b/tests/adapter_tests_async/test_async_fastapi.py
@@ -213,5 +213,5 @@ class TestFastAPI:
         response = client.get("/slack/install", allow_redirects=False)
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert response.headers.get("content-length") == "565"
+        assert response.headers.get("content-length") == "597"
         assert "https://slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests_async/test_async_sanic.py
+++ b/tests/adapter_tests_async/test_async_sanic.py
@@ -224,5 +224,5 @@ class TestSanic:
         )
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert response.headers.get("content-length") == "565"
+        assert response.headers.get("content-length") == "597"
         assert "https://slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests_async/test_async_starlette.py
+++ b/tests/adapter_tests_async/test_async_starlette.py
@@ -223,5 +223,5 @@ class TestAsyncStarlette:
         response = client.get("/slack/install", allow_redirects=False)
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert response.headers.get("content-length") == "565"
+        assert response.headers.get("content-length") == "597"
         assert "https://slack.com/oauth/v2/authorize?state=" in response.text


### PR DESCRIPTION
This PR adds the link tag to the install page, which stops the browser from making another call to get favicon.ico, which resets the state cookie. This resolves the issue discussed in https://github.com/slackapi/bolt-python/issues/366

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
