### PR TITLE
Fix #545 Enable to use lazy listeners even when having any custom context data

### DIFF
--- a/slack_bolt/context/async_context.py
+++ b/slack_bolt/context/async_context.py
@@ -12,7 +12,7 @@ from slack_bolt.util.utils import create_copy
 class AsyncBoltContext(BaseContext):
     """Context object associated with a request from Slack."""
 
-    def create_copy(self) -> "AsyncBoltContext":
+    def to_copiable(self) -> "AsyncBoltContext":
         new_dict = {}
         for prop_name, prop_value in self.items():
             if prop_name in self.standard_property_names:

--- a/slack_bolt/context/async_context.py
+++ b/slack_bolt/context/async_context.py
@@ -12,7 +12,7 @@ from slack_bolt.util.utils import create_copy
 class AsyncBoltContext(BaseContext):
     """Context object associated with a request from Slack."""
 
-    def to_copiable(self) -> "AsyncBoltContext":
+    def to_copyable(self) -> "AsyncBoltContext":
         new_dict = {}
         for prop_name, prop_value in self.items():
             if prop_name in self.standard_property_names:

--- a/slack_bolt/context/async_context.py
+++ b/slack_bolt/context/async_context.py
@@ -12,7 +12,7 @@ from slack_bolt.util.utils import create_copy
 class AsyncBoltContext(BaseContext):
     """Context object associated with a request from Slack."""
 
-    def create_no_custom_prop_copy(self) -> "AsyncBoltContext":
+    def create_copy(self) -> "AsyncBoltContext":
         new_dict = {}
         for prop_name, prop_value in self.items():
             if prop_name in self.standard_property_names:

--- a/slack_bolt/context/base_context.py
+++ b/slack_bolt/context/base_context.py
@@ -7,6 +7,27 @@ from slack_bolt.authorization import AuthorizeResult
 class BaseContext(dict):
     """Context object associated with a request from Slack."""
 
+    standard_property_names = [
+        "logger",
+        "token",
+        "enterprise_id",
+        "is_enterprise_install",
+        "team_id",
+        "user_id",
+        "channel_id",
+        "response_url",
+        "matches",
+        "authorize_result",
+        "bot_token",
+        "bot_id",
+        "bot_user_id",
+        "user_token",
+        "client",
+        "ack",
+        "say",
+        "respond",
+    ]
+
     @property
     def logger(self) -> Logger:
         """The properly configured logger that is available for middleware/listeners."""

--- a/slack_bolt/context/context.py
+++ b/slack_bolt/context/context.py
@@ -13,7 +13,7 @@ from slack_bolt.util.utils import create_copy
 class BoltContext(BaseContext):
     """Context object associated with a request from Slack."""
 
-    def create_copy(self) -> "BoltContext":
+    def to_copiable(self) -> "BoltContext":
         new_dict = {}
         for prop_name, prop_value in self.items():
             if prop_name in self.standard_property_names:

--- a/slack_bolt/context/context.py
+++ b/slack_bolt/context/context.py
@@ -13,7 +13,7 @@ from slack_bolt.util.utils import create_copy
 class BoltContext(BaseContext):
     """Context object associated with a request from Slack."""
 
-    def create_no_custom_prop_copy(self) -> "BoltContext":
+    def create_copy(self) -> "BoltContext":
         new_dict = {}
         for prop_name, prop_value in self.items():
             if prop_name in self.standard_property_names:

--- a/slack_bolt/context/context.py
+++ b/slack_bolt/context/context.py
@@ -13,7 +13,7 @@ from slack_bolt.util.utils import create_copy
 class BoltContext(BaseContext):
     """Context object associated with a request from Slack."""
 
-    def to_copiable(self) -> "BoltContext":
+    def to_copyable(self) -> "BoltContext":
         new_dict = {}
         for prop_name, prop_value in self.items():
             if prop_name in self.standard_property_names:

--- a/slack_bolt/listener/asyncio_runner.py
+++ b/slack_bolt/listener/asyncio_runner.py
@@ -198,7 +198,7 @@ class AsyncioListenerRunner:
     def _build_lazy_request(
         request: AsyncBoltRequest, lazy_func_name: str
     ) -> AsyncBoltRequest:
-        copied_request = create_copy(request)
+        copied_request = create_copy(request.to_copiable())
         copied_request.method = "NONE"
         copied_request.lazy_only = True
         copied_request.lazy_function_name = lazy_func_name

