### PR TITLE
Make cookies extraction on AWS Lambda compatible with its format v1.0

### DIFF
--- a/slack_bolt/adapter/aws_lambda/handler.py
+++ b/slack_bolt/adapter/aws_lambda/handler.py
@@ -84,8 +84,10 @@ def to_bolt_request(event) -> BoltRequest:
     body = event.get("body", "")
     if event["isBase64Encoded"]:
         body = base64.b64decode(body).decode("utf-8")
-    multiValueHeaders = event.get("multiValueHeaders", {})
-    cookies: Sequence[str] = multiValueHeaders.get("Cookie", [])
+    cookies: Sequence[str] = event.get("cookies", [])
+    if event.get("requestContext", {}).get("http", {}).get("method") is None: # judging whether payload format version is v1.0 or not
+        multiValueHeaders = event.get("multiValueHeaders", {})
+        cookies = multiValueHeaders.get("Cookie", [])
     headers = event.get("headers", {})
     headers["cookie"] = cookies
     return BoltRequest(

--- a/slack_bolt/adapter/aws_lambda/handler.py
+++ b/slack_bolt/adapter/aws_lambda/handler.py
@@ -84,7 +84,8 @@ def to_bolt_request(event) -> BoltRequest:
     body = event.get("body", "")
     if event["isBase64Encoded"]:
         body = base64.b64decode(body).decode("utf-8")
-    cookies: Sequence[str] = event.get("cookies", [])
+    multiValueHeaders = event.get("multiValueHeaders", {})
+    cookies: Sequence[str] = multiValueHeaders.get("Cookie", [])
     headers = event.get("headers", {})
     headers["cookie"] = cookies
     return BoltRequest(

--- a/slack_bolt/adapter/aws_lambda/handler.py
+++ b/slack_bolt/adapter/aws_lambda/handler.py
@@ -85,7 +85,8 @@ def to_bolt_request(event) -> BoltRequest:
     if event["isBase64Encoded"]:
         body = base64.b64decode(body).decode("utf-8")
     cookies: Sequence[str] = event.get("cookies", [])
-    if event.get("requestContext", {}).get("http", {}).get("method") is None: # judging whether payload format version is v1.0 or not
+    if cookies is None or len(cookies) == 0:
+        # In the case of format v1
         multiValueHeaders = event.get("multiValueHeaders", {})
         cookies = multiValueHeaders.get("Cookie", [])
     headers = event.get("headers", {})


### PR DESCRIPTION
I tried to deploy a slack bolt application on AWS Lambda with SQLAlchemy.
In the process of the verification of oauth redirect, the app could not be installed properly.
I found that the slack request handler could not extract cookie from the lambda event.
So, I modified the to_bolt_request to meet the format of the lambda event.