### PR TITLE
Add ASGI Falcon App support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,4 +70,5 @@ jobs:
     - name: Run tests for HTTP Mode adapters (asyncio-based libraries)
       run: |
         pip install -e ".[async]"
+        pip install "falcon>=3,<4"
         pytest tests/adapter_tests_async/

--- a/examples/falcon/async_app.py
+++ b/examples/falcon/async_app.py
@@ -1,0 +1,100 @@
+import falcon
+import logging
+import re
+from slack_bolt.async_app import AsyncApp, AsyncRespond, AsyncAck
+from slack_bolt.adapter.falcon import AsyncSlackAppResource
+
+logging.basicConfig(level=logging.DEBUG)
+app = AsyncApp()
+
+
+# @app.command("/bolt-py-proto", [lambda body: body["team_id"] == "T03E94MJU"])
+async def test_command(logger: logging.Logger, body: dict, ack: AsyncAck, respond: AsyncRespond):
+    logger.info(body)
+    await ack("thanks!")
+    await respond(
+        blocks=[
+            {
+                "type": "section",
+                "block_id": "b",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "You can add a button alongside text in your message. ",
+                },
+                "accessory": {
+                    "type": "button",
+                    "action_id": "a",
+                    "text": {"type": "plain_text", "text": "Button"},
+                    "value": "click_me_123",
+                },
+            }
+        ]
+    )
+
+
+app.command(re.compile(r"/hello-bolt-.+"))(test_command)
+
+
+@app.shortcut("test-shortcut")
+async def test_shortcut(ack, client, logger, body):
+    logger.info(body)
+    await ack()
+    res = await client.views_open(
+        trigger_id=body["trigger_id"],
+        view={
+            "type": "modal",
+            "callback_id": "view-id",
+            "title": {
+                "type": "plain_text",
+                "text": "My App",
+            },
+            "submit": {
+                "type": "plain_text",
+                "text": "Submit",
+            },
+            "close": {
+                "type": "plain_text",
+                "text": "Cancel",
+            },
+            "blocks": [
+                {
+                    "type": "input",
+                    "element": {"type": "plain_text_input"},
+                    "label": {
+                        "type": "plain_text",
+                        "text": "Label",
+                    },
+                }
+            ],
+        },
+    )
+    logger.info(res)
+
+
+@app.view("view-id")
+async def view_submission(ack, body, logger):
+    logger.info(body)
+    await ack()
+
+
+@app.action("a")
+async def button_click(logger, action, ack, respond):
+    logger.info(action)
+    await ack()
+    await respond("Here is my response")
+
+
+@app.event("app_mention")
+async def handle_app_mentions(body, say, logger):
+    logger.info(body)
+    await say("What's up?")
+
+
+api = falcon.asgi.App()
+resource = AsyncSlackAppResource(app)
+api.add_route("/slack/events", resource)
+
+# pip install -r requirements.txt
+# export SLACK_SIGNING_SECRET=***
+# export SLACK_BOT_TOKEN=xoxb-***
+# uvicorn --reload -h 0.0.0.0 -p 3000 app:api

--- a/examples/falcon/async_app.py
+++ b/examples/falcon/async_app.py
@@ -97,4 +97,4 @@ api.add_route("/slack/events", resource)
 # pip install -r requirements.txt
 # export SLACK_SIGNING_SECRET=***
 # export SLACK_BOT_TOKEN=xoxb-***
-# uvicorn --reload -h 0.0.0.0 -p 3000 app:api
+# uvicorn --reload -h 0.0.0.0 -p 3000 async_app:api

--- a/examples/falcon/async_oauth_app.py
+++ b/examples/falcon/async_oauth_app.py
@@ -97,6 +97,6 @@ api.add_route("/slack/events", resource)
 # pip install -r requirements.txt
 # export SLACK_SIGNING_SECRET=***
 # export SLACK_BOT_TOKEN=xoxb-***
-# uvicorn --reload -h 0.0.0.0 -p 3000 app:api
+# uvicorn --reload -h 0.0.0.0 -p 3000 async_oauth_app:api
 api.add_route("/slack/install", resource)
 api.add_route("/slack/oauth_redirect", resource)

