### PR TITLE
Improve the built-in authorize for better support of user-scope only installations

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -231,6 +231,7 @@ class App:
                 client_secret=settings.client_secret if settings is not None else None,
                 logger=self._framework_logger,
                 bot_only=installation_store_bot_only,
+                client=self._client,  # for proxy use cases etc.
             )
 
         self._oauth_flow: Optional[OAuthFlow] = None

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -239,6 +239,7 @@ class AsyncApp:
                 client_secret=settings.client_secret if settings is not None else None,
                 logger=self._framework_logger,
                 bot_only=installation_store_bot_only,
+                client=self._async_client,  # for proxy use cases etc.
             )
 
         self._async_oauth_flow: Optional[AsyncOAuthFlow] = None

--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -8,6 +8,7 @@ from slack_sdk.oauth.installation_store.async_installation_store import (
     AsyncInstallationStore,
 )
 from slack_sdk.oauth.token_rotation.async_rotator import AsyncTokenRotator
+from slack_sdk.web.async_client import AsyncWebClient
 
 from slack_bolt.authorization.async_authorize_args import AsyncAuthorizeArgs
 from slack_bolt.authorization import AuthorizeResult
@@ -124,6 +125,7 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
         # use only InstallationStore#find_bot(enterprise_id, team_id)
         bot_only: bool = False,
         cache_enabled: bool = False,
+        client: Optional[AsyncWebClient] = None,
     ):
         self.logger = logger
         self.installation_store = installation_store
@@ -136,6 +138,7 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
             self.token_rotator = AsyncTokenRotator(
                 client_id=client_id,
                 client_secret=client_secret,
+                client=client,
             )
         else:
             self.token_rotator = None

--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -180,6 +180,9 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
                 )
                 # If the user_token in the latest_installation is not for the user associated with this request,
                 # we'll fetch a different installation for the user below
+                # The example use cases are:
+                # - The app's installation requires both bot and user tokens
+                # - The app has two installation paths 1) bot installation 2) individual user authorization
                 this_user_installation: Optional[Installation] = None
 
                 if latest_installation is not None:

--- a/slack_bolt/authorization/authorize.py
+++ b/slack_bolt/authorization/authorize.py
@@ -179,7 +179,10 @@ class InstallationStoreAuthorize(Authorize):
                     is_enterprise_install=context.is_enterprise_install,
                 )
                 # If the user_token in the latest_installation is not for the user associated with this request,
-                # we'll fetch a different installation for the user below
+                # we'll fetch a different installation for the user below.
+                # The example use cases are:
+                # - The app's installation requires both bot and user tokens
+                # - The app has two installation paths 1) bot installation 2) individual user authorization
                 this_user_installation: Optional[Installation] = None
 
                 if latest_installation is not None:

--- a/slack_bolt/authorization/authorize.py
+++ b/slack_bolt/authorization/authorize.py
@@ -4,7 +4,7 @@ from typing import Optional, Callable, Dict, Any
 
 from slack_sdk.errors import SlackApiError
 from slack_sdk.oauth import InstallationStore
-from slack_sdk.oauth.installation_store import Bot
+from slack_sdk.oauth.installation_store.models.bot import Bot
 from slack_sdk.oauth.installation_store.models.installation import Installation
 from slack_sdk.oauth.token_rotation.rotator import TokenRotator
 
@@ -33,8 +33,8 @@ class Authorize:
 
 
 class CallableAuthorize(Authorize):
-    """When you pass the authorize argument in AsyncApp constructor,
-    This authorize implementation will be used.
+    """When you pass the `authorize` argument in AsyncApp constructor,
+    This `authorize` implementation will be used.
     """
 
     def __init__(
@@ -102,9 +102,9 @@ class CallableAuthorize(Authorize):
 
 
 class InstallationStoreAuthorize(Authorize):
-    """If you use the OAuth flow settings, this authorize implementation will be used.
+    """If you use the OAuth flow settings, this `authorize` implementation will be used.
     As long as your own InstallationStore (or the built-in ones) works as you expect,
-    you can expect that the authorize layer should work for you without any customization.
+    you can expect that the `authorize` layer should work for you without any customization.
     """
 
     authorize_result_cache: Dict[str, AuthorizeResult]