--- a/slack_bolt/listener/asyncio_runner.py
+++ b/slack_bolt/listener/asyncio_runner.py
@@ -198,7 +198,7 @@ class AsyncioListenerRunner:
     def _build_lazy_request(
         request: AsyncBoltRequest, lazy_func_name: str
     ) -> AsyncBoltRequest:
-        copied_request = create_copy(request.to_copiable())
+        copied_request = create_copy(request.to_copyable())
         copied_request.method = "NONE"
         copied_request.lazy_only = True
         copied_request.lazy_function_name = lazy_func_name

--- a/slack_bolt/listener/thread_runner.py
+++ b/slack_bolt/listener/thread_runner.py
@@ -195,7 +195,7 @@ class ThreadListenerRunner:
 
     @staticmethod
     def _build_lazy_request(request: BoltRequest, lazy_func_name: str) -> BoltRequest:
-        copied_request = create_copy(request)
+        copied_request = create_copy(request.to_copiable())
         copied_request.method = "NONE"
         copied_request.lazy_only = True
         copied_request.lazy_function_name = lazy_func_name

--- a/slack_bolt/listener/thread_runner.py
+++ b/slack_bolt/listener/thread_runner.py
@@ -195,7 +195,7 @@ class ThreadListenerRunner:
 
     @staticmethod
     def _build_lazy_request(request: BoltRequest, lazy_func_name: str) -> BoltRequest:
-        copied_request = create_copy(request.to_copiable())
+        copied_request = create_copy(request.to_copyable())
         copied_request.method = "NONE"
         copied_request.lazy_only = True
         copied_request.lazy_function_name = lazy_func_name

--- a/slack_bolt/request/async_request.py
+++ b/slack_bolt/request/async_request.py
@@ -76,11 +76,11 @@ class AsyncBoltRequest:
         )[0]
         self.mode = mode
 
-    def to_copiable(self) -> "AsyncBoltRequest":
+    def to_copyable(self) -> "AsyncBoltRequest":
         return AsyncBoltRequest(
             body=self.raw_body,
             query=self.query,
             headers=self.headers,
-            context=self.context.to_copiable(),
+            context=self.context.to_copyable(),
             mode=self.mode,
         )

--- a/slack_bolt/request/async_request.py
+++ b/slack_bolt/request/async_request.py
@@ -81,6 +81,6 @@ class AsyncBoltRequest:
             body=self.raw_body,
             query=self.query,
             headers=self.headers,
-            context=self.context.create_no_custom_prop_copy(),
+            context=self.context.create_copy(),
             mode=self.mode,
         )

--- a/slack_bolt/request/async_request.py
+++ b/slack_bolt/request/async_request.py
@@ -81,6 +81,6 @@ class AsyncBoltRequest:
             body=self.raw_body,
             query=self.query,
             headers=self.headers,
-            context=self.context.create_copy(),
+            context=self.context.to_copiable(),
             mode=self.mode,
         )

--- a/slack_bolt/request/async_request.py
+++ b/slack_bolt/request/async_request.py
@@ -75,3 +75,12 @@ class AsyncBoltRequest:
             "x-slack-bolt-lazy-function-name", [None]
         )[0]
         self.mode = mode
+
+    def to_copiable(self) -> "AsyncBoltRequest":
+        return AsyncBoltRequest(
+            body=self.raw_body,
+            query=self.query,
+            headers=self.headers,
+            context=self.context.create_no_custom_prop_copy(),
+            mode=self.mode,
+        )

--- a/slack_bolt/request/request.py
+++ b/slack_bolt/request/request.py
@@ -72,3 +72,12 @@ class BoltRequest:
             "x-slack-bolt-lazy-function-name", [None]
         )[0]
         self.mode = mode
+
+    def to_copiable(self) -> "BoltRequest":
+        return BoltRequest(
+            body=self.raw_body,
+            query=self.query,
+            headers=self.headers,
+            context=self.context.create_no_custom_prop_copy(),
+            mode=self.mode,
+        )

--- a/slack_bolt/request/request.py
+++ b/slack_bolt/request/request.py
@@ -73,11 +73,11 @@ class BoltRequest:
         )[0]
         self.mode = mode
 
-    def to_copiable(self) -> "BoltRequest":
+    def to_copyable(self) -> "BoltRequest":
         return BoltRequest(
             body=self.raw_body,
             query=self.query,
             headers=self.headers,
-            context=self.context.to_copiable(),
+            context=self.context.to_copyable(),
             mode=self.mode,
         )

