### PR TITLE
Adds update view on submission docs

### DIFF
--- a/docs/_basic/listening_modals.md
+++ b/docs/_basic/listening_modals.md
@@ -11,6 +11,19 @@ If a <a href="https://api.slack.com/reference/block-kit/views">view payload</a> 
 
 You can access the value of the `input` blocks by accessing the `state` object. `state` contains a `values` object that uses the `block_id` and unique `action_id` to store the input values.
 
+---
+
+##### Update views on submission
+
+To update a view in response to a `view_submission` event, you may pass a `response_action` of type `update` with a newly composed `view` to display in your acknowledgement.
+
+```python
+# Update the view on submission 
+@app.view("view_1")
+def handle_submission(ack, body):
+    ack(response_action="update", view=build_new_view(body))
+```
+Similarly, there are options for [displaying errors](https://api.slack.com/surfaces/modals/using#displaying_errors) in response to view submissions.
 Read more about view submissions in our <a href="https://api.slack.com/surfaces/modals/using#interactions">API documentation</a>.
 
 </div>


### PR DESCRIPTION
Updates listening to views documentation to add example for updating via ack() `response_action`. After [corresponding bolt-js changes](https://github.com/slackapi/bolt-js/pull/1130)

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes. 