@@ -168,61 +168,75 @@ class InstallationStoreAuthorize(Authorize):
             try:
                 # Note that this is the latest information for the org/workspace.
                 # The installer may not be the user associated with this incoming request.
-                installation: Optional[
+                latest_installation: Optional[
                     Installation
                 ] = self.installation_store.find_installation(
                     enterprise_id=enterprise_id,
                     team_id=team_id,
                     is_enterprise_install=context.is_enterprise_install,
                 )
-                if installation is not None:
-                    if installation.user_id != user_id:
+                # If the user_token in the latest_installation is not for the user associated with this request,
+                # we'll fetch a different installation for the user below
+                this_user_installation: Optional[Installation] = None
+
+                if latest_installation is not None:
+                    # Save the latest bot token
+                    bot_token = latest_installation.bot_token  # this still can be None
+                    user_token = (
+                        latest_installation.user_token
+                    )  # this still can be None
+
+                    if latest_installation.user_id != user_id:
                         # First off, remove the user token as the installer is a different user
-                        installation.user_token = None
-                        installation.user_scopes = []
+                        latest_installation.user_token = None
+                        latest_installation.user_scopes = []
 
                         # try to fetch the request user's installation
                         # to reflect the user's access token if exists
-                        user_installation = self.installation_store.find_installation(
-                            enterprise_id=enterprise_id,
-                            team_id=team_id,
-                            user_id=user_id,
-                            is_enterprise_install=context.is_enterprise_install,
-                        )
-                        if user_installation is not None:
-                            # Overwrite the installation with the one for this user
-                            installation = user_installation
-
-                    bot_token, user_token = (
-                        installation.bot_token,
-                        installation.user_token,
-                    )
-                    if (
-                        installation.user_refresh_token is not None
-                        or installation.bot_refresh_token is not None
-                    ):
-                        if self.token_rotator is None:
-                            raise BoltError(self._config_error_message)
-                        refreshed = self.token_rotator.perform_token_rotation(
-                            installation=installation,
-                            minutes_before_expiration=self.token_rotation_expiration_minutes,
-                        )
-                        if refreshed is not None:
-                            self.installation_store.save(refreshed)
-                            bot_token, user_token = (
-                                refreshed.bot_token,
-                                refreshed.user_token,
+                        this_user_installation = (
+                            self.installation_store.find_installation(
+                                enterprise_id=enterprise_id,
+                                team_id=team_id,
+                                user_id=user_id,
+                                is_enterprise_install=context.is_enterprise_install,
                             )
+                        )
+                        if this_user_installation is not None:
+                            user_token = this_user_installation.user_token
+                            if latest_installation.bot_token is None:
+                                # If latest_installation has a bot token, we never overwrite the value
+                                bot_token = this_user_installation.bot_token
+
+                            # If token rotation is enabled, running rotation may be needed here
+                            refreshed = self._rotate_and_save_tokens_if_necessary(
+                                this_user_installation
+                            )
+                            if refreshed is not None:
+                                user_token = refreshed.user_token
+                                if latest_installation.bot_token is None:
+                                    # If latest_installation has a bot token, we never overwrite the value
+                                    bot_token = refreshed.bot_token
+
+                    # If token rotation is enabled, running rotation may be needed here
+                    refreshed = self._rotate_and_save_tokens_if_necessary(
+                        latest_installation
+                    )
+                    if refreshed is not None:
+                        bot_token = refreshed.bot_token
+                        if this_user_installation is None:
+                            # Only when we don't have `this_user_installation` here,
+                            # the `user_token` is for the user associated with this request
+                            user_token = refreshed.user_token
 
             except NotImplementedError as _:
                 self.find_installation_available = False
 
         if (
-            # If you intentionally use only find_bot / delete_bot,
+            # If you intentionally use only `find_bot` / `delete_bot`,
             self.bot_only
-            # If find_installation method is not available,
+            # If the `find_installation` method is not available,
             or not self.find_installation_available
-            # If find_installation did not return data and find_bot method is available,
+            # If the `find_installation` method did not return data and find_bot method is available,
             or (
                 self.find_bot_available is True
                 and bot_token is None
@@ -290,3 +304,26 @@ class InstallationStoreAuthorize(Authorize):
             "No installation data found "
             f"for enterprise_id: {enterprise_id} team_id: {team_id}"
         )
+
+    def _rotate_and_save_tokens_if_necessary(
+        self, installation: Optional[Installation]
+    ) -> Optional[Installation]:
+        if installation is None or (
+            installation.user_refresh_token is None
+            and installation.bot_refresh_token is None
+        ):
+            # No need to rotate tokens
+            return None
+
+        if self.token_rotator is None:
+            # Token rotation is required but this Bolt app is not properly configured
+            raise BoltError(self._config_error_message)
+
+        refreshed: Optional[Installation] = self.token_rotator.perform_token_rotation(
+            installation=installation,
+            minutes_before_expiration=self.token_rotation_expiration_minutes,
+        )
+        if refreshed is not None:
+            # Save the refreshed data in database for following requests
+            self.installation_store.save(refreshed)
+        return refreshed

--- a/slack_bolt/authorization/authorize.py
+++ b/slack_bolt/authorization/authorize.py
@@ -7,6 +7,7 @@ from slack_sdk.oauth import InstallationStore
 from slack_sdk.oauth.installation_store.models.bot import Bot
 from slack_sdk.oauth.installation_store.models.installation import Installation
 from slack_sdk.oauth.token_rotation.rotator import TokenRotator
+from slack_sdk.web import WebClient
 
 from slack_bolt.authorization.authorize_args import AuthorizeArgs
 from slack_bolt.authorization.authorize_result import AuthorizeResult
@@ -129,6 +130,7 @@ class InstallationStoreAuthorize(Authorize):
         # use only InstallationStore#find_bot(enterprise_id, team_id)
         bot_only: bool = False,
         cache_enabled: bool = False,
+        client: Optional[WebClient] = None,
     ):
         self.logger = logger
         self.installation_store = installation_store
@@ -143,6 +145,7 @@ class InstallationStoreAuthorize(Authorize):
             self.token_rotator = TokenRotator(
                 client_id=client_id,
                 client_secret=client_secret,
+                client=client,
             )
         else:
             self.token_rotator = None

--- a/tests/slack_bolt/authorization/test_authorize.py
+++ b/tests/slack_bolt/authorization/test_authorize.py
@@ -10,6 +10,7 @@ from slack_sdk.oauth.installation_store import Bot, Installation
 
 from slack_bolt import BoltContext
 from slack_bolt.authorization.authorize import InstallationStoreAuthorize, Authorize
+from slack_bolt.error import BoltError
 from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     setup_mock_web_api_server,
@@ -211,6 +212,39 @@ class TestAuthorize:
         assert result.user_token == "xoxp-valid"
         assert_auth_test_count(self, 1)
 
+    def test_fetch_different_user_token_with_rotation(self):
+        context = BoltContext()
+        mock_client = WebClient(base_url=self.mock_api_server_base_url)
+        context["client"] = mock_client
+
+        installation_store = ValidUserTokenRotationInstallationStore()
+        invalid_authorize = InstallationStoreAuthorize(
+            logger=installation_store.logger, installation_store=installation_store
+        )
+        with pytest.raises(BoltError):
+            invalid_authorize(
+                context=context,
+                enterprise_id="E111",
+                team_id="T0G9PQBBK",
+                user_id="W222",
+            )
+
+        authorize = InstallationStoreAuthorize(
+            client_id="111.222",
+            client_secret="secret",
+            client=mock_client,
+            logger=installation_store.logger,
+            installation_store=installation_store,
+        )
+        result = authorize(
+            context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W222"
+        )
+        assert result.bot_id == "BZYBOTHED"
+        assert result.bot_user_id == "W23456789"
+        assert result.bot_token == "xoxb-valid-refreshed"
+        assert result.user_token == "xoxp-valid-refreshed"
+        assert_auth_test_count(self, 1)
+
 
 class LegacyMemoryInstallationStore(InstallationStore):
     @property
@@ -312,6 +346,54 @@ class ValidUserTokenInstallationStore(InstallationStore):
                 team_id="T0G9PQBBK",
                 user_id="W222",
                 user_token="xoxp-valid",
+                user_scopes=["search:read"],
+                installed_at=datetime.datetime.now().timestamp(),
+            )
+
+
+class ValidUserTokenRotationInstallationStore(InstallationStore):
+    @property
+    def logger(self) -> Logger:
+        return logging.getLogger(__name__)
+
+    def save(self, installation: Installation):
+        pass
+
+    def find_installation(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        user_id: Optional[str] = None,
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Installation]:
+        if user_id is None:
+            return Installation(
+                app_id="A111",
+                enterprise_id="E111",
+                team_id="T0G9PQBBK",
+                bot_token="xoxb-valid",
+                bot_refresh_token="xoxe-bot-valid",
+                bot_token_expires_in=-10,
+                bot_id="B",
+                bot_user_id="W",
+                bot_scopes=["commands", "chat:write"],
+                user_id="W11111",
+                user_token="xoxp-different-installer",
+                user_refresh_token="xoxe-1-user-valid",
+                user_token_expires_in=-10,
+                user_scopes=["search:read"],
+                installed_at=datetime.datetime.now().timestamp(),
+            )
+        elif user_id == "W222":
+            return Installation(
+                app_id="A111",
+                enterprise_id="E111",
+                team_id="T0G9PQBBK",
+                user_id="W222",
+                user_token="xoxp-valid",
+                user_refresh_token="xoxe-1-user-valid",
+                user_token_expires_in=-10,
                 user_scopes=["search:read"],
                 installed_at=datetime.datetime.now().timestamp(),
             )

--- a/tests/slack_bolt_async/authorization/test_async_authorize.py
+++ b/tests/slack_bolt_async/authorization/test_async_authorize.py
@@ -220,6 +220,23 @@ class TestAsyncAuthorize:
         assert result.user_token == "xoxp-valid"
         await assert_auth_test_count_async(self, 1)  # cached
 
+    @pytest.mark.asyncio
+    async def test_fetch_different_user_token(self):
+        installation_store = ValidUserTokenInstallationStore()
+        authorize = AsyncInstallationStoreAuthorize(
+            logger=installation_store.logger, installation_store=installation_store
+        )
+        context = AsyncBoltContext()
+        context["client"] = AsyncWebClient(base_url=self.mock_api_server_base_url)
+        result = await authorize(
+            context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W222"
+        )
+        assert result.bot_id == "BZYBOTHED"
+        assert result.bot_user_id == "W23456789"
+        assert result.bot_token == "xoxb-valid"
+        assert result.user_token == "xoxp-valid"
+        await assert_auth_test_count_async(self, 1)
+
 
 class LegacyMemoryInstallationStore(AsyncInstallationStore):
     @property
@@ -282,3 +299,45 @@ class BotOnlyMemoryInstallationStore(LegacyMemoryInstallationStore):
         is_enterprise_install: Optional[bool] = False,
     ) -> Optional[Installation]:
         raise ValueError
