### PR TITLE
Add section in docs for token rotation

### DIFF
--- a/docs/_advanced/context.md
+++ b/docs/_advanced/context.md
@@ -2,7 +2,7 @@
 title: Adding context
 lang: en
 slug: context
-order: 7
+order: 9
 ---
 
 <div class="section-content">

--- a/docs/_advanced/global_middleware.md
+++ b/docs/_advanced/global_middleware.md
@@ -2,7 +2,7 @@
 title: Global middleware
 lang: en
 slug: global-middleware
-order: 6
+order: 8
 ---
 
 <div class="section-content">

--- a/docs/_advanced/lazy_listener.md
+++ b/docs/_advanced/lazy_listener.md
@@ -2,7 +2,7 @@
 title: Lazy listeners (FaaS)
 lang: en
 slug: lazy-listeners
-order: 9
+order: 10
 ---
 
 <div class="section-content">

--- a/docs/_advanced/listener_middleware.md
+++ b/docs/_advanced/listener_middleware.md
@@ -2,7 +2,7 @@
 title: Listener middleware
 lang: en
 slug: listener-middleware
-order: 5
+order: 7
 ---
 
 <div class="section-content">

--- a/docs/_advanced/token_rotation.md
+++ b/docs/_advanced/token_rotation.md
@@ -1,0 +1,16 @@
+---
+title: Token rotation
+lang: en
+slug: token-rotation
+order: 6
+---
+
+<div class="section-content">
+Supported in Bolt for Python as of [v1.7.0](https://github.com/slackapi/bolt-python/releases/tag/v1.7.0), token rotation provides an extra layer of security for your access tokens and is defined by the [OAuth V2 RFC](https://datatracker.ietf.org/doc/html/rfc6749#section-10.4). 
+
+Instead of an access token representing an existing installation of your Slack app indefinitely, with token rotation enabled, access tokens expire. A refresh token acts as a long-lived way to refresh your access tokens.
+
+Bolt for Python supports and will handle token rotation automatically so long as the [built-in OAuth](https://slack.dev/bolt-python/concepts#authenticating-oauth) functionality is used.
+
+For more information about token rotation, please see the [documentation](https://api.slack.com/authentication/rotation).
+</div>


### PR DESCRIPTION
Add section to documentation that outlines token rotation and links out to corresponding release notes, spec and API documentation.

<img width="887" alt="Screen Shot 2021-07-20 at 7 15 12 PM" src="https://user-images.githubusercontent.com/7788242/126422065-3b4339c8-3526-4bb0-a02e-3fd6e03c7744.png">

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
