### PR TITLE
Use django.db close_old_connections in place of explicit connections.close

### DIFF
--- a/slack_bolt/adapter/django/handler.py
+++ b/slack_bolt/adapter/django/handler.py
@@ -54,15 +54,15 @@ def to_django_response(bolt_resp: BoltResponse) -> HttpResponse:
     return resp
 
 
-from django.db import connections
+from django.db import close_old_connections
 
 
 def release_thread_local_connections(logger: Logger, execution_type: str):
-    connections.close_all()
+    close_old_connections()
     if logger.level <= logging.DEBUG:
         current: Thread = current_thread()
         logger.debug(
-            f"Released thread-bound DB connections (thread name: {current.name}, execution type: {execution_type})"
+            f"close_old_connections called to manage thread-bound DB connections (thread name: {current.name}, execution type: {execution_type})"
         )
 
 
@@ -124,8 +124,8 @@ class SlackRequestHandler:
             Bolt skipped to set it to slack_sdk.adapter.django.DjangoListenerCompletionHandler.
             We strongly recommend having the following lines of code in your listener_completion_handler:
 
-            from django.db import connections
-            connections.close_all()
+            from django.db import close_old_connections
+            close_old_connections()
             """
             self.app.logger.warning(message)
             return


### PR DESCRIPTION

I was looking to enable the django db `CONN_MAX_AGE` to avoid the overhead of reconnecting to the database (TLS encrypted) for every event being handled similar to how I have in the past with normal django web requests. 

I quickly realized this wasn't working as I continued to see the mysql connection counters on the server rising for each request. I dug into the log message about closing connections and ran across `release_thread_local_connections`  https://github.com/slackapi/bolt-python/blob/99ed6a6c1bb09c8f186b916eaf54e963073a112c/slack_bolt/adapter/django/handler.py#L60

That method appears to explicitly close all connections after each event is handled which makes `CONN_MAX_AGE` ineffective. 

This PR makes a relatively minor change to `release_thread_local_connections` to instead call the same `request_finished` handler the signal mentioned in https://github.com/slackapi/bolt-python/issues/280#issue-849076180, `django.db.close_old_connections` which appears to be easy/safe since it ignores all args with `**kwargs`. 

This opens things up to connection reuse via `CONN_MAX_AGE` and otherwise gets the full django connection cleanup behavior on errors instead of explicitly closing the connection for each event handled.

/cc https://github.com/slackapi/bolt-python/issues/280 https://github.com/slackapi/bolt-python/pull/281 which introduced the explicit close
/cc @seratch who authored ^ and would likely know if this makes sense

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