+
+
+class ValidUserTokenInstallationStore(AsyncInstallationStore):
+    @property
+    def logger(self) -> Logger:
+        return logging.getLogger(__name__)
+
+    async def async_save(self, installation: Installation):
+        pass
+
+    async def async_find_installation(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        user_id: Optional[str] = None,
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Installation]:
+        if user_id is None:
+            return Installation(
+                app_id="A111",
+                enterprise_id="E111",
+                team_id="T0G9PQBBK",
+                bot_token="xoxb-valid",
+                bot_id="B",
+                bot_user_id="W",
+                bot_scopes=["commands", "chat:write"],
+                user_id="W11111",
+                user_token="xoxp-different-installer",
+                user_scopes=["search:read"],
+                installed_at=datetime.datetime.now().timestamp(),
+            )
+        elif user_id == "W222":
+            return Installation(
+                app_id="A111",
+                enterprise_id="E111",
+                team_id="T0G9PQBBK",
+                user_id="W222",
+                user_token="xoxp-valid",
+                user_scopes=["search:read"],
+                installed_at=datetime.datetime.now().timestamp(),
+            )

--- a/tests/slack_bolt_async/authorization/test_async_authorize.py
+++ b/tests/slack_bolt_async/authorization/test_async_authorize.py
@@ -16,6 +16,7 @@ from slack_bolt.authorization.async_authorize import (
     AsyncAuthorize,
 )
 from slack_bolt.context.async_context import AsyncBoltContext
