### PR TITLE
Fix #454 Add oauth_settings.state_validation_enabled to customize the OAuth flow

### DIFF
--- a/slack_bolt/oauth/async_oauth_settings.py
+++ b/slack_bolt/oauth/async_oauth_settings.py
@@ -44,6 +44,7 @@ class AsyncOAuthSettings:
     token_rotation_expiration_minutes: int
     authorize: AsyncAuthorize
     # state parameter related configurations
+    state_validation_enabled: bool
     state_store: AsyncOAuthStateStore
     state_cookie_name: str
     state_expiration_seconds: int
@@ -76,6 +77,7 @@ class AsyncOAuthSettings:
         installation_store_bot_only: bool = False,
         token_rotation_expiration_minutes: int = 120,
         # state parameter related configurations
+        state_validation_enabled: bool = True,
         state_store: Optional[AsyncOAuthStateStore] = None,
         state_cookie_name: str = OAuthStateUtils.default_cookie_name,
         state_expiration_seconds: int = OAuthStateUtils.default_expiration_seconds,
@@ -100,6 +102,7 @@ class AsyncOAuthSettings:
             installation_store: Specify the instance of `InstallationStore` (Default: `FileInstallationStore`)
             installation_store_bot_only: Use `InstallationStore#find_bot()` if True (Default: False)
             token_rotation_expiration_minutes: Minutes before refreshing tokens (Default: 2 hours)
+            state_validation_enabled: Set False if your OAuth flow omits the state parameter validation (Default: True)
             state_store: Specify the instance of `InstallationStore` (Default: `FileOAuthStateStore`)
             state_cookie_name: The cookie name that is set for installers' browser. (Default: "slack-app-oauth-state")
             state_expiration_seconds: The seconds that the state value is alive (Default: 600 seconds)
@@ -153,6 +156,7 @@ class AsyncOAuthSettings:
             bot_only=self.installation_store_bot_only,
         )
         # state parameter related configurations
+        self.state_validation_enabled = state_validation_enabled
         self.state_store = state_store or FileOAuthStateStore(
             expiration_seconds=state_expiration_seconds,
             client_id=client_id,

--- a/slack_bolt/oauth/oauth_flow.py
+++ b/slack_bolt/oauth/oauth_flow.py
@@ -158,30 +158,33 @@ class OAuthFlow:
     # -----------------------------
 
     def handle_installation(self, request: BoltRequest) -> BoltResponse:
-        state = self.issue_new_state(request)
-        url = self.build_authorize_url(state, request)
-        set_cookie_value = self.settings.state_utils.build_set_cookie_for_new_state(
-            state
-        )
+        set_cookie_value: Optional[str] = None
+        url = self.build_authorize_url("", request)
+        if self.settings.state_validation_enabled is True:
+            state = self.issue_new_state(request)
+            url = self.build_authorize_url(state, request)
+            set_cookie_value = self.settings.state_utils.build_set_cookie_for_new_state(
+                state
+            )
+
         if self.settings.install_page_rendering_enabled:
             html = self.build_install_page_html(url, request)
             return BoltResponse(
                 status=200,
                 body=html,
-                headers={
-                    "Content-Type": "text/html; charset=utf-8",
-                    "Set-Cookie": [set_cookie_value],
-                },
+                headers=self.append_set_cookie_headers(
+                    {"Content-Type": "text/html; charset=utf-8"},
+                    set_cookie_value,
+                ),
             )
         else:
             return BoltResponse(
                 status=302,
                 body="",
-                headers={
-                    "Content-Type": "text/html; charset=utf-8",
-                    "Location": url,
-                    "Set-Cookie": [set_cookie_value],
-                },
+                headers=self.append_set_cookie_headers(
+                    {"Content-Type": "text/html; charset=utf-8", "Location": url},
+                    set_cookie_value,
+                ),
             )
 
     # ----------------------
@@ -195,6 +198,11 @@ class OAuthFlow:
 
     def build_install_page_html(self, url: str, request: BoltRequest) -> str:
         return _build_default_install_page_html(url)
+
+    def append_set_cookie_headers(self, headers: dict, set_cookie_value: Optional[str]):
+        if set_cookie_value is not None:
+            headers["Set-Cookie"] = [set_cookie_value]
+        return headers
 
     # -----------------------------
     # Callback
@@ -216,29 +224,30 @@ class OAuthFlow:
             )
 
         # state parameter verification
