### PR TITLE
Fix a bug in the asyncio based token rotation support

### DIFF
--- a/docs/api-docs/slack_bolt/authorization/async_authorize.html
+++ b/docs/api-docs/slack_bolt/authorization/async_authorize.html
@@ -237,7 +237,7 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
                             raise BoltError(self._config_error_message)
                         refreshed = await self.token_rotator.perform_token_rotation(
                             installation=installation,
-                            minutes_before_expiration=self.token_rotation_expiration_minutes,
+                            token_rotation_expiration_minutes=self.token_rotation_expiration_minutes,
                         )
                         if refreshed is not None:
                             await self.installation_store.async_save(refreshed)
@@ -569,7 +569,7 @@ you can expect that the authorize layer should work for you without any customiz
                             raise BoltError(self._config_error_message)
                         refreshed = await self.token_rotator.perform_token_rotation(
                             installation=installation,
-                            minutes_before_expiration=self.token_rotation_expiration_minutes,
+                            token_rotation_expiration_minutes=self.token_rotation_expiration_minutes,
                         )
                         if refreshed is not None:
                             await self.installation_store.async_save(refreshed)


### PR DESCRIPTION
The kwarg for `perform_token_rotation` needs changing to match the core slack sdk 

### Category

* [x] `slack_bolt.async_app.AsyncApp` and/or its core components

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
