### PR TITLE
Fix a token rotation bug where a bot token is not refreshed if a user token does not exist

### DIFF
--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -189,7 +189,10 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
                         installation.user_token,
                     )
 
-                    if installation.user_refresh_token is not None:
+                    if (
+                        installation.user_refresh_token is not None
+                        or installation.bot_refresh_token is not None
+                    ):
                         if self.token_rotator is None:
                             raise BoltError(self._config_error_message)
                         refreshed = await self.token_rotator.perform_token_rotation(

--- a/slack_bolt/authorization/authorize.py
+++ b/slack_bolt/authorization/authorize.py
@@ -186,7 +186,10 @@ class InstallationStoreAuthorize(Authorize):
                         installation.bot_token,
                         installation.user_token,
                     )
-                    if installation.user_refresh_token is not None:
+                    if (
+                        installation.user_refresh_token is not None
+                        or installation.bot_refresh_token is not None
+                    ):
                         if self.token_rotator is None:
                             raise BoltError(self._config_error_message)
                         refreshed = self.token_rotator.perform_token_rotation(


### PR DESCRIPTION
This pull request fixes a token rotation feature bug where a bot token cannot be refreshed if a user token does not exist in the same installation. This bug can affect all token-rotation enabled apps using the built-in `InstallationStoreAuthorize`. I overlooked this bug as I did tests only with installations that have both a bot and a user token 🤦 

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
