### PR TITLE
Add support for socket mode request body's for python 3.6+

### DIFF
--- a/slack_bolt/request/request.py
+++ b/slack_bolt/request/request.py
@@ -1,3 +1,5 @@
+import json
+import sys
 from typing import Dict, Optional, Union, Any, Sequence
 
 from slack_bolt.context.context import BoltContext
@@ -50,9 +52,16 @@ class BoltRequest:
             # Socket Mode
             if body is not None and isinstance(body, str):
                 self.raw_body = body
+            # After Python 3.7, dicts in all Python versions will preserve insertion order.
+            elif (
+                body is not None
+                and isinstance(body, dict)
+                and sys.version_info >= (3, 6)
+            ):
+                self.raw_body = json.dumps(body)
+            # Prior to Python 3.6, we can't convert the dict value to str while guaranteeing preservation of the
+            # original structure/format.
             else:
-                # We don't convert the dict value to str
-                # as doing so does not guarantee to keep the original structure/format.
                 self.raw_body = ""
 
         self.query = parse_query(query)


### PR DESCRIPTION
### Category

* [x] `slack_bolt.App` and/or its core components (`slack_bolt.BoltRequest`)
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.

This PR will resolve issue #552 

Results after running all tests before changes:
![image](https://user-images.githubusercontent.com/34385202/147299753-0ce3597a-2eba-42c2-93d9-afa2f3eae7a6.png)

Results after running all tests after changes:
![image](https://user-images.githubusercontent.com/34385202/147299426-c1f0985c-5756-4a9c-b4bd-0d75babfce94.png)
