### PR TITLE
Upgrade test dependencies & fix Falcon warning

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -89,6 +89,7 @@ If you make changes to `slack_bolt/adapter/*`, please verify if it surely works 
 ```bash
 # Install all optional dependencies
 $ pip install -e ".[adapter]"
+$ pip install -e ".[adapter_testing]"
 
 # Set required env variables
 $ export SLACK_SIGNING_SECRET=***

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -29,6 +29,7 @@ jobs:
         pip install -e ".[async]"
         pip install -e ".[adapter]"
         pip install -e ".[testing]"
+        pip install -e ".[adapter_testing]"
     - name: Run all tests for codecov
       run: |
         pytest --cov=slack_bolt/ && bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Run tests for Socket Mode adapters
       run: |
         pip install -e ".[adapter]"
+        pip install -e ".[adapter_testing]"
         pytest tests/adapter_tests/socket_mode/
     - name: Run tests for HTTP Mode adapters (AWS)
       run: |
@@ -47,8 +48,12 @@ jobs:
     - name: Run tests for HTTP Mode adapters (Django)
       run: |
         pytest tests/adapter_tests/django/
-    - name: Run tests for HTTP Mode adapters (Falcon)
+    - name: Run tests for HTTP Mode adapters (Falcon 3.x)
       run: |
+        pytest tests/adapter_tests/falcon/
+    - name: Run tests for HTTP Mode adapters (Falcon 2.x)
+      run: |
+        pip install "falcon<3"
         pytest tests/adapter_tests/falcon/
     - name: Run tests for HTTP Mode adapters (Flask)
       run: |

--- a/scripts/install_all_and_run_tests.sh
+++ b/scripts/install_all_and_run_tests.sh
@@ -15,13 +15,23 @@ pip install -e .
 
 if [[ $test_target != "" ]]
 then
-  pip install -e ".[testing]" && \
+  # To fix: Using legacy 'setup.py install' for greenlet, since package 'wheel' is not installed.
+  pip install -U wheel && \
+    pip install -e ".[testing]" && \
     pip install -e ".[adapter]" && \
+    pip install -e ".[adapter_testing]" && \
+    # To avoid errors due to the old versions of click forced by Chalice
+    pip install -U pip click && \
     black slack_bolt/ tests/ && \
     pytest $1
 else
-  pip install -e ".[testing]" && \
+  # To fix: Using legacy 'setup.py install' for greenlet, since package 'wheel' is not installed.
+  pip install -U wheel && \
+    pip install -e ".[testing]" && \
     pip install -e ".[adapter]" && \
+    pip install -e ".[adapter_testing]" && \
+    # To avoid errors due to the old versions of click forced by Chalice
+    pip install -U pip click && \
     black slack_bolt/ tests/ && \
     pytest && \
     pip install -U pytype && \

--- a/scripts/run_pytype.sh
+++ b/scripts/run_pytype.sh
@@ -5,5 +5,5 @@ script_dir=$(dirname $0)
 cd ${script_dir}/.. && \
   pip install -e ".[async]" && \
   pip install -e ".[adapter]" && \
-  pip install "pytype==2022.1.13" && \
+  pip install "pytype==2022.1.31" && \
   pytype slack_bolt/

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -20,6 +20,7 @@ else
     black slack_bolt/ tests/ \
       && pytest -vv \
       && pip install -e ".[adapter]" \
+      && pip install -e ".[adapter_testing]" \
       && pip install -U pip setuptools wheel \
       && pip install -U pytype \
       && pytype slack_bolt/

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,9 @@ with open(f"{here}/README.md", "r") as fh:
 test_dependencies = [
     "pytest>=6.2.5,<7",
     "pytest-cov>=3,<4",
-    "Flask-Sockets>=0.2,<1",
-    "Werkzeug<2",  # TODO: support Flask 2.x
-    "black==21.12b0",
+    "Flask-Sockets>=0.2,<1",  # TODO: This module is not yet Flask 2.x compatible
+    "Werkzeug>=2,<3",
+    "black==22.1.0",
 ]
 
 async_test_dependencies = test_dependencies + [
@@ -63,36 +63,40 @@ setuptools.setup(
         "adapter": [
             # used only under src/slack_bolt/adapter
             "boto3<=2",
-            # TODO: Upgrade to v2
-            "moto<2",  # For AWS tests
             "bottle>=0.12,<1",
-            "boddle>=0.2,<0.3",  # For Bottle app tests
-            "chalice>=1.26.1,<2",
+            "chalice>=1.26.5,<2",
             "click>=7,<8",  # for chalice
             "CherryPy>=18,<19",
-            "Django>=3,<4",
-            "falcon>=2,<3",
+            "Django>=3,<5",
+            "falcon>=2,<4",
             "fastapi>=0.70.0,<1",
-            "Flask>=1,<2",
-            "Werkzeug<2",  # TODO: support Flask 2.x
-            "pyramid>=1,<2",
+            "Flask>=1,<3",
+            "Werkzeug>=2,<3",
+            "pyramid>=1,<3",
             "sanic>=21,<22" if sys.version_info.minor > 6 else "sanic>=20,<21",
-            "sanic-testing>=0.7" if sys.version_info.minor > 6 else "",
             "starlette>=0.14,<1",
-            "requests>=2,<3",  # For starlette's TestClient
             "tornado>=6,<7",
             # server
             "uvicorn<1",
             "gunicorn>=20,<21",
             # Socket Mode 3rd party implementation
-            # TODO: 1.2.2 has a regression (https://github.com/websocket-client/websocket-client/issues/769)
-            # ERROR on_error invoked (error: AttributeError, message: 'Dispatcher' object has no attribute 'read')
-            "websocket_client>=1,<1.2.2",
+            # Note: 1.2.2 has a regression (https://github.com/websocket-client/websocket-client/issues/769)
+            "websocket_client>=1.2.3,<2",
         ],
         # pip install -e ".[testing_without_asyncio]"
         "testing_without_asyncio": test_dependencies,
         # pip install -e ".[testing]"
         "testing": async_test_dependencies,
+        # pip install -e ".[adapter_testing]"
+        "adapter_testing": [
+            "moto>=3,<4",  # For AWS tests
+            "docker>=5,<6",  # Used by moto
+            "boddle>=0.2,<0.3",  # For Bottle app tests
+            "Flask>=1,<2",  # TODO: Flask-Sockets is not yet compatible with Flask 2.x
+            "Werkzeug>=1,<2",  # TODO: Flask-Sockets is not yet compatible with Flask 2.x
+            "sanic-testing>=0.7" if sys.version_info.minor > 6 else "",
+            "requests>=2,<3",  # For starlette's TestClient
+        ],
     },
     classifiers=[
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,18 @@ test_dependencies = [
     "pytest>=6.2.5,<7",
     "pytest-cov>=3,<4",
     "Flask-Sockets>=0.2,<1",  # TODO: This module is not yet Flask 2.x compatible
-    "Werkzeug>=2,<3",
+    "Werkzeug>=1,<2",  # TODO: Flask-Sockets is not yet compatible with Flask 2.x
     "black==22.1.0",
+]
+
+adapter_test_dependencies = [
+    "moto>=3,<4",  # For AWS tests
+    "docker>=5,<6",  # Used by moto
+    "boddle>=0.2,<0.3",  # For Bottle app tests
+    "Flask>=1,<2",  # TODO: Flask-Sockets is not yet compatible with Flask 2.x
+    "Werkzeug>=1,<2",  # TODO: Flask-Sockets is not yet compatible with Flask 2.x
+    "sanic-testing>=0.7" if sys.version_info.minor > 6 else "",
+    "requests>=2,<3",  # For Starlette's TestClient
 ]
 
 async_test_dependencies = test_dependencies + [
@@ -88,15 +98,7 @@ setuptools.setup(
         # pip install -e ".[testing]"
         "testing": async_test_dependencies,
         # pip install -e ".[adapter_testing]"
-        "adapter_testing": [
-            "moto>=3,<4",  # For AWS tests
-            "docker>=5,<6",  # Used by moto
-            "boddle>=0.2,<0.3",  # For Bottle app tests
-            "Flask>=1,<2",  # TODO: Flask-Sockets is not yet compatible with Flask 2.x
-            "Werkzeug>=1,<2",  # TODO: Flask-Sockets is not yet compatible with Flask 2.x
-            "sanic-testing>=0.7" if sys.version_info.minor > 6 else "",
-            "requests>=2,<3",  # For starlette's TestClient
-        ],
+        "adapter_testing": adapter_test_dependencies,
     },
     classifiers=[
         "Programming Language :: Python :: 3.6",

--- a/slack_bolt/adapter/falcon/resource.py
+++ b/slack_bolt/adapter/falcon/resource.py
@@ -1,7 +1,7 @@
 from datetime import datetime  # type: ignore
 from http import HTTPStatus
 
-from falcon import Request, Response
+from falcon import Request, Response, version as falcon_version
 
 from slack_bolt import BoltResponse
 from slack_bolt.app import App
@@ -50,7 +50,11 @@ class SlackAppResource:
         )
 
     def _write_response(self, bolt_resp: BoltResponse, resp: Response):
-        resp.body = bolt_resp.body
+        if falcon_version.__version__.startswith("2."):
+            resp.body = bolt_resp.body
+        else:
+            resp.text = bolt_resp.body
+
         status = HTTPStatus(bolt_resp.status)
         resp.status = str(f"{status.value} {status.phrase}")
         resp.set_headers(bolt_resp.first_headers_without_set_cookie())

--- a/tests/adapter_tests/django/test_django_settings.py
+++ b/tests/adapter_tests/django/test_django_settings.py
@@ -5,3 +5,6 @@ DATABASES = {
         "NAME": "logs/db.sqlite3",
     }
 }
+# Django 4 warning: The default value of USE_TZ will change from False to True in Django 5.0.
+# Set USE_TZ to False in your project settings if you want to keep the current default behavior.
+USE_TZ = False

--- a/tests/adapter_tests/falcon/test_falcon.py
+++ b/tests/adapter_tests/falcon/test_falcon.py
@@ -3,6 +3,8 @@ from time import time
 from urllib.parse import quote
 
 import falcon
+
+
 from falcon import testing
 from slack_sdk.signature import SignatureVerifier
 from slack_sdk.web import WebClient
@@ -16,6 +18,13 @@ from tests.mock_web_api_server import (
     assert_auth_test_count,
 )
 from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+def new_falcon_app():
+    if falcon.version.__version__.startswith("2."):
+        return falcon.API()
+    else:
+        return falcon.App()
 
 
 class TestFalcon:
@@ -87,7 +96,7 @@ class TestFalcon:
         }
         timestamp, body = str(int(time())), json.dumps(input)
 
-        api = falcon.API()
+        api = new_falcon_app()
         resource = SlackAppResource(app)
         api.add_route("/slack/events", resource)
 
@@ -128,7 +137,7 @@ class TestFalcon:
 
         timestamp, body = str(int(time())), f"payload={quote(json.dumps(input))}"
 
-        api = falcon.API()
+        api = new_falcon_app()
         resource = SlackAppResource(app)
         api.add_route("/slack/events", resource)
 
@@ -169,7 +178,7 @@ class TestFalcon:
         )
         timestamp, body = str(int(time())), input
 
-        api = falcon.API()
+        api = new_falcon_app()
         resource = SlackAppResource(app)
         api.add_route("/slack/events", resource)
 
@@ -192,7 +201,7 @@ class TestFalcon:
                 scopes=["chat:write", "commands"],
             ),
         )
-        api = falcon.API()
+        api = new_falcon_app()
         resource = SlackAppResource(app)
         api.add_route("/slack/install", resource)
 


### PR DESCRIPTION
This pull request upgrades the dependencies in testing. Also, it resolves a deprecation warning in Falcon 3.x.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
