### PR TITLE
Upgrade pytype version to 2021.10.25

### DIFF
--- a/scripts/run_pytype.sh
+++ b/scripts/run_pytype.sh
@@ -5,5 +5,5 @@ script_dir=$(dirname $0)
 cd ${script_dir}/.. && \
   pip install -e ".[async]" && \
   pip install -e ".[adapter]" && \
-  pip install "pytype==2021.10.11" && \
+  pip install "pytype==2021.10.25" && \
   pytype slack_bolt/


### PR DESCRIPTION
This pull request upgrades pytype version to the latest. The version did not detect any new errors in my execution on my laptop.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
