### PR TITLE
Fix #459 Invalid type hints in App / AsyncApp

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -684,7 +684,7 @@ class App:
 
     def error(
         self, func: Callable[..., Optional[BoltResponse]]
-    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[BoltResponse]]:
         """Updates the global error handler. This method can be used as either a decorator or a method.
 
             # Use this method as a decorator

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -1281,7 +1281,7 @@ class App:
         matchers: Optional[Sequence[Callable[..., bool]]],
         middleware: Optional[Sequence[Union[Callable, Middleware]]],
         auto_acknowledgement: bool = False,
-    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
+    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         value_to_return = None
         if not isinstance(functions, list):
             functions = list(functions)

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -684,7 +684,7 @@ class App:
 
     def error(
         self, func: Callable[..., Optional[BoltResponse]]
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Updates the global error handler. This method can be used as either a decorator or a method.
 
             # Use this method as a decorator
@@ -722,7 +722,7 @@ class App:
         ],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new event listener. This method can be used as either a decorator or a method.
 
             # Use this method as a decorator
@@ -763,7 +763,7 @@ class App:
         keyword: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new message event listener. This method can be used as either a decorator or a method.
         Check the `App#event` method's docstring for details.
 
@@ -811,7 +811,7 @@ class App:
         command: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new slash command listener.
         This method can be used as either a decorator or a method.
 
@@ -854,7 +854,7 @@ class App:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new shortcut listener.
         This method can be used as either a decorator or a method.
 
@@ -900,7 +900,7 @@ class App:
         callback_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new global shortcut listener."""
 
         def __call__(*args, **kwargs):
@@ -917,7 +917,7 @@ class App:
         callback_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new message shortcut listener."""
 
         def __call__(*args, **kwargs):
@@ -937,7 +937,7 @@ class App:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new action listener. This method can be used as either a decorator or a method.
 
             # Use this method as a decorator
@@ -976,7 +976,7 @@ class App:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `block_actions` action listener.
         Refer to https://api.slack.com/reference/interaction-payloads/block-actions for details.
         """
@@ -995,7 +995,7 @@ class App:
         callback_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `interactive_message` action listener.
         Refer to https://api.slack.com/legacy/message-buttons for details."""
 
@@ -1013,7 +1013,7 @@ class App:
         callback_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `dialog_submission` listener.
         Refer to https://api.slack.com/dialogs for details."""
 
@@ -1031,7 +1031,7 @@ class App:
         callback_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `dialog_cancellation` listener.
         Refer to https://api.slack.com/dialogs for details."""
 
@@ -1052,7 +1052,7 @@ class App:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `view_submission`/`view_closed` event listener.
         This method can be used as either a decorator or a method.
 
@@ -1102,7 +1102,7 @@ class App:
         constraints: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `view_submission` listener.
         Refer to https://api.slack.com/reference/interaction-payloads/views#view_submission for details."""
 
@@ -1120,7 +1120,7 @@ class App:
         constraints: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `view_closed` listener.
         Refer to https://api.slack.com/reference/interaction-payloads/views#view_closed for details."""
 
@@ -1141,7 +1141,7 @@ class App:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new options listener.
         This method can be used as either a decorator or a method.
 
@@ -1191,7 +1191,7 @@ class App:
         action_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `block_suggestion` listener."""
 
         def __call__(*args, **kwargs):
@@ -1208,7 +1208,7 @@ class App:
         callback_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `dialog_suggestion` listener.
         Refer to https://api.slack.com/dialogs for details."""
 
@@ -1281,7 +1281,7 @@ class App:
         matchers: Optional[Sequence[Callable[..., bool]]],
         middleware: Optional[Sequence[Union[Callable, Middleware]]],
         auto_acknowledgement: bool = False,
-    ) -> Optional[Callable[..., Optional[BoltResponse]]]:
+    ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         value_to_return = None
         if not isinstance(functions, list):
             functions = list(functions)

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -1333,7 +1333,7 @@ class AsyncApp:
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]],
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]],
         auto_acknowledgement: bool = False,
-    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
+    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         value_to_return = None
         if not isinstance(functions, list):
             functions = list(functions)

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -770,7 +770,7 @@ class AsyncApp:
         ],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new event listener. This method can be used as either a decorator or a method.
 
             # Use this method as a decorator
@@ -811,7 +811,7 @@ class AsyncApp:
         keyword: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new message event listener. This method can be used as either a decorator or a method.
         Check the `App#event` method's docstring for details.
 
@@ -861,7 +861,7 @@ class AsyncApp:
         command: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new slash command listener.
         This method can be used as either a decorator or a method.
 
@@ -904,7 +904,7 @@ class AsyncApp:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new shortcut listener.
         This method can be used as either a decorator or a method.
 
@@ -950,7 +950,7 @@ class AsyncApp:
         callback_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new global shortcut listener."""
 
         def __call__(*args, **kwargs):
@@ -967,7 +967,7 @@ class AsyncApp:
         callback_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new message shortcut listener."""
 
         def __call__(*args, **kwargs):
@@ -987,7 +987,7 @@ class AsyncApp:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new action listener. This method can be used as either a decorator or a method.
 
             # Use this method as a decorator
@@ -1026,7 +1026,7 @@ class AsyncApp:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `block_actions` action listener.
         Refer to https://api.slack.com/reference/interaction-payloads/block-actions for details.
         """
@@ -1045,7 +1045,7 @@ class AsyncApp:
         callback_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `interactive_message` action listener.
         Refer to https://api.slack.com/legacy/message-buttons for details."""
 
@@ -1063,7 +1063,7 @@ class AsyncApp:
         callback_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `dialog_submission` listener.
         Refer to https://api.slack.com/dialogs for details."""
 
@@ -1081,7 +1081,7 @@ class AsyncApp:
         callback_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `dialog_submission` listener.
         Refer to https://api.slack.com/dialogs for details."""
 
@@ -1102,7 +1102,7 @@ class AsyncApp:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `view_submission`/`view_closed` event listener.
         This method can be used as either a decorator or a method.
 
@@ -1152,7 +1152,7 @@ class AsyncApp:
         constraints: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `view_submission` listener.
         Refer to https://api.slack.com/reference/interaction-payloads/views#view_submission for details."""
 
@@ -1170,7 +1170,7 @@ class AsyncApp:
         constraints: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `view_closed` listener.
         Refer to https://api.slack.com/reference/interaction-payloads/views#view_closed for details."""
 
@@ -1191,7 +1191,7 @@ class AsyncApp:
         constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new options listener.
         This method can be used as either a decorator or a method.
 
@@ -1241,7 +1241,7 @@ class AsyncApp:
         action_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `block_suggestion` listener."""
 
         def __call__(*args, **kwargs):
@@ -1258,7 +1258,7 @@ class AsyncApp:
         callback_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `dialog_suggestion` listener.
         Refer to https://api.slack.com/dialogs for details."""
 
@@ -1333,7 +1333,7 @@ class AsyncApp:
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]],
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]],
         auto_acknowledgement: bool = False,
-    ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
+    ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         value_to_return = None
         if not isinstance(functions, list):
             functions = list(functions)


### PR DESCRIPTION
This pull request fixes #459. Refer to the issue for details.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
