### PR TITLE
Update OAuth link to point to JP docs instead of EN

### DIFF
--- a/docs/_advanced/ja_token_rotation.md
+++ b/docs/_advanced/ja_token_rotation.md
@@ -10,7 +10,7 @@ Bolt for Python [v1.7.0](https://github.com/slackapi/bolt-python/releases/tag/v1
 
 既存の Slack アプリではアクセストークンが無期限に存在し続けるのに対して、トークンローテーションを有効にしたアプリではアクセストークンが失効するようになります。リフレッシュトークンを利用して、アクセストークンを長期間にわたって更新し続けることができます。
 
-[Bolt for Python の組み込みの OAuth 機能](https://slack.dev/bolt-python/concepts#authenticating-oauth) を使用していれば、Bolt for Python が自動的にトークンローテーションの処理をハンドリングします。
+[Bolt for Python の組み込みの OAuth 機能](https://slack.dev/bolt-python/ja-jp/concepts#authenticating-oauth) を使用していれば、Bolt for Python が自動的にトークンローテーションの処理をハンドリングします。
 
 トークンローテーションに関する詳細は [API ドキュメント](https://api.slack.com/authentication/rotation)を参照してください。
 </div>


### PR DESCRIPTION
(Describe the goal of this PR. Mention any related Issue numbers)

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
