### PR TITLE
Fix #480 #479 Adds updating views on submission for Japanese docs

### DIFF
--- a/docs/_basic/ja_listening_modals.md
+++ b/docs/_basic/ja_listening_modals.md
@@ -15,7 +15,7 @@ order: 12
 
 ##### モーダル送信でのビューの更新
 
-`view_submission` リクエストに対してモーダルを更新するには、リクエストの確認の中で `update` を指定した `response_action` と新しく作成した `view` を指定します。
+`view_submission` リクエストに対してモーダルを更新するには、リクエストの確認の中で `update` という `response_action` と新しく作成した `view` を指定します。
 
 ```python
 # モーダル送信でのビューの更新


### PR DESCRIPTION
Fixes #480. Adds the fixes in #479 (Updating views on `view_submission`) for the Japanese docs.  

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
