### PR TITLE
Fix cookie extraction during OAuth for REST based AWS API GW + Lambda app

### DIFF
--- a/slack_bolt/adapter/aws_lambda/handler.py
+++ b/slack_bolt/adapter/aws_lambda/handler.py
@@ -75,12 +75,6 @@ class SlackRequestHandler:
 
 
 def to_bolt_request(event) -> BoltRequest:
-    """Note that this handler supports only the payload format 2.0.
-    This means you can use this with HTTP API while REST API is not supported.
-
-    Read https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
-    for more details.
-    """
     body = event.get("body", "")
     if event["isBase64Encoded"]:
         body = base64.b64decode(body).decode("utf-8")
@@ -88,7 +82,10 @@ def to_bolt_request(event) -> BoltRequest:
     if cookies is None or len(cookies) == 0:
         # In the case of format v1
         multiValueHeaders = event.get("multiValueHeaders", {})
-        cookies = multiValueHeaders.get("Cookie", [])
+        cookies = multiValueHeaders.get("cookie", [])
+        if len(cookies) == 0:
+            # Try using uppercase
+            cookies = multiValueHeaders.get("Cookie", [])
     headers = event.get("headers", {})
     headers["cookie"] = cookies
     return BoltRequest(


### PR DESCRIPTION
### Summary:
This pull request is related to #379. 

I too deployed a Bolt-python app to AWS Lambda, integrated with REST (format v1.0) based API GW. In the process of the verification of oauth redirect, the app could not be installed properly. Taking a look at the CloudWatch logs I could see the multivalueheader in the request had the key "cookie" instead of "Cookie" as is expected by "to_bolt_request".

```python
   if cookies is None or len(cookies) == 0:
        # In the case of format v1
        multiValueHeaders = event.get("multiValueHeaders", {})
        cookies = multiValueHeaders.get("Cookie", [])
```
After modifying the following line to account for lower case "cookie", everything worked fine:
```python
     cookies = multiValueHeaders.get("cookie", [])
```
I think the comment about `to_bolt_request` not supporting REST API can now be removed because I tried and it works


### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