-        state = request.query.get("state", [None])[0]
-        if not self.settings.state_utils.is_valid_browser(state, request.headers):
-            return self.failure_handler(
-                FailureArgs(
-                    request=request,
-                    reason="invalid_browser",
-                    suggested_status_code=400,
-                    settings=self.settings,
-                    default=self.default_callback_options,
+        if self.settings.state_validation_enabled is True:
+            state = request.query.get("state", [None])[0]
+            if not self.settings.state_utils.is_valid_browser(state, request.headers):
+                return self.failure_handler(
+                    FailureArgs(
+                        request=request,
+                        reason="invalid_browser",
+                        suggested_status_code=400,
+                        settings=self.settings,
+                        default=self.default_callback_options,
+                    )
                 )
-            )
 
-        valid_state_consumed = self.settings.state_store.consume(state)
-        if not valid_state_consumed:
-            return self.failure_handler(
-                FailureArgs(
-                    request=request,
-                    reason="invalid_state",
-                    suggested_status_code=401,
-                    settings=self.settings,
-                    default=self.default_callback_options,
+            valid_state_consumed = self.settings.state_store.consume(state)
+            if not valid_state_consumed:
+                return self.failure_handler(
+                    FailureArgs(
+                        request=request,
+                        reason="invalid_state",
+                        suggested_status_code=401,
+                        settings=self.settings,
+                        default=self.default_callback_options,
+                    )
                 )
-            )
 
         # run installation
         code = request.query.get("code", [None])[0]

--- a/slack_bolt/oauth/oauth_settings.py
+++ b/slack_bolt/oauth/oauth_settings.py
@@ -39,6 +39,7 @@ class OAuthSettings:
     token_rotation_expiration_minutes: int
     authorize: Authorize
     # state parameter related configurations
+    state_validation_enabled: bool
     state_store: OAuthStateStore
     state_cookie_name: str
     state_expiration_seconds: int
@@ -71,6 +72,7 @@ class OAuthSettings:
         installation_store_bot_only: bool = False,
         token_rotation_expiration_minutes: int = 120,
         # state parameter related configurations
+        state_validation_enabled: bool = True,
         state_store: Optional[OAuthStateStore] = None,
         state_cookie_name: str = OAuthStateUtils.default_cookie_name,
         state_expiration_seconds: int = OAuthStateUtils.default_expiration_seconds,
@@ -95,6 +97,7 @@ class OAuthSettings:
             installation_store: Specify the instance of `InstallationStore` (Default: `FileInstallationStore`)
             installation_store_bot_only: Use `InstallationStore#find_bot()` if True (Default: False)
             token_rotation_expiration_minutes: Minutes before refreshing tokens (Default: 2 hours)
+            state_validation_enabled: Set False if your OAuth flow omits the state parameter validation (Default: True)
             state_store: Specify the instance of `InstallationStore` (Default: `FileOAuthStateStore`)
             state_cookie_name: The cookie name that is set for installers' browser. (Default: "slack-app-oauth-state")
             state_expiration_seconds: The seconds that the state value is alive (Default: 600 seconds)
@@ -147,6 +150,7 @@ class OAuthSettings:
             bot_only=self.installation_store_bot_only,
         )
         # state parameter related configurations
+        self.state_validation_enabled = state_validation_enabled
         self.state_store = state_store or FileOAuthStateStore(
             expiration_seconds=state_expiration_seconds,
             client_id=client_id,

--- a/tests/slack_bolt/oauth/test_oauth_flow.py
+++ b/tests/slack_bolt/oauth/test_oauth_flow.py
@@ -56,10 +56,11 @@ class TestOAuthFlow:
         resp = oauth_flow.handle_installation(req)
         assert resp.status == 200
         assert resp.headers.get("content-type") == ["text/html; charset=utf-8"]
+        assert resp.headers.get("set-cookie") is not None
         assert "https://slack.com/oauth/v2/authorize?state=" in resp.body
 
     # https://github.com/slackapi/bolt-python/issues/183
-    # For direct install URL suppport
+    # For direct install URL support
     def test_handle_installation_no_rendering(self):
         oauth_flow = OAuthFlow(
             settings=OAuthSettings(
@@ -77,6 +78,25 @@ class TestOAuthFlow:
         assert resp.status == 302
         location_header = resp.headers.get("location")[0]
         assert "https://slack.com/oauth/v2/authorize?state=" in location_header
+        assert resp.headers.get("set-cookie") is not None
+
+    def test_handle_installation_no_state_validation(self):
+        oauth_flow = OAuthFlow(
+            settings=OAuthSettings(
+                client_id="111.222",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+                user_scopes=["search:read"],
+                installation_store=FileInstallationStore(),
+                install_page_rendering_enabled=False,  # disabled
+                state_validation_enabled=False,  # disabled
+                state_store=None,
+            )
+        )
+        req = BoltRequest(body="")
+        resp = oauth_flow.handle_installation(req)
+        assert resp.status == 302
+        assert resp.headers.get("set-cookie") is None
 
     def test_scopes_as_str(self):
         settings = OAuthSettings(
@@ -159,6 +179,27 @@ class TestOAuthFlow:
         )
         resp = oauth_flow.handle_callback(req)
         assert resp.status == 400
+
+    def test_handle_callback_no_state_validation(self):
+        oauth_flow = OAuthFlow(
+            client=WebClient(base_url=self.mock_api_server_base_url),
+            settings=OAuthSettings(
+                client_id="111.222",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+                installation_store=FileInstallationStore(),
+                state_validation_enabled=False,  # disabled
+                state_store=None,
+            ),
+        )
+        state = oauth_flow.issue_new_state(None)
+        req = BoltRequest(
+            body="",
+            query=f"code=foo&state=invalid",
+            headers={"cookie": [f"{oauth_flow.settings.state_cookie_name}={state}"]},
+        )
+        resp = oauth_flow.handle_callback(req)
+        assert resp.status == 200
 
     def test_handle_callback_using_options(self):
         def success(args: SuccessArgs) -> BoltResponse:


### PR DESCRIPTION
This pull request resolves #454 by introducing a new option to `OAuthSettings` and `AsyncOAuthSettings`. Refer to the issue to learn why we are going to add this.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
