### PR TITLE
Fix url_verification error with the Flask adapter

### DIFF
--- a/examples/app_authorize.py
+++ b/examples/app_authorize.py
@@ -39,4 +39,4 @@ if __name__ == "__main__":
 # pip install slack_bolt
 # export SLACK_SIGNING_SECRET=***
 # export MY_TOKEN=xoxb-***
-# python app.py
+# python app_authorize.py

--- a/examples/async_app.py
+++ b/examples/async_app.py
@@ -32,4 +32,4 @@ if __name__ == "__main__":
 # pip install slack_bolt
 # export SLACK_SIGNING_SECRET=***
 # export SLACK_BOT_TOKEN=xoxb-***
-# python app.py
+# python async_app.py

--- a/slack_bolt/adapter/flask/handler.py
+++ b/slack_bolt/adapter/flask/handler.py
@@ -17,6 +17,9 @@ def to_bolt_request(req: Request) -> BoltRequest:
 def to_flask_response(bolt_resp: BoltResponse) -> Response:
     resp: Response = make_response(bolt_resp.body, bolt_resp.status)
     for k, values in bolt_resp.headers.items():
+        if k.lower() == "content-type" and resp.headers.get("content-type") is not None:
+            # Remove the one set by Flask
+            resp.headers.pop("content-type")
         for v in values:
             resp.headers.add_header(k, v)
     return resp


### PR DESCRIPTION
After a recent update, the Slack server-side no longer accepts multiple Content-Type headers. The current Flask adapter implementation sends two "Content-Type" header values in response:

* Content-Type: text/html (set by Flask)
* Content-Type: application/json; charset=utf-8 (set by Bolt)

This pull request removes the first one to make it work with the current Slack server-side.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