+from slack_bolt.error import BoltError
 from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
@@ -237,6 +238,40 @@ class TestAsyncAuthorize:
         assert result.user_token == "xoxp-valid"
         await assert_auth_test_count_async(self, 1)
 
+    @pytest.mark.asyncio
+    async def test_fetch_different_user_token_with_rotation(self):
+        context = AsyncBoltContext()
+        mock_client = AsyncWebClient(base_url=self.mock_api_server_base_url)
+        context["client"] = mock_client
+
+        installation_store = ValidUserTokenRotationInstallationStore()
+        invalid_authorize = AsyncInstallationStoreAuthorize(
+            logger=installation_store.logger, installation_store=installation_store
+        )
+        with pytest.raises(BoltError):
+            await invalid_authorize(
+                context=context,
+                enterprise_id="E111",
+                team_id="T0G9PQBBK",
+                user_id="W222",
+            )
+
+        authorize = AsyncInstallationStoreAuthorize(
+            client_id="111.222",
+            client_secret="secret",
+            client=mock_client,
+            logger=installation_store.logger,
+            installation_store=installation_store,
+        )
+        result = await authorize(
+            context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W222"
+        )
+        assert result.bot_id == "BZYBOTHED"
+        assert result.bot_user_id == "W23456789"
+        assert result.bot_token == "xoxb-valid-refreshed"
+        assert result.user_token == "xoxp-valid-refreshed"
+        await assert_auth_test_count_async(self, 1)
+
 
 class LegacyMemoryInstallationStore(AsyncInstallationStore):
     @property
@@ -338,6 +373,54 @@ class ValidUserTokenInstallationStore(AsyncInstallationStore):
                 team_id="T0G9PQBBK",
                 user_id="W222",
                 user_token="xoxp-valid",
+                user_scopes=["search:read"],
+                installed_at=datetime.datetime.now().timestamp(),
+            )
+
+
+class ValidUserTokenRotationInstallationStore(AsyncInstallationStore):
+    @property
+    def logger(self) -> Logger:
+        return logging.getLogger(__name__)
+
+    async def async_save(self, installation: Installation):
+        pass
+
+    async def async_find_installation(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        user_id: Optional[str] = None,
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Installation]:
+        if user_id is None:
+            return Installation(
+                app_id="A111",
+                enterprise_id="E111",
+                team_id="T0G9PQBBK",
+                bot_token="xoxb-valid",
+                bot_refresh_token="xoxe-bot-valid",
+                bot_token_expires_in=-10,
+                bot_id="B",
+                bot_user_id="W",
+                bot_scopes=["commands", "chat:write"],
+                user_id="W11111",
+                user_token="xoxp-different-installer",
+                user_refresh_token="xoxe-1-user-valid",
+                user_token_expires_in=-10,
+                user_scopes=["search:read"],
+                installed_at=datetime.datetime.now().timestamp(),
+            )
+        elif user_id == "W222":
+            return Installation(
+                app_id="A111",
+                enterprise_id="E111",
+                team_id="T0G9PQBBK",
+                user_id="W222",
+                user_token="xoxp-valid",
+                user_refresh_token="xoxe-1-user-valid",
+                user_token_expires_in=-10,
                 user_scopes=["search:read"],
                 installed_at=datetime.datetime.now().timestamp(),
             )


### PR DESCRIPTION
While answering the question at https://github.com/slackapi/bolt-python/issues/574, I found that there is room for improvement in the `InstallationStoreAuthorize` module. This pull request improves the internals to cover the following situation:

* An app has two paths of app installations
  * App installation with bot scopes (plus user scopes is optional) `/slack/install`
  * User scope installation with individual users `/slack/user_install` 
* The admin user A installed the app into the workspace with bot token and the person's user scopes
* End-user B installed the app to grant user scopes to the app from `/slack/user_install`
* The app receives an incoming request associated with user B

In this scenario, the `authorize` function should return the bot token generated by admin user A plus the user B's user token in `AuthorizeResult`. However, the current implementation returns only user B's user token.

This pull request resolves the issue, plus improved the readability of the code by renaming local variables and adding more comments.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
