### PR TITLE
Fix #505 - a code snippet error in a Japanese document page

### DIFF
--- a/docs/_tutorials/ja_getting_started.md
+++ b/docs/_tutorials/ja_getting_started.md
@@ -228,12 +228,6 @@ def message_hello(message, say):
         text=f"Hey there <@{message['user']}>!"
     )
 
-@app.action("button_click")
-def action_button_click(body, ack, say):
-    # アクションのリクエストを確認
-    ack()
-    say(f"<@{body['user']['id']}> clicked the button")
-
 # アプリを起動します
 if __name__ == "__main__":
     SocketModeHandler(app, os.environ["SLACK_APP_TOKEN"]).start()


### PR DESCRIPTION
The document of getting_started.md has not already been implemented action_button_click at this time.

Fixes #505

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
Success: no errors found 🎉 
