### PR TITLE
Update the respond utility guide

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 .vscode/
 .bundle/
 vendor/
+.ruby-version

--- a/docs/_basic/ja_responding_actions.md
+++ b/docs/_basic/ja_responding_actions.md
@@ -31,7 +31,7 @@ def approve_request(ack, say):
 
 <div class="secondary-content" markdown="0">
 
-`respond()` は `response_url` を使って送信するときに便利なメソッドで、これらと同じような動作をします。投稿するメッセージのペイロードには JSON オブジェクトを渡すことができ、メッセージはやり取りの発生元に反映されます。オプションのプロパティとして `response_type`（値は `in_channel` または `ephemeral`）、`replace_original`、`delete_original` などを指定できます。
+`respond()` は `response_url` を使って送信するときに便利なメソッドで、これらと同じような動作をします。投稿するメッセージのペイロードには、全ての[メッセージペイロードのプロパティ](https://api.slack.com/reference/messaging/payload)とオプションのプロパティとして `response_type`（値は `"in_channel"` または `"ephemeral"`）、`replace_original`、`delete_original`、`unfurl_links`、`unfurl_media` などを指定できます。こうすることによってアプリから送信されるメッセージは、やり取りの発生元に反映されます。
 
 </div>
 

--- a/docs/_basic/responding_actions.md
+++ b/docs/_basic/responding_actions.md
@@ -32,7 +32,7 @@ def approve_request(ack, say):
 
 <div class="secondary-content" markdown="0">
 
-Since `respond()` is a utility for calling the `response_url`, it behaves in the same way. You can pass a JSON object with a new message payload that will be published back to the source of the original interaction with optional properties like `response_type` (which has a value of `in_channel` or `ephemeral`), `replace_original`, and `delete_original`.
+Since `respond()` is a utility for calling the `response_url`, it behaves in the same way. You can pass [all the message payload properties](https://api.slack.com/reference/messaging/payload) as keyword arguments along with optional properties like `response_type` (which has a value of `"in_channel"` or `"ephemeral"`), `replace_original`, `delete_original`, `unfurl_links`, and `unfurl_media`. With that, your app can send a new message payload that will be published back to the source of the original interaction.
 
 </div>
 


### PR DESCRIPTION
This pull request improves the document page on the `respond()` utility usage.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