--- a/examples/falcon/async_oauth_app.py
+++ b/examples/falcon/async_oauth_app.py
@@ -1,0 +1,102 @@
+import falcon
+import logging
+import re
+from slack_bolt.async_app import AsyncApp, AsyncRespond, AsyncAck
+from slack_bolt.adapter.falcon import AsyncSlackAppResource
+
+logging.basicConfig(level=logging.DEBUG)
+app = AsyncApp()
+
+
+# @app.command("/bolt-py-proto", [lambda body: body["team_id"] == "T03E94MJU"])
+async def test_command(logger: logging.Logger, body: dict, ack: AsyncAck, respond: AsyncRespond):
+    logger.info(body)
+    await ack("thanks!")
+    await respond(
+        blocks=[
+            {
+                "type": "section",
+                "block_id": "b",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "You can add a button alongside text in your message. ",
+                },
+                "accessory": {
+                    "type": "button",
+                    "action_id": "a",
+                    "text": {"type": "plain_text", "text": "Button"},
+                    "value": "click_me_123",
+                },
+            }
+        ]
+    )
+
+
+app.command(re.compile(r"/hello-bolt-.+"))(test_command)
+
+
+@app.shortcut("test-shortcut")
+async def test_shortcut(ack, client, logger, body):
+    logger.info(body)
+    await ack()
+    res = await client.views_open(
+        trigger_id=body["trigger_id"],
+        view={
+            "type": "modal",
+            "callback_id": "view-id",
+            "title": {
+                "type": "plain_text",
+                "text": "My App",
+            },
+            "submit": {
+                "type": "plain_text",
+                "text": "Submit",
+            },
+            "close": {
+                "type": "plain_text",
+                "text": "Cancel",
+            },
+            "blocks": [
+                {
+                    "type": "input",
+                    "element": {"type": "plain_text_input"},
+                    "label": {
+                        "type": "plain_text",
+                        "text": "Label",
+                    },
+                }
+            ],
+        },
+    )
+    logger.info(res)
+
+
+@app.view("view-id")
+async def view_submission(ack, body, logger):
+    logger.info(body)
+    await ack()
+
+
+@app.action("a")
+async def button_click(logger, action, ack, respond):
+    logger.info(action)
+    await ack()
+    await respond("Here is my response")
+
+
+@app.event("app_mention")
+async def handle_app_mentions(body, say, logger):
+    logger.info(body)
+    await say("What's up?")
+
+
+api = falcon.asgi.App()
+resource = AsyncSlackAppResource(app)
+api.add_route("/slack/events", resource)
+
+# pip install -r requirements.txt
+# export SLACK_SIGNING_SECRET=***
+# export SLACK_BOT_TOKEN=xoxb-***
+# uvicorn --reload -h 0.0.0.0 -p 3000 app:api
+api.add_route("/slack/install", resource)
+api.add_route("/slack/oauth_redirect", resource)

--- a/examples/falcon/requirements.txt
+++ b/examples/falcon/requirements.txt
@@ -1,2 +1,3 @@
 falcon>=2,<3
 gunicorn>=20,<21
