### PR TITLE
Add Japanese translation of "token rotation" docment

### DIFF
--- a/docs/_advanced/ja_context.md
+++ b/docs/_advanced/ja_context.md
@@ -2,7 +2,7 @@
 title: コンテキストの追加
 lang: ja-jp
 slug: context
-order: 7
+order: 9
 ---
 
 <div class="section-content">

--- a/docs/_advanced/ja_global_middleware.md
+++ b/docs/_advanced/ja_global_middleware.md
@@ -2,7 +2,7 @@
 title: グローバルミドルウェア
 lang: ja-jp
 slug: global-middleware
-order: 6
+order: 8
 ---
 
 <div class="section-content">

--- a/docs/_advanced/ja_lazy_listener.md
+++ b/docs/_advanced/ja_lazy_listener.md
@@ -2,7 +2,7 @@
 title: Lazy リスナー（FaaS）
 lang: ja-jp
 slug: lazy-listeners
-order: 9
+order: 10
 ---
 
 <div class="section-content">

--- a/docs/_advanced/ja_listener_middleware.md
+++ b/docs/_advanced/ja_listener_middleware.md
@@ -2,7 +2,7 @@
 title: リスナーミドルウェア
 lang: ja-jp
 slug: listener-middleware
-order: 5
+order: 7
 ---
 
 <div class="section-content">

--- a/docs/_advanced/ja_token_rotation.md
+++ b/docs/_advanced/ja_token_rotation.md
@@ -1,0 +1,16 @@
+---
+title: トークンのローテーション
+lang: ja-jp
+slug: token-rotation
+order: 6
+---
+
+<div class="section-content">
+Bolt for Python [v1.7.0](https://github.com/slackapi/bolt-python/releases/tag/v1.7.0) より、[OAuth V2 RFC](https://datatracker.ietf.org/doc/html/rfc6749#section-10.4) で規定され、アクセストークンに対するセキュリティを強化する、トークンローテーションを提供しています。
+
+既存の Slack app のアクセストークンが無期限に存在し続けるのに対し、トークンローテーションを有効にすると、アクセストークンは失効します。これに対し、リフレッシュトークンを用いて、長期にわたりアクセストークンの更新行います。
+
+Bolt for Python は[組み込みの OAuth](https://slack.dev/bolt-python/concepts#authenticating-oauth) が使用されている場合、自動的にトークンローテーションを行います。
+
+トークンローテーションについての詳細な情報は、この[ドキュメント](https://api.slack.com/authentication/rotation)をご覧ください。
+</div>

--- a/docs/_advanced/ja_token_rotation.md
+++ b/docs/_advanced/ja_token_rotation.md
@@ -6,11 +6,11 @@ order: 6
 ---
 
 <div class="section-content">
-Bolt for Python [v1.7.0](https://github.com/slackapi/bolt-python/releases/tag/v1.7.0) より、[OAuth V2 RFC](https://datatracker.ietf.org/doc/html/rfc6749#section-10.4) で規定され、アクセストークンに対するセキュリティを強化する、トークンローテーションを提供しています。
+Bolt for Python [v1.7.0](https://github.com/slackapi/bolt-python/releases/tag/v1.7.0) から、アクセストークンのさらなるセキュリティ強化のレイヤーであるトークンローテーションの機能に対応しています。トークンローテーションは [OAuth V2 の RFC](https://datatracker.ietf.org/doc/html/rfc6749#section-10.4) で規定されているものです。
 
-既存の Slack app のアクセストークンが無期限に存在し続けるのに対し、トークンローテーションを有効にすると、アクセストークンは失効します。これに対し、リフレッシュトークンを用いて、長期にわたりアクセストークンの更新行います。
+既存の Slack アプリではアクセストークンが無期限に存在し続けるのに対して、トークンローテーションを有効にしたアプリではアクセストークンが失効するようになります。リフレッシュトークンを利用して、アクセストークンを長期間にわたって更新し続けることができます。
 
-Bolt for Python は[組み込みの OAuth](https://slack.dev/bolt-python/concepts#authenticating-oauth) が使用されている場合、自動的にトークンローテーションを行います。
+[Bolt for Python の組み込みの OAuth 機能](https://slack.dev/bolt-python/concepts#authenticating-oauth) を使用していれば、Bolt for Python が自動的にトークンローテーションの処理をハンドリングします。
 
-トークンローテーションについての詳細な情報は、この[ドキュメント](https://api.slack.com/authentication/rotation)をご覧ください。
+トークンローテーションに関する詳細は [API ドキュメント](https://api.slack.com/authentication/rotation)を参照してください。
 </div>


### PR DESCRIPTION
(Describe the goal of this PR. Mention any related Issue numbers)

Related to #414 
I added Japanese translation of `Token rotation` document introduced in #413.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
