### PR TITLE
Upgrade pytype, black versions

### DIFF
--- a/scripts/run_pytype.sh
+++ b/scripts/run_pytype.sh
@@ -5,5 +5,5 @@ script_dir=$(dirname $0)
 cd ${script_dir}/.. && \
   pip install -e ".[async]" && \
   pip install -e ".[adapter]" && \
-  pip install "pytype==2021.10.25" && \
+  pip install "pytype==2021.12.8" && \
   pytype slack_bolt/

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ test_dependencies = [
     "pytest-cov>=3,<4",
     "Flask-Sockets>=0.2,<1",
     "Werkzeug<2",  # TODO: support Flask 2.x
-    "black==21.10b0",
+    "black==21.12b0",
 ]
 
 async_test_dependencies = test_dependencies + [

--- a/slack_bolt/adapter/falcon/resource.py
+++ b/slack_bolt/adapter/falcon/resource.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime  # type: ignore
 from http import HTTPStatus
 
 from falcon import Request, Response

--- a/slack_bolt/adapter/sanic/async_handler.py
+++ b/slack_bolt/adapter/sanic/async_handler.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime  # type: ignore
 
 from sanic.request import Request
 from sanic.response import HTTPResponse

--- a/slack_bolt/adapter/tornado/handler.py
+++ b/slack_bolt/adapter/tornado/handler.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime  # type: ignore
 
 from tornado.httputil import HTTPServerRequest
 from tornado.web import RequestHandler

--- a/slack_bolt/context/base_context.py
+++ b/slack_bolt/context/base_context.py
@@ -1,3 +1,6 @@
+# pytype: skip-file
+# Note: Since 2021.12.8, the pytype code analyzer does not properly work for this file
+
 from logging import Logger
 from typing import Optional, Tuple
 


### PR DESCRIPTION
This pull request upgrades the following dev tool versions:

* pytype
* black

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
