### PR TITLE
Fix #506 - a description typo in a Japanese document page

### DIFF
--- a/docs/_tutorials/ja_getting_started.md
+++ b/docs/_tutorials/ja_getting_started.md
@@ -95,7 +95,7 @@ Bolt for Python のパッケージを新しいプロジェクトにインスト�
 export SLACK_BOT_TOKEN=xoxb-<ボットトークン>
 ```
 
-2. **OAuth & Permissions ページのアプリレベルトークン（xapp）をコピー**して、別の環境変数に保存します。
+2. **Basic Information ページのアプリレベルトークン（xapp）をコピー**して、別の環境変数に保存します。
 ```shell
 export SLACK_APP_TOKEN=<アプリレベルトークン>
 ```


### PR DESCRIPTION
app-level (xapp) token can be gotton from the Basic Information page
Fixes #506

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
Yes, ok. I got Success: no errors found :tada: