### PR TITLE
Fix #552 Unable to use request body with lazy listener when socket mode is enabled

### DIFF
--- a/slack_bolt/request/async_request.py
+++ b/slack_bolt/request/async_request.py
@@ -77,8 +77,9 @@ class AsyncBoltRequest:
         self.mode = mode
 
     def to_copyable(self) -> "AsyncBoltRequest":
+        body: Union[str, dict] = self.raw_body if self.mode == "http" else self.body
         return AsyncBoltRequest(
-            body=self.raw_body,
+            body=body,
             query=self.query,
             headers=self.headers,
             context=self.context.to_copyable(),

--- a/slack_bolt/request/request.py
+++ b/slack_bolt/request/request.py
@@ -74,8 +74,9 @@ class BoltRequest:
         self.mode = mode
 
     def to_copyable(self) -> "BoltRequest":
+        body: Union[str, dict] = self.raw_body if self.mode == "http" else self.body
         return BoltRequest(
-            body=self.raw_body,
+            body=body,
             query=self.query,
             headers=self.headers,
             context=self.context.to_copyable(),

--- a/tests/adapter_tests/socket_mode/test_lazy_listeners.py
+++ b/tests/adapter_tests/socket_mode/test_lazy_listeners.py
@@ -1,0 +1,79 @@
+import logging
+import time
+
+from slack_sdk import WebClient
+
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+from .mock_socket_mode_server import (
+    start_socket_mode_server,
+    stop_socket_mode_server,
+)
+from .mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from ...utils import remove_os_env_temporarily, restore_os_env
+
+
+class TestSocketModeLazyListeners:
+    logger = logging.getLogger(__name__)
+
+    def setup_method(self):
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
+        self.web_client = WebClient(
+            token="xoxb-api_test",
+            base_url="http://localhost:8888",
+        )
+        start_socket_mode_server(self, 3011)
+        time.sleep(2)  # wait for the server
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
+        stop_socket_mode_server(self)
+
+    def test_lazy_listener_calls(self):
+
+        app = App(client=self.web_client)
+
+        result = {"lazy_called": False}
+
+        @app.shortcut("do-something")
+        def handle_shortcuts(ack):
+            ack()
+
+        @app.event("message")
+        def handle_message_events(body, logger):
+            logger.info(body)
+
+        def lazy_func(body):
+            assert body.get("command") == "/hello-socket-mode"
+            result["lazy_called"] = True
+
+        app.command("/hello-socket-mode")(
+            ack=lambda ack: ack(),
+            lazy=[lazy_func],
+        )
+
+        handler = SocketModeHandler(
+            app_token="xapp-A111-222-xyz",
+            app=app,
+            trace_enabled=True,
+        )
+        try:
+            handler.client.wss_uri = "ws://127.0.0.1:3011/link"
+            handler.connect()
+            assert handler.client.is_connected() is True
+            time.sleep(2)  # wait for the message receiver
+            handler.client.send_message("foo")
+
+            spent_time = 0
+            while spent_time < 5 and result["lazy_called"] is False:
+                spent_time += 0.5
+                time.sleep(0.5)
+            assert result["lazy_called"] is True
+
+        finally:
+            handler.client.close()

--- a/tests/adapter_tests_async/socket_mode/test_async_lazy_listeners.py
+++ b/tests/adapter_tests_async/socket_mode/test_async_lazy_listeners.py
@@ -1,0 +1,84 @@
+import asyncio
+
+import pytest
+from slack_sdk.web.async_client import AsyncWebClient
+
+from slack_bolt.adapter.socket_mode.aiohttp import AsyncSocketModeHandler
+from slack_bolt.app.async_app import AsyncApp
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+from ...adapter_tests.socket_mode.mock_socket_mode_server import (
+    start_socket_mode_server,
+    stop_socket_mode_server_async,
+)
+
+
+class TestSocketModeAiohttp:
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    web_client = AsyncWebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    @pytest.fixture
+    def event_loop(self):
+        old_os_env = remove_os_env_temporarily()
+        try:
+            setup_mock_web_api_server(self)
+            loop = asyncio.get_event_loop()
+            yield loop
+            loop.close()
+            cleanup_mock_web_api_server(self)
+        finally:
+            restore_os_env(old_os_env)
+
+    @pytest.mark.asyncio
+    async def test_lazy_listeners(self):
+        start_socket_mode_server(self, 3021)
+        await asyncio.sleep(1)  # wait for the server
+
+        app = AsyncApp(client=self.web_client)
+
+        result = {"lazy_called": False}
+
+        @app.shortcut("do-something")
+        async def shortcut_handler(ack):
+            await ack()
+
+        @app.event("message")
+        async def handle_message_events(body, logger):
+            logger.info(body)
+
+        async def just_ack(ack):
+            await ack()
+
+        async def lazy_func(body):
+            assert body.get("command") == "/hello-socket-mode"
+            result["lazy_called"] = True
+
+        app.command("/hello-socket-mode")(ack=just_ack, lazy=[lazy_func])
+
+        handler = AsyncSocketModeHandler(
+            app_token="xapp-A111-222-xyz",
+            app=app,
+        )
+        try:
+            handler.client.wss_uri = "ws://localhost:3021/link"
+
+            await handler.connect_async()
+            await asyncio.sleep(2)  # wait for the message receiver
+            await handler.client.send_message("foo")
+
+            spent_time = 0
+            while spent_time < 5 and result["lazy_called"] is False:
+                spent_time += 0.5
+                await asyncio.sleep(0.5)
+            assert result["lazy_called"] is True
+
+        finally:
+            await handler.client.close()
+            await stop_socket_mode_server_async(self)


### PR DESCRIPTION
This pull request resolves #552, which is a regression bug since v1.11.0.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
