### PR TITLE
Upgrade pytype version to the latest

### DIFF
--- a/scripts/run_pytype.sh
+++ b/scripts/run_pytype.sh
@@ -5,5 +5,5 @@ script_dir=$(dirname $0)
 cd ${script_dir}/.. && \
   pip install -e ".[async]" && \
   pip install -e ".[adapter]" && \
-  pip install "pytype==2022.3.8" && \
+  pip install "pytype==2022.4.15" && \
   pytype slack_bolt/

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -1453,13 +1453,19 @@ class SlackAppDevelopmentServer:
                     request_path, _, query = self.path.partition("?")
                     if request_path == _bolt_oauth_flow.install_path:
                         bolt_req = BoltRequest(
-                            body="", query=query, headers=self.headers
+                            body="",
+                            query=query,
+                            # email.message.Message's mapping interface is dict compatible
+                            headers=self.headers,  # type:ignore
                         )
                         bolt_resp = _bolt_oauth_flow.handle_installation(bolt_req)
                         self._send_bolt_response(bolt_resp)
                     elif request_path == _bolt_oauth_flow.redirect_uri_path:
                         bolt_req = BoltRequest(
-                            body="", query=query, headers=self.headers
+                            body="",
+                            query=query,
+                            # email.message.Message's mapping interface is dict compatible
+                            headers=self.headers,  # type:ignore
                         )
                         bolt_resp = _bolt_oauth_flow.handle_callback(bolt_req)
                         self._send_bolt_response(bolt_resp)
@@ -1477,7 +1483,10 @@ class SlackAppDevelopmentServer:
                 len_header = self.headers.get("Content-Length") or 0
                 request_body = self.rfile.read(int(len_header)).decode("utf-8")
                 bolt_req = BoltRequest(
-                    body=request_body, query=query, headers=self.headers
+                    body=request_body,
+                    query=query,
+                    # email.message.Message's mapping interface is dict compatible
+                    headers=self.headers,  # type:ignore
                 )
                 bolt_resp: BoltResponse = _bolt_app.dispatch(bolt_req)
                 self._send_bolt_response(bolt_resp)
@@ -1503,7 +1512,7 @@ class SlackAppDevelopmentServer:
                 for k, vs in headers.items():
                     for v in vs:
                         self.send_header(k, v)
-                self.send_header("Content-Length", len(body_bytes))
+                self.send_header("Content-Length", str(len(body_bytes)))
                 self.end_headers()
                 self.wfile.write(body_bytes)
 


### PR DESCRIPTION
This pull request upgrades "pytype" code validator to 2022.4.15 plus updates the code to be compatible with the version.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
