### PR TITLE
Improve the Django app example to be more robust

### DIFF
--- a/examples/django/oauth_app/slack_datastores.py
+++ b/examples/django/oauth_app/slack_datastores.py
@@ -33,9 +33,13 @@ class DjangoInstallationStore(InstallationStore):
         i = installation.to_dict()
         if is_naive(i["installed_at"]):
             i["installed_at"] = make_aware(i["installed_at"])
-        if "bot_token_expires_at" in i and is_naive(i["bot_token_expires_at"]):
+        if i.get("bot_token_expires_at") is not None and is_naive(
+            i["bot_token_expires_at"]
+        ):
             i["bot_token_expires_at"] = make_aware(i["bot_token_expires_at"])
-        if "user_token_expires_at" in i and is_naive(i["user_token_expires_at"]):
+        if i.get("user_token_expires_at") is not None and is_naive(
+            i["user_token_expires_at"]
+        ):
             i["user_token_expires_at"] = make_aware(i["user_token_expires_at"])
         i["client_id"] = self.client_id
         row_to_update = (
@@ -58,7 +62,7 @@ class DjangoInstallationStore(InstallationStore):
         b = bot.to_dict()
         if is_naive(b["installed_at"]):
             b["installed_at"] = make_aware(b["installed_at"])
-        if "bot_token_expires_at" in b is not None and is_naive(
+        if b.get("bot_token_expires_at") is not None and is_naive(
             b["bot_token_expires_at"]
         ):
             b["bot_token_expires_at"] = make_aware(b["bot_token_expires_at"])


### PR DESCRIPTION
This pull request improves the Django example app to be more robust. 

@paulfab
Thanks again for your input at #522 

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
