### PR TITLE
Added basic lazy lambda example setup and deploy instructions

### DIFF
--- a/examples/aws_lambda/.gitignore
+++ b/examples/aws_lambda/.gitignore
@@ -1,2 +1,2 @@
-vendor/
+slack-bolt/
 .env

--- a/examples/aws_lambda/README.md
+++ b/examples/aws_lambda/README.md
@@ -1,0 +1,70 @@
+# Lazy Lambda Listener Example Bolt App
+
+1. You need an AWS account and your AWS credentials set up on your machine.
+2. Make sure you have an AWS IAM Role defined with the needed permissions for
+   your Lambda function powering your Slack app:
+  - Head to the AWS IAM section of AWS Console
+  - Click Roles from the menu
+  - Click the Create Role button
+  - Under "Select type of trusted entity", choose "AWS service"
+  - Under "Choose a use case", select "Common use cases: Lambda"
+  - Click "Next: Permissions"
+  - Under "Attach permission policies", enter "lambda" in the Filter input
+  - Check the "AWSLambdaBasicExecutionRole" and "AWSLambdaExecute" policies
+  - Click "Next: tags"
+  - Click "Next: review"
+  - Enter `bolt_python_lambda_invocation` as the Role name. You can change this
+      if you want, but then make sure to update the role name in
+      `lazy_aws_lambda_config.yaml`
+  - Optionally enter a description for the role, such as "Bolt Python basic
+      role"
+3. Ensure you have created an app on api.slack.com/apps as per the [Getting
+   Started Guide](https://slack.dev/bolt-python/tutorial/getting-started).
+   Ensure you have installed it to a workspace.
+4. Ensure you have exported your Slack Bot Token and Slack Signing Secret for your
+   apps as the environment variables `SLACK_BOT_TOKEN` and
+   `SLACK_SIGNING_SECRET`, respectively, as per the [Getting
+   Started Guide](https://slack.dev/bolt-python/tutorial/getting-started).
+5. You may want to create a dedicated virtual environment for this example app, as
+   per the "Setting up your project" section of the [Getting
+   Started Guide](https://slack.dev/bolt-python/tutorial/getting-started).
+6. Let's deploy the Lambda! Run `./deploy_lazy.sh`. By default it deploys to the
+   us-east-1 region in AWS - you can change this at the top of `lazy_aws_lambda_config.yaml` if you wish.
+7. Load up AWS Lambda inside the AWS Console - make sure you are in the  correct
+   region that you deployed your app to. You should see a `bolt_py_function`
+   Lambda there.
+8. While your Lambda exists, it is not accessible to the internet, so Slack
+   cannot send events happening in your Slack workspace to your Lambda. Let's
+   fix that by adding an AWS API Gateway in front of your Lambda so that your
+   Lambda can accept HTTP requests:
+  - Click on your `bolt_py_function` Lambda
+  - In the Function Overview, on the left side, click "+ Add Trigger"
+  - Select API Gateway from the trigger list
+  - Make sure "Create an API" is selected in the dropdown, and choose "HTTP API"
+      as the API Type
+  - Under Security, select "Open"
+  - Click "Add"
+9. Congrats! Your Slack app is now accessible to the public. On the left side of
+   your `bolt_py_function` Function Overview you should see a purple API Gateway
+   icon. Click it.
+10. Click Details to expand the details section.
+11. Copy the API Endpoint - this is the URL your Lambda function is accessible
+    at publicly.
+12. We will now inform Slack that this example app can accept Slash Commands.
+  - Back on api.slack.com/apps, select your app and choose Slash Commands from the left menu.
+  - Click Create New Command
+  - By default, the `lazy_aws_lambda.py` function has logic for a
+      `/hello-bolt-python-lambda` command. Enter `/hello-bolt-python-lambda` as
+      the Command.
+  - Under Request URL, paste in the previously-copied API Endpoint from API
+      Gateway.
+  - Click Save
+13. Test it out! Back in your Slack workspace, try typing
+    `/hello-bolt-python-lambda hello`.
+14. If you have issues, here are some debugging options:
+  - Check the Monitor tab under your Lambda. Did the Lambda get invoked? Did it
+      respond with an error? Investigate the graphs to see how your Lambda is
+      behaving.
+  - From this same Monitor tab, you can also click "View Logs in CloudWatch" to
+      see the execution logs for your Lambda. This can be helpful to see what
+      errors are being raised.

--- a/examples/aws_lambda/deploy_lazy.sh
+++ b/examples/aws_lambda/deploy_lazy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-rm -rf vendor && mkdir -p vendor/slack_bolt && cp -pr ../../slack_bolt/* vendor/slack_bolt/
+rm -rf slack_bolt && mkdir slack_bolt && cp -pr ../../slack_bolt/* slack_bolt/
 pip install python-lambda -U
 lambda deploy \
   --config-file lazy_aws_lambda_config.yaml \

--- a/examples/aws_lambda/lazy_aws_lambda_config.yaml
+++ b/examples/aws_lambda/lazy_aws_lambda_config.yaml
@@ -38,4 +38,4 @@ environment_variables:
 
 # Build options
 build:
-  source_directories: vendor # a comma delimited list of directories in your project root that contains source to package.
+  source_directories: slack_bolt # a comma delimited list of directories in your project root that contains source to package.


### PR DESCRIPTION
Also fixed vendor module import issues; based on the [Create python package with dependencies AWS docs for Lambda](https://docs.aws.amazon.com/lambda/latest/dg/python-package-create.html#python-package-create-with-dependency), any dependencies need to exist in the root of the package. The changes in this PR are the changes I needed to incorporate to help me run the lazy example. I also tried to document my setup journey in a README in this directory.

This PR is based on trying to help out with #440.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
