### PR TITLE
Fix type hint errors detected by pytype 2021.7.19

### DIFF
--- a/slack_bolt/adapter/aws_lambda/local_lambda_client.py
+++ b/slack_bolt/adapter/aws_lambda/local_lambda_client.py
@@ -14,7 +14,7 @@ class LocalLambdaClient(BaseClient):
 
     def invoke(
         self,
-        FunctionName: str = None,
+        FunctionName: str,
         InvocationType: str = "Event",
         Payload: str = "{}",
     ) -> InvokeResponse:

--- a/slack_bolt/authorization/authorize.py
+++ b/slack_bolt/authorization/authorize.py
@@ -42,7 +42,6 @@ class CallableAuthorize(Authorize):
         self.arg_names = inspect.getfullargspec(func).args
 
     def __call__(
-
         self,
         *,
         context: BoltContext,

--- a/slack_bolt/authorization/authorize.py
+++ b/slack_bolt/authorization/authorize.py
@@ -42,6 +42,7 @@ class CallableAuthorize(Authorize):
         self.arg_names = inspect.getfullargspec(func).args
 
     def __call__(
+
         self,
         *,
         context: BoltContext,

--- a/slack_bolt/middleware/ssl_check/ssl_check.py
+++ b/slack_bolt/middleware/ssl_check/ssl_check.py
@@ -1,4 +1,5 @@
-from typing import Callable
+from logging import Logger
+from typing import Callable, Optional
 
 from slack_bolt.logger import get_bolt_logger
 from slack_bolt.middleware.middleware import Middleware
@@ -7,7 +8,10 @@ from slack_bolt.response import BoltResponse
 
 
 class SslCheck(Middleware):  # type: ignore
-    def __init__(self, verification_token: str = None):
+    verification_token: Optional[str]
+    logger: Logger
+
+    def __init__(self, verification_token: Optional[str] = None):
         """Handles `ssl_check` requests.
         Refer to https://api.slack.com/interactivity/slash-commands for details.
 


### PR DESCRIPTION
This pull request fixes the CI build errors with the latest version of pytype.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
