### PR TITLE
Fix #468 Replying with 0 results for a multi-select external option display previous successful results

### DIFF
--- a/slack_bolt/context/ack/internals.py
+++ b/slack_bolt/context/ack/internals.py
@@ -42,10 +42,10 @@ def _set_response(
         elif blocks and len(blocks) > 0:
             body.update({"text": text, "blocks": convert_to_dict_list(blocks)})
             self.response = BoltResponse(status=200, body=body)
-        elif options and len(options) > 0:
+        elif options is not None:
             body = {"options": convert_to_dict_list(options)}
             self.response = BoltResponse(status=200, body=body)
-        elif option_groups and len(option_groups) > 0:
+        elif option_groups is not None:
             body = {"option_groups": convert_to_dict_list(option_groups)}
             self.response = BoltResponse(status=200, body=body)
         elif response_action:

--- a/tests/scenario_tests/test_block_suggestion.py
+++ b/tests/scenario_tests/test_block_suggestion.py
@@ -180,6 +180,34 @@ class TestBlockSuggestion:
         assert response.status == 404
         assert_auth_test_count(self, 1)
 
+    def test_empty_options(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        app.options("mes_a")(show_empty_options)
+
+        request = self.build_valid_multi_request()
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert response.body == """{"options": []}"""
+        assert response.headers["content-type"][0] == "application/json;charset=utf-8"
+        assert_auth_test_count(self, 1)
+
+    def test_empty_option_groups(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        app.options("mes_a")(show_empty_option_groups)
+
+        request = self.build_valid_multi_request()
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert response.body == """{"option_groups": []}"""
+        assert response.headers["content-type"][0] == "application/json;charset=utf-8"
+        assert_auth_test_count(self, 1)
+
 
 body = {
     "type": "block_suggestion",
@@ -296,3 +324,15 @@ def show_multi_options(ack, body, payload, options):
     assert body == options
     assert payload == options
     ack(multi_response)
+
+
+def show_empty_options(ack, body, payload, options):
+    assert body == options
+    assert payload == options
+    ack(options=[])
+
+
+def show_empty_option_groups(ack, body, payload, options):
+    assert body == options
+    assert payload == options
+    ack(option_groups=[])

--- a/tests/scenario_tests_async/test_block_suggestion.py
+++ b/tests/scenario_tests_async/test_block_suggestion.py
@@ -195,6 +195,36 @@ class TestAsyncBlockSuggestion:
         assert response.status == 404
         await assert_auth_test_count_async(self, 1)
 
+    @pytest.mark.asyncio
+    async def test_empty_options(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        app.options("mes_a")(show_empty_options)
+
+        request = self.build_valid_multi_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert response.body == """{"options": []}"""
+        assert response.headers["content-type"][0] == "application/json;charset=utf-8"
+        await assert_auth_test_count_async(self, 1)
+
+    @pytest.mark.asyncio
+    async def test_empty_option_groups(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        app.options("mes_a")(show_empty_option_groups)
+
+        request = self.build_valid_multi_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert response.body == """{"option_groups": []}"""
+        assert response.headers["content-type"][0] == "application/json;charset=utf-8"
+        await assert_auth_test_count_async(self, 1)
+
 
 body = {
     "type": "block_suggestion",
@@ -311,3 +341,15 @@ async def show_multi_options(ack, body, payload, options):
     assert body == options
     assert payload == options
     await ack(multi_response)
+
+
+async def show_empty_options(ack, body, payload, options):
+    assert body == options
+    assert payload == options
+    await ack(options=[])
+
+
+async def show_empty_option_groups(ack, body, payload, options):
+    assert body == options
+    assert payload == options
+    await ack(option_groups=[])


### PR DESCRIPTION
This pull request resolves #468, which is a bolt-python bug for a long time.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
