### PR TITLE
Add more labels to exempt-issue-labels in stale GitHub action

### DIFF
--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -26,7 +26,7 @@ jobs:
           stale-issue-label: auto-triage-stale
           stale-issue-message: 👋 It looks like this issue has been open for 30 days with no activity. We'll mark this as stale for now, and wait 10 days for an update or for further comment before closing this issue out.
           close-issue-message: As this issue has been inactive for more than one month, we will be closing it. Thank you to all the participants! If you would like to raise a related issue, please create a new issue which includes your specific details and references this issue number.
-          exempt-issue-labels: auto-triage-skip,bug,discussion,docs,enhancementimprovement,,security,area:examples,server-side
+          exempt-issue-labels: auto-triage-skip,bug,discussion,docs,enhancement,improvement,security,area:examples,server-side
           exempt-all-milestones: true
           remove-stale-when-updated: true
           enable-statistics: true

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -26,7 +26,7 @@ jobs:
           stale-issue-label: auto-triage-stale
           stale-issue-message: 👋 It looks like this issue has been open for 30 days with no activity. We'll mark this as stale for now, and wait 10 days for an update or for further comment before closing this issue out.
           close-issue-message: As this issue has been inactive for more than one month, we will be closing it. Thank you to all the participants! If you would like to raise a related issue, please create a new issue which includes your specific details and references this issue number.
-          exempt-issue-labels: auto-triage-skip
+          exempt-issue-labels: auto-triage-skip,bug,discussion,docs,enhancementimprovement,,security,area:examples,server-side
           exempt-all-milestones: true
           remove-stale-when-updated: true
           enable-statistics: true


### PR DESCRIPTION
This pull request improves the stale GitHub Action job not to mark stale to issues with enhancement etc.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.