### PR TITLE
Allow a custom Executor in App

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -175,7 +175,8 @@ class App:
             oauth_settings: The settings related to Slack app installation flow (OAuth flow)
             oauth_flow: Instantiated `slack_bolt.oauth.OAuthFlow`. This is always prioritized over oauth_settings.
             verification_token: Deprecated verification mechanism. This can used only for ssl_check requests.
-            listener_executor: Optional executor to run background tasks. If absent, a ThreadPoolExecutor will be used.
+            listener_executor: Optional executor to run background tasks. If absent, a `ThreadPoolExecutor` will
+                be used.
         """
         signing_secret = signing_secret or os.environ.get("SLACK_SIGNING_SECRET")
         token = token or os.environ.get("SLACK_BOT_TOKEN")

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -114,6 +114,7 @@ class App:
         oauth_flow: Optional[OAuthFlow] = None,
         # No need to set (the value is used only in response to ssl_check requests)
         verification_token: Optional[str] = None,
+        # Set this one only when you want to customize the executor
         listener_executor: Optional[Executor] = None,
     ):
         """Bolt App that provides functionalities to register middleware/listeners.
@@ -175,7 +176,7 @@ class App:
             oauth_settings: The settings related to Slack app installation flow (OAuth flow)
             oauth_flow: Instantiated `slack_bolt.oauth.OAuthFlow`. This is always prioritized over oauth_settings.
             verification_token: Deprecated verification mechanism. This can used only for ssl_check requests.
-            listener_executor: Optional executor to run background tasks. If absent, a `ThreadPoolExecutor` will
+            listener_executor: Custom executor to run background tasks. If absent, the default `ThreadPoolExecutor` will
                 be used.
         """
         signing_secret = signing_secret or os.environ.get("SLACK_SIGNING_SECRET")

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import time
+from concurrent.futures import Executor
 from concurrent.futures.thread import ThreadPoolExecutor
 from http.server import SimpleHTTPRequestHandler, HTTPServer
 from typing import List, Union, Pattern, Callable, Dict, Optional, Sequence, Any
@@ -113,6 +114,7 @@ class App:
         oauth_flow: Optional[OAuthFlow] = None,
         # No need to set (the value is used only in response to ssl_check requests)
         verification_token: Optional[str] = None,
+        listener_executor: Optional[Executor] = None,
     ):
         """Bolt App that provides functionalities to register middleware/listeners.
 
@@ -173,6 +175,7 @@ class App:
             oauth_settings: The settings related to Slack app installation flow (OAuth flow)
             oauth_flow: Instantiated `slack_bolt.oauth.OAuthFlow`. This is always prioritized over oauth_settings.
             verification_token: Deprecated verification mechanism. This can used only for ssl_check requests.
+            listener_executor: Optional executor to run background tasks. If absent, a ThreadPoolExecutor will be used.
         """
         signing_secret = signing_secret or os.environ.get("SLACK_SIGNING_SECRET")
         token = token or os.environ.get("SLACK_BOT_TOKEN")
@@ -302,7 +305,9 @@ class App:
         self._middleware_list: List[Union[Callable, Middleware]] = []
         self._listeners: List[Listener] = []
 
-        listener_executor = ThreadPoolExecutor(max_workers=5)
+        if listener_executor is None:
+            listener_executor = ThreadPoolExecutor(max_workers=5)
+
         self._process_before_response = process_before_response
         self._listener_runner = ThreadListenerRunner(
             logger=self._framework_logger,

--- a/slack_bolt/lazy_listener/thread_runner.py
+++ b/slack_bolt/lazy_listener/thread_runner.py
@@ -1,4 +1,4 @@
-from concurrent.futures.thread import ThreadPoolExecutor
+from concurrent.futures import Executor
 from logging import Logger
 from typing import Callable
 
@@ -13,7 +13,7 @@ class ThreadLazyListenerRunner(LazyListenerRunner):
     def __init__(
         self,
         logger: Logger,
-        executor: ThreadPoolExecutor,
+        executor: Executor,
     ):
         self.logger = logger
         self.executor = executor

--- a/slack_bolt/listener/thread_runner.py
+++ b/slack_bolt/listener/thread_runner.py
@@ -1,5 +1,5 @@
 import time
-from concurrent.futures.thread import ThreadPoolExecutor
+from concurrent.futures import Executor
 from logging import Logger
 from typing import Optional, Callable
 
@@ -22,7 +22,7 @@ class ThreadListenerRunner:
     process_before_response: bool
     listener_error_handler: ListenerErrorHandler
     listener_completion_handler: ListenerCompletionHandler
-    listener_executor: ThreadPoolExecutor
+    listener_executor: Executor
     lazy_listener_runner: LazyListenerRunner
 
     def __init__(
@@ -31,7 +31,7 @@ class ThreadListenerRunner:
         process_before_response: bool,
         listener_error_handler: ListenerErrorHandler,
         listener_completion_handler: ListenerCompletionHandler,
-        listener_executor: ThreadPoolExecutor,
+        listener_executor: Executor,
         lazy_listener_runner: LazyListenerRunner,
     ):
         self.logger = logger

--- a/tests/scenario_tests/test_app.py
+++ b/tests/scenario_tests/test_app.py
@@ -1,3 +1,5 @@
+from concurrent.futures import Executor
+
 import pytest
 from slack_sdk import WebClient
 from slack_sdk.oauth.installation_store import FileInstallationStore
@@ -55,6 +57,22 @@ class TestApp:
         app = App(signing_secret="valid", client=self.web_client)
         with pytest.raises(BoltError):
             app.action({"type": "invalid_type", "action_id": "a"})(self.simple_listener)
+
+    def test_listener_executor(self):
+        class TestExecutor(Executor):
+            """A stupid executor that does nothing."""
+
+            pass
+
+        executor = TestExecutor()
+        app = App(
+            signing_secret="valid",
+            client=self.web_client,
+            listener_executor=executor,
+        )
+
+        assert app.listener_runner.listener_executor == executor
+        assert app.listener_runner.lazy_listener_runner.executor == executor
 
     # --------------------------
     # single team auth

--- a/tests/scenario_tests/test_app.py
+++ b/tests/scenario_tests/test_app.py
@@ -60,7 +60,7 @@ class TestApp:
 
     def test_listener_executor(self):
         class TestExecutor(Executor):
-            """A stupid executor that does nothing."""
+            """A executor that does nothing for testing"""
 
             pass
 


### PR DESCRIPTION
This pull request adds a `listener_executor` keyword parameter to `App.__init__`, so that the executor for running background listener functions can be customized by the user. It also weakens the type requirement for executors to just `concurrent.futures.Executor`, the abstract base class of executors.

Fixes #452.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
