### PR TITLE
update block id from listening modals

### DIFF
--- a/docs/_basic/listening_modals.md
+++ b/docs/_basic/listening_modals.md
@@ -21,13 +21,13 @@ Read more about view submissions in our <a href="https://api.slack.com/surfaces/
 # Handle a view_submission request
 @app.view("view_1")
 def handle_submission(ack, body, client, view, logger):
-    # Assume there's an input block with `block_c` as the block_id and `dreamy_input`
-    hopes_and_dreams = view["state"]["values"]["block_c"]["dreamy_input"]
+    # Assume there's an input block with `input_c` as the block_id and `dreamy_input`
+    hopes_and_dreams = view["state"]["values"]["input_c"]["dreamy_input"]
     user = body["user"]["id"]
     # Validate the inputs
     errors = {}
     if hopes_and_dreams is not None and len(hopes_and_dreams) <= 5:
-        errors["block_c"] = "The value must be longer than 5 characters"
+        errors["input_c"] = "The value must be longer than 5 characters"
     if len(errors) > 0:
         ack(response_action="errors", errors=errors)
         return


### PR DESCRIPTION
current, the serial order in which a user reads the documentation sets the
opening_modals example as a pre-requisite that the listening_modals builds
upon.

Currently, an attempt to walk through the examples in order yeilds a
python

`keyError: 'block_c'`

This is because block_c does not match the name of the previous modal examle
`input_c`.

This patch updates the variable to be the same so that users can step through
the documentation without the above exception.

(Describe the goal of this PR. Mention any related Issue numbers)

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
