### PR TITLE
Add Python 3.10 to the supported versions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         python setup.py install
         pip install -U pip
-        pip install "pytest>=5,<6" "pytest-cov>=2,<3" "flask_sockets>0.2,<1"
+        pip install -e ".[testing_without_asyncio]"
     - name: Run tests without aiohttp
       run: |
         pytest tests/slack_bolt/

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,14 @@ with open(f"{here}/README.md", "r") as fh:
 test_dependencies = [
     "pytest>=6.2.5,<7",
     "pytest-cov>=2,<3",
-    "pytest-asyncio<1",  # for async
-    "aiohttp>=3,<4",  # for async
     "Flask-Sockets>=0.2,<1",
     "Werkzeug<2",  # TODO: support Flask 2.x
     "black==21.9b0",
+]
+
+async_test_dependencies = test_dependencies + [
+    "pytest-asyncio<1",  # for async
+    "aiohttp>=3,<4",  # for async
 ]
 
 setuptools.setup(
@@ -45,7 +48,7 @@ setuptools.setup(
         "slack_sdk>=3.9.0,<4",
     ],
     setup_requires=["pytest-runner==5.2"],
-    tests_require=test_dependencies,
+    tests_require=async_test_dependencies,
     test_suite="tests",
     extras_require={
         # pip install -e ".[async]"
@@ -84,8 +87,10 @@ setuptools.setup(
             # Socket Mode 3rd party implementation
             "websocket_client>=1,<2",
         ],
+        # pip install -e ".[testing_without_asyncio]"
+        "testing_without_asyncio": test_dependencies,
         # pip install -e ".[testing]"
-        "testing": test_dependencies,
+        "testing": async_test_dependencies,
     },
     classifiers=[
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
This pull request adds a CI build job with Python 3.10 and updates the package metadata.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