--- a/slack_bolt/request/request.py
+++ b/slack_bolt/request/request.py
@@ -78,6 +78,6 @@ class BoltRequest:
             body=self.raw_body,
             query=self.query,
             headers=self.headers,
-            context=self.context.create_no_custom_prop_copy(),
+            context=self.context.create_copy(),
             mode=self.mode,
         )

--- a/slack_bolt/request/request.py
+++ b/slack_bolt/request/request.py
@@ -78,6 +78,6 @@ class BoltRequest:
             body=self.raw_body,
             query=self.query,
             headers=self.headers,
-            context=self.context.create_copy(),
+            context=self.context.to_copiable(),
             mode=self.mode,
         )

--- a/tests/scenario_tests/test_lazy.py
+++ b/tests/scenario_tests/test_lazy.py
@@ -138,3 +138,73 @@ class TestErrorHandler:
         assert response.status == 200
         time.sleep(1)  # wait a bit
         assert self.mock_received_requests["/chat.postMessage"] == 2
+
+    def test_issue_545_context_copy_failure(self):
+        def just_ack(ack):
+            ack()
+
+        class LazyClass:
+            def __call__(self, context, say):
+                assert context.get("foo") == "FOO"
+                assert context.get("ssl_context") is None
+                time.sleep(0.3)
+                say(text="lazy function 1")
+
+        def async2(context, say):
+            assert context.get("foo") == "FOO"
+            assert context.get("ssl_context") is None
+            time.sleep(0.5)
+            say(text="lazy function 2")
+
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+
+        @app.middleware
+        def set_ssl_context(context, next_):
+            from ssl import SSLContext
+
+            context["foo"] = "FOO"
+            # This causes an error when starting lazy listener executions
+            context["ssl_context"] = SSLContext()
+            next_()
+
+        # 2021-12-13 11:14:29 ERROR Failed to run a middleware middleware (error: cannot pickle 'SSLContext' object)
+        # Traceback (most recent call last):
+        #   File "/path/to/bolt-python/slack_bolt/app/app.py", line 545, in dispatch
+        #     ] = self._listener_runner.run(
+        #   File "/path/to/bolt-python/slack_bolt/listener/thread_runner.py", line 166, in run
+        #     self._start_lazy_function(lazy_func, request)
+        #   File "/path/to/bolt-python/slack_bolt/listener/thread_runner.py", line 193, in _start_lazy_function
+        #     copied_request = self._build_lazy_request(request, func_name)
+        #   File "/path/to/bolt-python/slack_bolt/listener/thread_runner.py", line 198, in _build_lazy_request
+        #     copied_request = create_copy(request)
+        #   File "/path/to/bolt-python/slack_bolt/util/utils.py", line 48, in create_copy
+        #     return copy.deepcopy(original)
+        #   File "/path/to/python/lib/python3.9/copy.py", line 172, in deepcopy
+        #     y = _reconstruct(x, memo, *rv)
+        #   File "/path/to/python/lib/python3.9/copy.py", line 270, in _reconstruct
+        #     state = deepcopy(state, memo)
+        #   File "/path/to/python/lib/python3.9/copy.py", line 146, in deepcopy
+        #     y = copier(x, memo)
+        #   File "/path/to/python/lib/python3.9/copy.py", line 230, in _deepcopy_dict
+        #     y[deepcopy(key, memo)] = deepcopy(value, memo)
+        #   File "/path/to/python/lib/python3.9/copy.py", line 172, in deepcopy
+        #     y = _reconstruct(x, memo, *rv)
+        #   File "/path/to/python/lib/python3.9/copy.py", line 296, in _reconstruct
+        #     value = deepcopy(value, memo)
+        #   File "/path/to/python/lib/python3.9/copy.py", line 161, in deepcopy
+        #     rv = reductor(4)
+        # TypeError: cannot pickle 'SSLContext' object
+
+        app.action("a")(
+            ack=just_ack,
+            lazy=[LazyClass(), async2],
+        )
+
+        request = self.build_valid_request()
+        response = app.dispatch(request)
+        assert response.status == 200
+        time.sleep(1)  # wait a bit
+        assert self.mock_received_requests["/chat.postMessage"] == 2


### PR DESCRIPTION
This pull request fixes #545 by enhancing the internals of lazy listener execution mechanism.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
