### PR TITLE
Improve the error message in the case where AuthorizeResult is not found

### DIFF
--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -16,6 +16,9 @@ from slack_bolt.error import BoltError
 
 
 class AsyncAuthorize:
+    """This provides authorize function that returns AuthorizeResult
+    for an incoming request from Slack."""
+
     def __init__(self):
         pass
 
@@ -31,6 +34,10 @@ class AsyncAuthorize:
 
 
 class AsyncCallableAuthorize(AsyncAuthorize):
+    """When you pass the authorize argument in AsyncApp constructor,
+    This authorize implementation will be used.
+    """
+
     def __init__(
         self, *, logger: Logger, func: Callable[..., Awaitable[AuthorizeResult]]
     ):
@@ -93,6 +100,11 @@ class AsyncCallableAuthorize(AsyncAuthorize):
 
 
 class AsyncInstallationStoreAuthorize(AsyncAuthorize):
+    """If you use the OAuth flow settings, this authorize implementation will be used.
+    As long as your own InstallationStore (or the built-in ones) works as you expect,
+    you can expect that the authorize layer should work for you without any customization.
+    """
+
     authorize_result_cache: Dict[str, AuthorizeResult]
     find_installation_available: Optional[bool]
     find_bot_available: Optional[bool]

--- a/slack_bolt/authorization/authorize.py
+++ b/slack_bolt/authorization/authorize.py
@@ -1,5 +1,4 @@
 import inspect
-import os
 from logging import Logger
 from typing import Optional, Callable, Dict, Any
 
@@ -16,6 +15,9 @@ from slack_bolt.error import BoltError
 
 
 class Authorize:
+    """This provides authorize function that returns AuthorizeResult
+    for an incoming request from Slack."""
+
     def __init__(self):
         pass
 
@@ -31,6 +33,10 @@ class Authorize:
 
 
 class CallableAuthorize(Authorize):
+    """When you pass the authorize argument in AsyncApp constructor,
+    This authorize implementation will be used.
+    """
+
     def __init__(
         self,
         *,
@@ -96,6 +102,11 @@ class CallableAuthorize(Authorize):
 
 
 class InstallationStoreAuthorize(Authorize):
+    """If you use the OAuth flow settings, this authorize implementation will be used.
+    As long as your own InstallationStore (or the built-in ones) works as you expect,
+    you can expect that the authorize layer should work for you without any customization.
+    """
+
     authorize_result_cache: Dict[str, AuthorizeResult]
     bot_only: bool
     find_installation_available: bool

--- a/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
@@ -62,8 +62,13 @@ class AsyncMultiTeamsAuthorization(AsyncAuthorization):
                 req.context.client.token = token
                 return await next()
             else:
-                # Just in case
-                self.logger.error("auth.test API call result is unexpectedly None")
+                # This situation can arise if:
+                # * A developer installed the app from the "Install to Workspace" button in Slack app config page
+                # * The InstallationStore failed to save or deleted the installation for this workspace
+                self.logger.error(
+                    "Although the app should be installed into this workspace, "
+                    "the AuthorizeResult (returned value from authorize) for it was not found."
+                )
                 return _build_error_response()
 
         except SlackApiError as e:

--- a/slack_bolt/middleware/authorization/multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/multi_teams_authorization.py
@@ -67,8 +67,13 @@ class MultiTeamsAuthorization(Authorization):
                 req.context.client.token = token
                 return next()
             else:
-                # Just in case
-                self.logger.error("auth.test API call result is unexpectedly None")
+                # This situation can arise if:
+                # * A developer installed the app from the "Install to Workspace" button in Slack app config page
+                # * The InstallationStore failed to save or deleted the installation for this workspace
+                self.logger.error(
+                    "Although the app should be installed into this workspace, "
+                    "the AuthorizeResult (returned value from authorize) for it was not found."
+                )
                 return _build_error_response()
 
         except SlackApiError as e:


### PR DESCRIPTION
While answering this question https://github.com/slackapi/bolt-python/issues/474, I found that, indeed, the error message is a bit confusing. This pull request improves the message to be clearer. Also, I've added a few class comments to related modules.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
