### PR TITLE
Update Sanic adapter and its tests to be compatible with sanic v21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ test_dependencies = [
     "aiohttp>=3,<4",  # for async
     "Flask-Sockets>=0.2,<1",
     "Werkzeug<2",  # TODO: support Flask 2.x
-    "black==21.5b1",
+    "black==21.7b0",
 ]
 
 setuptools.setup(
@@ -41,7 +41,7 @@ setuptools.setup(
     ),
     include_package_data=True,  # MANIFEST.in
     install_requires=[
-        "slack_sdk>=3.8.0,<4",
+        "slack_sdk>=3.9.0rc1,<4",  # TODO: Update once v3.9.0 is released
     ],
     setup_requires=["pytest-runner==5.2"],
     tests_require=test_dependencies,
@@ -52,7 +52,7 @@ setuptools.setup(
             # async features heavily depends on aiohttp
             "aiohttp>=3,<4",
             # Socket Mode 3rd party implementation
-            "websockets>=8,<9",
+            "websockets>=8,<10",
         ],
         # pip install -e ".[adapter]"
         # NOTE: any of async ones requires pip install -e ".[async]" too
@@ -72,7 +72,8 @@ setuptools.setup(
             "Flask>=1,<2",
             "Werkzeug<2",  # TODO: support Flask 2.x
             "pyramid>=1,<2",
-            "sanic>=20,<21",
+            "sanic>=21,<22",
+            "sanic-testing>=0.6",
             "starlette>=0.13,<1",
             "requests>=2,<3",  # For starlette's TestClient
             "tornado>=6,<7",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import sys
 
 import setuptools
 
@@ -72,8 +73,8 @@ setuptools.setup(
             "Flask>=1,<2",
             "Werkzeug<2",  # TODO: support Flask 2.x
             "pyramid>=1,<2",
-            "sanic>=21,<22",
-            "sanic-testing>=0.6",
+            "sanic>=21,<22" if sys.version_info.minor > 6 else "sanic>=20,<21",
+            "sanic-testing>=0.6" if sys.version_info.minor > 6 else "",
             "starlette>=0.13,<1",
             "requests>=2,<3",  # For starlette's TestClient
             "tornado>=6,<7",

--- a/slack_bolt/adapter/sanic/async_handler.py
+++ b/slack_bolt/adapter/sanic/async_handler.py
@@ -31,7 +31,8 @@ def to_sanic_response(bolt_resp: BoltResponse) -> HTTPResponse:
                 resp.cookies[name]["expires"] = expire
             resp.cookies[name]["path"] = c.get("path")
             resp.cookies[name]["domain"] = c.get("domain")
-            resp.cookies[name]["max-age"] = c.get("max-age")
+            if c.get("max-age") is not None and len(c.get("max-age")) > 0:
+                resp.cookies[name]["max-age"] = int(c.get("max-age"))
             resp.cookies[name]["secure"] = True
             resp.cookies[name]["httponly"] = True
     return resp

--- a/tests/adapter_tests_async/test_async_sanic.py
+++ b/tests/adapter_tests_async/test_async_sanic.py
@@ -32,7 +32,7 @@ class TestSanic:
 
     @staticmethod
     def unique_sanic_app_name() -> str:
-        return f"awesome-slack-app-{time()}"
+        return f"awesome-slack-app-{str(time()).replace('.', '-')}"
 
     @pytest.fixture
     def event_loop(self):
@@ -107,7 +107,7 @@ class TestSanic:
 
         _, response = await api.asgi_client.post(
             url="/slack/events",
-            data=body,
+            content=body,
             headers=self.build_headers(timestamp, body),
         )
         assert response.status_code == 200
@@ -151,7 +151,7 @@ class TestSanic:
 
         _, response = await api.asgi_client.post(
             url="/slack/events",
-            data=body,
+            content=body,
             headers=self.build_headers(timestamp, body),
         )
         assert response.status_code == 200
@@ -195,7 +195,7 @@ class TestSanic:
 
         _, response = await api.asgi_client.post(
             url="/slack/events",
-            data=body,
+            content=body,
             headers=self.build_headers(timestamp, body),
         )
         assert response.status_code == 200
@@ -224,5 +224,9 @@ class TestSanic:
         )
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert response.headers.get("content-length") == "597"
+
+        # NOTE: Although sanic-testing 0.6 does not have this value,
+        # Sanic apps properly generate the content-length header
+        # assert response.headers.get("content-length") == "597"
+
         assert "https://slack.com/oauth/v2/authorize?state=" in response.text


### PR DESCRIPTION
This pull request upgrades Sanic version for testing and fixes a few issues with the new major version.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
