### PR TITLE
Add more guide message in the HTML generated by the default failure handler

### DIFF
--- a/slack_bolt/oauth/internals.py
+++ b/slack_bolt/oauth/internals.py
@@ -62,22 +62,8 @@ class CallbackResponseBuilder:
 
         # Adding a bit more details ot the error code for helping installers understand what's happening.
         # This modification in the HTML page works only when developers use this built-in failure handler.
-        if reason == "invalid_browser":
-            reason = (
-                f"{reason}: Perhaps, you reloaded this page or "
-                "didn't start the OAuth flow from the valid starting URL. "
-                "Another possibility is that your /slack/install URL might not be https:// URL."
-            )
-        elif reason == "invalid_state":
-            reason = f"{reason}: The state parameter is no longer valid."
-        elif reason == "missing_code":
-            reason = f"{reason}: The code parameter is missing in this redirection."
-        elif reason == "storage_error":
-            reason = f"{reason}: The app's server-side has some issue. Contact the app developer."
-        else:
-            reason = f"{reason}: This error code is returned from Slack. Refer to the documents for details."
-
-        html = self._redirect_uri_page_renderer.render_failure_page(reason)
+        detailed_error = build_detailed_error(reason)
+        html = self._redirect_uri_page_renderer.render_failure_page(detailed_error)
         return BoltResponse(
             status=status,
             headers={
@@ -143,3 +129,20 @@ def select_consistent_installation_store(
     else:
         # only oauth_flow_store is available
         return oauth_flow_store
+
+
+def build_detailed_error(reason: str) -> str:
+    if reason == "invalid_browser":
+        return (
+            f"{reason}: Perhaps, you reloaded this page or "
+            "didn't start the OAuth flow from the valid starting URL. "
+            "Another possibility is that your /slack/install URL might not be https:// URL."
+        )
+    elif reason == "invalid_state":
+        return f"{reason}: The state parameter is no longer valid."
+    elif reason == "missing_code":
+        return f"{reason}: The code parameter is missing in this redirection."
+    elif reason == "storage_error":
+        return f"{reason}: The app's server-side has some issue. Contact the app developer."
+    else:
+        return f"{reason}: This error code is returned from Slack. Refer to the documents for details."

--- a/slack_bolt/oauth/internals.py
+++ b/slack_bolt/oauth/internals.py
@@ -60,7 +60,7 @@ class CallbackResponseBuilder:
         )
         self._logger.debug(debug_message)
 
-        # Adding a bit more details ot the error code for helping installers understand what's happening.
+        # Adding a bit more details to the error code to help installers understand what's happening.
         # This modification in the HTML page works only when developers use this built-in failure handler.
         detailed_error = build_detailed_error(reason)
         html = self._redirect_uri_page_renderer.render_failure_page(detailed_error)
@@ -134,15 +134,15 @@ def select_consistent_installation_store(
 def build_detailed_error(reason: str) -> str:
     if reason == "invalid_browser":
         return (
-            f"{reason}: Perhaps, you reloaded this page or "
-            "didn't start the OAuth flow from the valid starting URL. "
-            "Another possibility is that your /slack/install URL might not be https:// URL."
+            f"{reason}: This can occur due to page reload, "
+            "not beginning the OAuth flow from the valid starting URL, or "
+            "the /slack/install URL not using https://"
         )
     elif reason == "invalid_state":
         return f"{reason}: The state parameter is no longer valid."
     elif reason == "missing_code":
         return f"{reason}: The code parameter is missing in this redirection."
     elif reason == "storage_error":
-        return f"{reason}: The app's server-side has some issue. Contact the app developer."
+        return f"{reason}: The app's server encountered an issue. Contact the app developer."
     else:
         return f"{reason}: This error code is returned from Slack. Refer to the documents for details."

--- a/slack_bolt/oauth/internals.py
+++ b/slack_bolt/oauth/internals.py
@@ -60,6 +60,23 @@ class CallbackResponseBuilder:
         )
         self._logger.debug(debug_message)
 
+        # Adding a bit more details ot the error code for helping installers understand what's happening.
+        # This modification in the HTML page works only when developers use this built-in failure handler.
+        if reason == "invalid_browser":
+            reason = (
+                f"{reason}: Perhaps, you reloaded this page or "
+                "didn't start the OAuth flow from the valid starting URL. "
+                "Another possibility is that your /slack/install URL might not be https:// URL."
+            )
+        elif reason == "invalid_state":
+            reason = f"{reason}: The state parameter is no longer valid."
+        elif reason == "missing_code":
+            reason = f"{reason}: The code parameter is missing in this redirection."
+        elif reason == "storage_error":
+            reason = f"{reason}: The app's server-side has some issue. Contact the app developer."
+        else:
+            reason = f"{reason}: This error code is returned from Slack. Refer to the documents for details."
+
         html = self._redirect_uri_page_renderer.render_failure_page(reason)
         return BoltResponse(
             status=status,

--- a/tests/slack_bolt/oauth/test_internals.py
+++ b/tests/slack_bolt/oauth/test_internals.py
@@ -4,7 +4,7 @@ from slack_bolt.oauth.internals import build_detailed_error
 class TestOAuthInternals:
     def test_build_detailed_error_invalid_browser(self):
         result = build_detailed_error("invalid_browser")
-        assert result.startswith("invalid_browser: Perhaps, you reloaded this page or")
+        assert result.startswith("invalid_browser: This can occur due to page reload, ")
 
     def test_build_detailed_error_invalid_state(self):
         result = build_detailed_error("invalid_state")
@@ -21,7 +21,7 @@ class TestOAuthInternals:
     def test_build_detailed_error_storage_error(self):
         result = build_detailed_error("storage_error")
         assert result.startswith(
-            "storage_error: The app's server-side has some issue. Contact the app developer."
+            "storage_error: The app's server encountered an issue. Contact the app developer."
         )
 
     def test_build_detailed_error_others(self):

--- a/tests/slack_bolt/oauth/test_internals.py
+++ b/tests/slack_bolt/oauth/test_internals.py
@@ -1,0 +1,31 @@
+from slack_bolt.oauth.internals import build_detailed_error
+
+
+class TestOAuthInternals:
+    def test_build_detailed_error_invalid_browser(self):
+        result = build_detailed_error("invalid_browser")
+        assert result.startswith("invalid_browser: Perhaps, you reloaded this page or")
+
+    def test_build_detailed_error_invalid_state(self):
+        result = build_detailed_error("invalid_state")
+        assert result.startswith(
+            "invalid_state: The state parameter is no longer valid."
+        )
+
+    def test_build_detailed_error_missing_code(self):
+        result = build_detailed_error("missing_code")
+        assert result.startswith(
+            "missing_code: The code parameter is missing in this redirection."
+        )
+
+    def test_build_detailed_error_storage_error(self):
+        result = build_detailed_error("storage_error")
+        assert result.startswith(
+            "storage_error: The app's server-side has some issue. Contact the app developer."
+        )
+
+    def test_build_detailed_error_others(self):
+        result = build_detailed_error("access_denied")
+        assert result.startswith(
+            "access_denied: This error code is returned from Slack. Refer to the documents for details."
+        )


### PR DESCRIPTION
We've received questions about the "invalid_browser" error in the OAuth flow (=the OAuth flow didn't start in the same browser correctly -- meaning that the OAuth flow didn't start from /slack/install correctly): https://github.com/slackapi/bolt-python/issues?q=is%3Aissue+invalid_browser+

This pull request improves the default error page to have more details to help installers understand what's happening and what to do next.

<img width="600" src="https://user-images.githubusercontent.com/19658/134830773-7e809c8d-db6c-4b61-8926-7da407fe359f.png">
<img width="600" src="https://user-images.githubusercontent.com/19658/134830778-43f4e538-9355-4b2c-a693-e215061b2dd4.png">

Suggestions to the message text would be appreciated.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
