### PR TITLE
Bump optional dependencies for v1.9.4 release

### DIFF
--- a/examples/aws_lambda/.gitignore
+++ b/examples/aws_lambda/.gitignore
@@ -1,2 +1,4 @@
 slack-bolt/
+slack_bolt/
+vendor/
 .env

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(f"{here}/README.md", "r") as fh:
 
 test_dependencies = [
     "pytest>=6.2.5,<7",
-    "pytest-cov>=2,<3",
+    "pytest-cov>=3,<4",
     "Flask-Sockets>=0.2,<1",
     "Werkzeug<2",  # TODO: support Flask 2.x
     "black==21.9b0",
@@ -67,18 +67,18 @@ setuptools.setup(
             "moto<2",  # For AWS tests
             "bottle>=0.12,<1",
             "boddle>=0.2,<0.3",  # For Bottle app tests
-            "chalice>=1.22.4,<2",
+            "chalice>=1.26.1,<2",
             "click>=7,<8",  # for chalice
             "CherryPy>=18,<19",
             "Django>=3,<4",
             "falcon>=2,<3",
-            "fastapi<1",
+            "fastapi>=0.70.0,<1",
             "Flask>=1,<2",
             "Werkzeug<2",  # TODO: support Flask 2.x
             "pyramid>=1,<2",
             "sanic>=21,<22" if sys.version_info.minor > 6 else "sanic>=20,<21",
-            "sanic-testing>=0.6" if sys.version_info.minor > 6 else "",
-            "starlette>=0.13,<1",
+            "sanic-testing>=0.7" if sys.version_info.minor > 6 else "",
+            "starlette>=0.14,<1",
             "requests>=2,<3",  # For starlette's TestClient
             "tornado>=6,<7",
             # server


### PR DESCRIPTION
This pull request upgrade some of the optional dependencies. Although we do tests with these versions, older minor/patch versions of these dependencies should work with bolt-python.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
