### PR TITLE
Fix #584 Wrong user_token assigned to new user (affected versions: v1.11.2, v1.11.3)

### DIFF
--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -194,7 +194,10 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
 
                     if latest_installation.user_id != user_id:
                         # First off, remove the user token as the installer is a different user
+                        user_token = None
                         latest_installation.user_token = None
+                        latest_installation.user_refresh_token = None
+                        latest_installation.user_token_expires_at = None
                         latest_installation.user_scopes = []
 
                         # try to fetch the request user's installation

--- a/slack_bolt/authorization/authorize.py
+++ b/slack_bolt/authorization/authorize.py
@@ -194,7 +194,10 @@ class InstallationStoreAuthorize(Authorize):
 
                     if latest_installation.user_id != user_id:
                         # First off, remove the user token as the installer is a different user
+                        user_token = None
                         latest_installation.user_token = None
+                        latest_installation.user_refresh_token = None
+                        latest_installation.user_token_expires_at = None
                         latest_installation.user_scopes = []
 
                         # try to fetch the request user's installation

--- a/tests/mock_web_api_server.py
+++ b/tests/mock_web_api_server.py
@@ -155,19 +155,21 @@ class MockHandler(SimpleHTTPRequestHandler):
                     self.logger.info(f"request body: {request_body}")
 
                     if request_body.get("grant_type") == "refresh_token":
-                        if "bot-valid" in request_body.get("refresh_token"):
-                            self.send_response(200)
-                            self.set_common_headers()
-                            body = self.oauth_v2_access_bot_refresh_response
-                            self.wfile.write(body.encode("utf-8"))
-                            return
-                        if "user-valid" in request_body.get("refresh_token"):
-                            self.send_response(200)
-                            self.set_common_headers()
-                            body = self.oauth_v2_access_user_refresh_response
-                            self.wfile.write(body.encode("utf-8"))
-                            return
-                    if request_body.get("code") is not None:
+                        refresh_token = request_body.get("refresh_token")
+                        if refresh_token is not None:
+                            if "bot-valid" in refresh_token:
+                                self.send_response(200)
+                                self.set_common_headers()
+                                body = self.oauth_v2_access_bot_refresh_response
+                                self.wfile.write(body.encode("utf-8"))
+                                return
+                            if "user-valid" in refresh_token:
+                                self.send_response(200)
+                                self.set_common_headers()
+                                body = self.oauth_v2_access_user_refresh_response
+                                self.wfile.write(body.encode("utf-8"))
+                                return
+                    elif request_body.get("code") is not None:
                         self.send_response(200)
                         self.set_common_headers()
                         self.wfile.write(self.oauth_v2_access_response.encode("utf-8"))


### PR DESCRIPTION
This pull request resolves #584 

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
