### PR TITLE
user_token now set to None for new user without installation - #584

### DIFF
--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -207,7 +207,9 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
                                 is_enterprise_install=context.is_enterprise_install,
                             )
                         )
+
                         if this_user_installation is not None:
+
                             user_token = this_user_installation.user_token
                             if latest_installation.bot_token is None:
                                 # If latest_installation has a bot token, we never overwrite the value
@@ -222,6 +224,12 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
                                 if latest_installation.bot_token is None:
                                     # If latest_installation has a bot token, we never overwrite the value
                                     bot_token = refreshed.bot_token
+                    
+                        # Handle when user has no installations (ie. when this_user_installation returns None)
+                        # ensures user_token isn't passed to the wrong user
+                        else:
+                            user_token = None
+
 
                     # If token rotation is enabled, running rotation may be needed here
                     refreshed = await self._rotate_and_save_tokens_if_necessary(

--- a/slack_bolt/authorization/authorize.py
+++ b/slack_bolt/authorization/authorize.py
@@ -222,6 +222,11 @@ class InstallationStoreAuthorize(Authorize):
                                 if latest_installation.bot_token is None:
                                     # If latest_installation has a bot token, we never overwrite the value
                                     bot_token = refreshed.bot_token
+                        
+                        # Handle when user has no installations (ie. when this_user_installation returns None)
+                        # ensures user_token isn't passed to the wrong user
+                        else:
+                            user_token = None
 
                     # If token rotation is enabled, running rotation may be needed here
                     refreshed = self._rotate_and_save_tokens_if_necessary(


### PR DESCRIPTION
This is for issue #584 

After updating to v1.11.3 I was experiencing that the user token was not being reassigned to `None` if the requesting user has not yet had an installation. This fix was part of issue [#576](https://github.com/slackapi/bolt-python/pull/576).

This update simply adds an `else` statement and ensures `user_token` is `None` if the user has no installations (ie. `this_user_installation` returns `None`)

### Category (place an `x` in each of the `[ ]`)

* [ x] `slack_bolt.App` and/or its core components
* [x ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [ x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.

The tests failed on my Mac - some M1 chip errors.