+uvicorn

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setuptools.setup(
             "click>=7,<8",  # for chalice
             "CherryPy>=18,<19",
             "Django>=3,<5",
-            "falcon>=2,<4",
+            "falcon>=3,<4",
             "fastapi>=0.70.0,<1",
             "Flask>=1,<3",
             "Werkzeug>=2,<3",

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setuptools.setup(
             "click>=7,<8",  # for chalice
             "CherryPy>=18,<19",
             "Django>=3,<5",
-            "falcon>=3,<4",
+            "falcon>=2,<4",
             "fastapi>=0.70.0,<1",
             "Flask>=1,<3",
             "Werkzeug>=2,<3",

--- a/slack_bolt/adapter/falcon/__init__.py
+++ b/slack_bolt/adapter/falcon/__init__.py
@@ -1,2 +1,2 @@
+# Don't add async module imports here
 from .resource import SlackAppResource
-from .async_resource import AsyncSlackAppResource

--- a/slack_bolt/adapter/falcon/__init__.py
+++ b/slack_bolt/adapter/falcon/__init__.py
@@ -1,1 +1,2 @@
 from .resource import SlackAppResource
+from .async_resource import AsyncSlackAppResource

--- a/slack_bolt/adapter/falcon/async_resource.py
+++ b/slack_bolt/adapter/falcon/async_resource.py
@@ -5,6 +5,7 @@ from falcon import version as falcon_version
 from falcon.asgi import Request, Response
 from slack_bolt import BoltResponse
 from slack_bolt.async_app import AsyncApp
+from slack_bolt.error import BoltError
 from slack_bolt.oauth.async_oauth_flow import AsyncOAuthFlow
 from slack_bolt.request.async_request import AsyncBoltRequest
 
@@ -22,6 +23,9 @@ class AsyncSlackAppResource:
     """
 
     def __init__(self, app: AsyncApp):  # type: ignore
+        if falcon_version.__version__.startswith("2."):
+            raise BoltError("This ASGI compatible adapter requires Falcon version >= 3.0")
+
         self.app = app
 
     async def on_get(self, req: Request, resp: Response):
@@ -56,11 +60,6 @@ class AsyncSlackAppResource:
         )
 
     async def _write_response(self, bolt_resp: BoltResponse, resp: Response):
-        if falcon_version.__version__.startswith("2."):
-            raise NotImplementedError("ASGI Falcon requires version >= 3.0")
-        else:
-            resp.text = bolt_resp.body
-
         status = HTTPStatus(bolt_resp.status)
         resp.status = str(f"{status.value} {status.phrase}")
         resp.set_headers(bolt_resp.first_headers_without_set_cookie())

--- a/slack_bolt/adapter/falcon/async_resource.py
+++ b/slack_bolt/adapter/falcon/async_resource.py
@@ -60,6 +60,7 @@ class AsyncSlackAppResource:
         )
 
     async def _write_response(self, bolt_resp: BoltResponse, resp: Response):
+        resp.text = bolt_resp.body
         status = HTTPStatus(bolt_resp.status)
         resp.status = str(f"{status.value} {status.phrase}")
         resp.set_headers(bolt_resp.first_headers_without_set_cookie())

--- a/slack_bolt/adapter/falcon/async_resource.py
+++ b/slack_bolt/adapter/falcon/async_resource.py
@@ -1,0 +1,84 @@
+from datetime import datetime  # type: ignore
+from http import HTTPStatus
+
+from falcon import version as falcon_version
+from falcon.asgi import Request, Response
+from slack_bolt import BoltResponse
+from slack_bolt.async_app import AsyncApp
+from slack_bolt.oauth.async_oauth_flow import AsyncOAuthFlow
+from slack_bolt.request.async_request import AsyncBoltRequest
+
+
+class AsyncSlackAppResource:
+    """
+    For use with ASGI Falcon Apps.
+
+    from slack_bolt.async_app import AsyncApp
+    app = AsyncApp()
+
+    import falcon
+    app = falcon.asgi.App()
+    app.add_route("/slack/events", AsyncSlackAppResource(app))
+    """
+
+    def __init__(self, app: AsyncApp):  # type: ignore
+        self.app = app
+
+    async def on_get(self, req: Request, resp: Response):
+        if self.app.oauth_flow is not None:
+            oauth_flow: AsyncOAuthFlow = self.app.oauth_flow
+            if req.path == oauth_flow.install_path:
+                bolt_resp = await oauth_flow.handle_installation(
+                    await self._to_bolt_request(req)
+                )
+                await self._write_response(bolt_resp, resp)
+                return
+            elif req.path == oauth_flow.redirect_uri_path:
+                bolt_resp = await oauth_flow.handle_callback(
+                    await self._to_bolt_request(req)
+                )
+                await self._write_response(bolt_resp, resp)
+                return
+
+        resp.status = "404"
+        resp.body = "The page is not found..."
+
+    async def on_post(self, req: Request, resp: Response):
+        bolt_req = await self._to_bolt_request(req)
+        bolt_resp = await self.app.async_dispatch(bolt_req)
+        await self._write_response(bolt_resp, resp)
+
+    async def _to_bolt_request(self, req: Request) -> AsyncBoltRequest:
+        return AsyncBoltRequest(
+            body=(await req.stream.read(req.content_length or 0)).decode("utf-8"),
+            query=req.query_string,
+            headers={k.lower(): v for k, v in req.headers.items()},
+        )
+
+    async def _write_response(self, bolt_resp: BoltResponse, resp: Response):
+        if falcon_version.__version__.startswith("2."):
+            raise NotImplementedError("ASGI Falcon requires version >= 3.0")
+        else:
+            resp.text = bolt_resp.body
+
+        status = HTTPStatus(bolt_resp.status)
+        resp.status = str(f"{status.value} {status.phrase}")
+        resp.set_headers(bolt_resp.first_headers_without_set_cookie())
+        for cookie in bolt_resp.cookies():
+            for name, c in cookie.items():
+                expire_value = c.get("expires")
+                expire = (
+                    datetime.strptime(expire_value, "%a, %d %b %Y %H:%M:%S %Z")
+                    if expire_value
+                    else None
+                )
+                resp.set_cookie(
+                    name=name,
+                    value=c.value,
+                    expires=expire,
+                    max_age=c.get("max-age"),
+                    domain=c.get("domain"),
+                    path=c.get("path"),
+                    secure=True,
+                    http_only=True,
+                )

--- a/tests/adapter_tests_async/test_async_falcon.py
+++ b/tests/adapter_tests_async/test_async_falcon.py
@@ -20,10 +20,7 @@ from tests.utils import remove_os_env_temporarily, restore_os_env
 
 
 def new_falcon_app():
-    if falcon.version.__version__.startswith("2."):
-        raise NotImplementedError("ASGI Falcon requires version >= 3.0")
-    else:
-        return falcon.asgi.App()
+    return falcon.asgi.App()
 
 
 class TestAsyncFalcon:

--- a/tests/adapter_tests_async/test_async_falcon.py
+++ b/tests/adapter_tests_async/test_async_falcon.py
@@ -1,0 +1,212 @@
+import json
+from time import time
+from urllib.parse import quote
+
+import falcon
+from falcon import testing
+
+from slack_sdk.signature import SignatureVerifier
+from slack_sdk.web.async_client import AsyncWebClient
+
+from slack_bolt.adapter.falcon.async_resource import AsyncSlackAppResource
+from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.oauth.async_oauth_settings import AsyncOAuthSettings
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+    assert_auth_test_count,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+def new_falcon_app():
+    if falcon.version.__version__.startswith("2."):
+        raise NotImplementedError("ASGI Falcon requires version >= 3.0")
+    else:
+        return falcon.asgi.App()
+
+
+class TestAsyncFalcon:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = AsyncWebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    def setup_method(self):
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body,
+            timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        content_type = (
+            "application/json"
+            if body.startswith("{")
+            else "application/x-www-form-urlencoded"
+        )
+        return {
+            "content-type": content_type,
+            "x-slack-signature": self.generate_signature(body, timestamp),
+            "x-slack-request-timestamp": timestamp,
+        }
+
+    def test_events(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+
+        async def event_handler():
+            pass
+
+        app.event("app_mention")(event_handler)
+
+        input = {
+            "token": "verification_token",
+            "team_id": "T111",
+            "enterprise_id": "E111",
+            "api_app_id": "A111",
+            "event": {
+                "client_msg_id": "9cbd4c5b-7ddf-4ede-b479-ad21fca66d63",
+                "type": "app_mention",
+                "text": "<@W111> Hi there!",
+                "user": "W222",
+                "ts": "1595926230.009600",
+                "team": "T111",
+                "channel": "C111",
+                "event_ts": "1595926230.009600",
+            },
+            "type": "event_callback",
+            "event_id": "Ev111",
+            "event_time": 1595926230,
+            "authed_users": ["W111"],
+        }
+        timestamp, body = str(int(time())), json.dumps(input)
+
+        api = new_falcon_app()
+        resource = AsyncSlackAppResource(app)
+        api.add_route("/slack/events", resource)
+
+        client = testing.TestClient(api)
+        response = client.simulate_post(
+            "/slack/events",
+            body=body,
+            headers=self.build_headers(timestamp, body),
+        )
+        assert response.status_code == 200
+        assert_auth_test_count(self, 1)
+
+    def test_shortcuts(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+
+        async def shortcut_handler(ack):
+            await ack()
+
+        app.shortcut("test-shortcut")(shortcut_handler)
+
+        input = {
+            "type": "shortcut",
+            "token": "verification_token",
+            "action_ts": "111.111",
+            "team": {
+                "id": "T111",
+                "domain": "workspace-domain",
+                "enterprise_id": "E111",
+                "enterprise_name": "Org Name",
+            },
+            "user": {"id": "W111", "username": "primary-owner", "team_id": "T111"},
+            "callback_id": "test-shortcut",
+            "trigger_id": "111.111.xxxxxx",
+        }
+
+        timestamp, body = str(int(time())), f"payload={quote(json.dumps(input))}"
+
+        api = new_falcon_app()
+        resource = AsyncSlackAppResource(app)
+        api.add_route("/slack/events", resource)
+
+        client = testing.TestClient(api)
+        response = client.simulate_post(
+            "/slack/events",
+            body=body,
+            headers=self.build_headers(timestamp, body),
+        )
+        assert response.status_code == 200
+        assert_auth_test_count(self, 1)
+
+    def test_commands(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+
+        async def command_handler(ack):
+            await ack()
+
+        app.command("/hello-world")(command_handler)
+
+        input = (
+            "token=verification_token"
+            "&team_id=T111"
+            "&team_domain=test-domain"
+            "&channel_id=C111"
+            "&channel_name=random"
+            "&user_id=W111"
+            "&user_name=primary-owner"
+            "&command=%2Fhello-world"
+            "&text=Hi"
+            "&enterprise_id=E111"
+            "&enterprise_name=Org+Name"
+            "&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT111%2F111%2Fxxxxx"
+            "&trigger_id=111.111.xxx"
+        )
+        timestamp, body = str(int(time())), input
+
+        api = new_falcon_app()
+        resource = AsyncSlackAppResource(app)
+        api.add_route("/slack/events", resource)
+
+        client = testing.TestClient(api)
+        response = client.simulate_post(
+            "/slack/events",
+            body=body,
+            headers=self.build_headers(timestamp, body),
+        )
+        assert response.status_code == 200
+        assert_auth_test_count(self, 1)
+
+    def test_oauth(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            oauth_settings=AsyncOAuthSettings(
+                client_id="111.111",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+            ),
+        )
+        api = new_falcon_app()
+        resource = AsyncSlackAppResource(app)
+        api.add_route("/slack/install", resource)
+
+        client = testing.TestClient(api)
+        response = client.simulate_get("/slack/install")
+        assert response.status_code == 200
+        assert response.headers.get("content-type") == "text/html; charset=utf-8"
+        assert response.headers.get("content-length") == "597"
+        assert "https://slack.com/oauth/v2/authorize?state=" in response.text


### PR DESCRIPTION
This PR adds an ASGI Falcon App adapter to complement the existing Falcon adapter for WSGI apps.

I wrote this code originally based on the existing adapter for https://git.sr.ht/~sara/openverse-slack-reaction.

The code I wrote there is copied almost directly here with some modifications to raise errors when an incompatible Falcon version is being used. You can see the original code here: https://git.sr.ht/~sara/openverse-slack-reaction/tree/main/item/falcon_adapter.py

It's deployed to production with https://openverse-slack.sarayourfriend.pictures.

Hope it's okay I didn't open an issue for this first, but I needed it for my own app one way or another and copying the file  and adding tests was trivial so I didn't spend too much extra time on this compared to just writing a helpful issue describing the feature :slightly_smiling_face: 

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
