### PR TITLE
Fix #409 Custom token rotation expiration time does not work if installation_store is passed at top level

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -270,6 +270,9 @@ class App:
             )
             if self._authorize is None:
                 self._authorize = self._oauth_flow.settings.authorize
+            self._authorize.token_rotation_expiration_minutes = (
+                oauth_settings.token_rotation_expiration_minutes
+            )
 
         if (
             self._installation_store is not None or self._authorize is not None

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -288,6 +288,9 @@ class AsyncApp:
             )
             if self._async_authorize is None:
                 self._async_authorize = self._async_oauth_flow.settings.authorize
+            self._async_authorize.token_rotation_expiration_minutes = (
+                oauth_settings.token_rotation_expiration_minutes
+            )
 
         if (
             self._async_installation_store is not None


### PR DESCRIPTION
This pull request fixes #409. The initialization for top level `installation_store` is a bit tricky ... (we may want to deprecate it in the future) but this works for sure.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
