### PR TITLE
Enable Flake8 in the CI builds

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 125
+ignore = F841,F821,W503,E402

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -18,6 +18,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Run pytype verification
+    - name: Run flake8 verification
       run: |
         ./scripts/run_flake8.sh

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -20,4 +20,4 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Run pytype verification
       run: |
-        ./scripts/run_pytype.sh
+        ./scripts/run_flake8.sh

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,4 +1,4 @@
-name: Run pytype validation
+name: Run flake8 validation
 
 on:
   push:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,23 @@
+name: Run pytype validation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        python-version: ['3.9']
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Run pytype verification
+      run: |
+        ./scripts/run_pytype.sh

--- a/examples/django/myslackapp/urls.py
+++ b/examples/django/myslackapp/urls.py
@@ -13,7 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
+from django.contrib import admin  # noqa: F401
 from django.urls import path
 
 # Set this flag to False if you want to enable oauth_app instead

--- a/examples/django/simple_app/models.py
+++ b/examples/django/simple_app/models.py
@@ -1,3 +1,3 @@
-from django.db import models
+from django.db import models  # noqa: F401
 
 # Create your models here.

--- a/examples/getting_started/app.py
+++ b/examples/getting_started/app.py
@@ -7,6 +7,7 @@ app = App(
     signing_secret=os.environ.get("SLACK_SIGNING_SECRET"),
 )
 
+
 # Listens to incoming messages that contain "hello"
 # To learn available listener method arguments,
 # visit https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html

--- a/examples/google_cloud_functions/main.py
+++ b/examples/google_cloud_functions/main.py
@@ -26,6 +26,7 @@ from slack_bolt.adapter.flask import SlackRequestHandler
 
 handler = SlackRequestHandler(app)
 
+
 # Cloud Function
 def hello_bolt_app(request):
     """HTTP Cloud Function.

--- a/examples/workflow_steps/async_steps_from_apps.py
+++ b/examples/workflow_steps/async_steps_from_apps.py
@@ -28,7 +28,7 @@ async def edit(ack: AsyncAck, step: dict, configure: AsyncConfigure):
                 "block_id": "intro-section",
                 "text": {
                     "type": "plain_text",
-                    "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps.",
+                    "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps.",  # noqa: E501
                 },
             },
             {
@@ -155,8 +155,8 @@ async def execute(
                 "blocks": blocks,
             },
         )
-    except:
-        await fail(error={"message": "Something wrong!"})
+    except Exception as e:
+        await fail(error={"message": f"Something wrong! (error: {e})"})
 
 
 app.step(

--- a/examples/workflow_steps/async_steps_from_apps_decorator.py
+++ b/examples/workflow_steps/async_steps_from_apps_decorator.py
@@ -33,7 +33,7 @@ async def edit(ack: AsyncAck, step: dict, configure: AsyncConfigure):
                 "block_id": "intro-section",
                 "text": {
                     "type": "plain_text",
-                    "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps.",
+                    "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps.",  # noqa: E501
                 },
             },
             {

--- a/examples/workflow_steps/async_steps_from_apps_primitive.py
+++ b/examples/workflow_steps/async_steps_from_apps_primitive.py
@@ -27,7 +27,7 @@ async def edit(body: dict, ack: AsyncAck, client: AsyncWebClient):
                     "block_id": "intro-section",
                     "text": {
                         "type": "plain_text",
-                        "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps.",
+                        "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps.",  # noqa: E501
                     },
                 },
                 {

--- a/examples/workflow_steps/steps_from_apps.py
+++ b/examples/workflow_steps/steps_from_apps.py
@@ -31,7 +31,7 @@ def edit(ack: Ack, step, configure: Configure):
                 "block_id": "intro-section",
                 "text": {
                     "type": "plain_text",
-                    "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps.",
+                    "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps.",  # noqa: E501
                 },
             },
             {

--- a/examples/workflow_steps/steps_from_apps_decorator.py
+++ b/examples/workflow_steps/steps_from_apps_decorator.py
@@ -35,7 +35,7 @@ def edit(ack: Ack, step, configure: Configure):
                 "block_id": "intro-section",
                 "text": {
                     "type": "plain_text",
-                    "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps.",
+                    "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps.",  # noqa: E501
                 },
             },
             {

--- a/examples/workflow_steps/steps_from_apps_primitive.py
+++ b/examples/workflow_steps/steps_from_apps_primitive.py
@@ -29,7 +29,7 @@ def edit(body: dict, ack: Ack, client: WebClient):
                     "block_id": "intro-section",
                     "text": {
                         "type": "plain_text",
-                        "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps.",
+                        "text": "Create a task in one of the listed projects. The link to the task and other details will be available as variable data in later steps.",  # noqa: E501
                     },
                 },
                 {

--- a/scripts/run_flake8.sh
+++ b/scripts/run_flake8.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# ./scripts/run_pytype.sh
+
+script_dir=$(dirname $0)
+cd ${script_dir}/.. && \
+  pip install "flake8==4.0.1" && \
+  flake8 slack_bolt/ && flake8 examples/

--- a/scripts/run_flake8.sh
+++ b/scripts/run_flake8.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# ./scripts/run_pytype.sh
+# ./scripts/run_flake8.sh
 
 script_dir=$(dirname $0)
 cd ${script_dir}/.. && \

--- a/slack_bolt/__init__.py
+++ b/slack_bolt/__init__.py
@@ -1,10 +1,10 @@
 """
-A Python framework to build Slack apps in a flash with the latest platform features. Read the [getting started guide](https://slack.dev/bolt-python/tutorial/getting-started) and look at our [code examples](https://github.com/slackapi/bolt-python/tree/main/examples) to learn how to build apps using Bolt.
+A Python framework to build Slack apps in a flash with the latest platform features.Read the [getting started guide](https://slack.dev/bolt-python/tutorial/getting-started) and look at our [code examples](https://github.com/slackapi/bolt-python/tree/main/examples) to learn how to build apps using Bolt.
 
 * Website: https://slack.dev/bolt-python/
 * GitHub repository: https://github.com/slackapi/bolt-python
 * The class representing a Bolt app: `slack_bolt.app.app`
-"""
+"""  # noqa: E501
 # Don't add async module imports here
 from .app import App  # noqa
 from .context import BoltContext  # noqa

--- a/slack_bolt/adapter/aws_lambda/__init__.py
+++ b/slack_bolt/adapter/aws_lambda/__init__.py
@@ -1,1 +1,1 @@
-from .handler import SlackRequestHandler
+from .handler import SlackRequestHandler  # noqa: F401

--- a/slack_bolt/adapter/bottle/__init__.py
+++ b/slack_bolt/adapter/bottle/__init__.py
@@ -1,1 +1,1 @@
-from .handler import SlackRequestHandler
+from .handler import SlackRequestHandler  # noqa: F401

--- a/slack_bolt/adapter/cherrypy/__init__.py
+++ b/slack_bolt/adapter/cherrypy/__init__.py
@@ -1,1 +1,1 @@
-from .handler import SlackRequestHandler
+from .handler import SlackRequestHandler  # noqa: F401

--- a/slack_bolt/adapter/django/__init__.py
+++ b/slack_bolt/adapter/django/__init__.py
@@ -1,1 +1,1 @@
-from .handler import SlackRequestHandler
+from .handler import SlackRequestHandler  # noqa: F401

--- a/slack_bolt/adapter/django/handler.py
+++ b/slack_bolt/adapter/django/handler.py
@@ -142,8 +142,8 @@ class SlackRequestHandler:
             # it's okay to skip calling the same connection clean-up method at the listener completion.
             message = """As you've already set app.listener_runner.listener_start_handler to your own one,
             Bolt skipped to set it to slack_sdk.adapter.django.DjangoListenerStartHandler.
-            
-            If you go with your own handler here, we highly recommend having the following lines of code 
+
+            If you go with your own handler here, we highly recommend having the following lines of code
             in your handle() method to clean up unmanaged stale/old database connections:
 
             from django.db import close_old_connections

--- a/slack_bolt/adapter/falcon/__init__.py
+++ b/slack_bolt/adapter/falcon/__init__.py
@@ -1,2 +1,2 @@
 # Don't add async module imports here
-from .resource import SlackAppResource
+from .resource import SlackAppResource  # noqa: F401

--- a/slack_bolt/adapter/flask/__init__.py
+++ b/slack_bolt/adapter/flask/__init__.py
@@ -1,1 +1,1 @@
-from .handler import SlackRequestHandler
+from .handler import SlackRequestHandler  # noqa: F401

--- a/slack_bolt/adapter/pyramid/__init__.py
+++ b/slack_bolt/adapter/pyramid/__init__.py
@@ -1,1 +1,1 @@
-from .handler import SlackRequestHandler
+from .handler import SlackRequestHandler  # noqa: F401

--- a/slack_bolt/adapter/sanic/__init__.py
+++ b/slack_bolt/adapter/sanic/__init__.py
@@ -1,1 +1,1 @@
-from .async_handler import AsyncSlackRequestHandler
+from .async_handler import AsyncSlackRequestHandler  # noqa: F401

--- a/slack_bolt/adapter/socket_mode/__init__.py
+++ b/slack_bolt/adapter/socket_mode/__init__.py
@@ -4,7 +4,7 @@
 * `slack_bolt.adapter.socket_mode.websocket_client`
 * `slack_bolt.adapter.socket_mode.aiohttp`
 * `slack_bolt.adapter.socket_mode.websockets`
-"""
+"""  # noqa: E501
 
 # Don't add async module imports here
-from .builtin import SocketModeHandler  # noqa
+from .builtin import SocketModeHandler  # noqa: F401

--- a/slack_bolt/adapter/starlette/__init__.py
+++ b/slack_bolt/adapter/starlette/__init__.py
@@ -1,2 +1,2 @@
 # Don't add async module imports here
-from .handler import SlackRequestHandler
+from .handler import SlackRequestHandler  # noqa: F401

--- a/slack_bolt/adapter/tornado/__init__.py
+++ b/slack_bolt/adapter/tornado/__init__.py
@@ -1,1 +1,1 @@
-from .handler import SlackEventsHandler, SlackOAuthHandler
+from .handler import SlackEventsHandler, SlackOAuthHandler  # noqa: F401

--- a/slack_bolt/app/__init__.py
+++ b/slack_bolt/app/__init__.py
@@ -6,4 +6,4 @@ you can use `slack_bolt.app.async_app` for building async apps.\
 """
 
 # Don't add async module imports here
-from .app import App  # type: ignore
+from .app import App  # noqa: F401 type: ignore

--- a/slack_bolt/async_app.py
+++ b/slack_bolt/async_app.py
@@ -43,7 +43,7 @@ If you want to use another async Web framework (e.g., Sanic, FastAPI, Starlette)
 Apps can be run the same way as the synchronous example above. If you'd prefer another async Web framework (e.g., Sanic, FastAPI, Starlette), take a look at [the built-in adapters](https://github.com/slackapi/bolt-python/tree/main/slack_bolt/adapter) and their corresponding [examples](https://github.com/slackapi/bolt-python/tree/main/examples).
 
 Refer to `slack_bolt.app.async_app` for more details.
-"""
+"""  # noqa: E501
 from .app.async_app import AsyncApp  # noqa
 from .context.ack.async_ack import AsyncAck  # noqa
 from .context.async_context import AsyncBoltContext  # noqa

--- a/slack_bolt/authorization/__init__.py
+++ b/slack_bolt/authorization/__init__.py
@@ -3,4 +3,4 @@ while processing an incoming Slack event.
 
 Refer to https://slack.dev/bolt-python/concepts#authorization for details.
 """
-from .authorize_result import AuthorizeResult
+from .authorize_result import AuthorizeResult  # noqa

--- a/slack_bolt/context/__init__.py
+++ b/slack_bolt/context/__init__.py
@@ -6,4 +6,4 @@ Refer to https://slack.dev/bolt-python/concepts#context for details.
 """
 
 # Don't add async module imports here
-from .context import BoltContext
+from .context import BoltContext  # noqa: F401

--- a/slack_bolt/context/ack/__init__.py
+++ b/slack_bolt/context/ack/__init__.py
@@ -1,2 +1,2 @@
 # Don't add async module imports here
-from .ack import Ack
+from .ack import Ack  # noqa: F401

--- a/slack_bolt/context/ack/internals.py
+++ b/slack_bolt/context/ack/internals.py
@@ -61,7 +61,7 @@ def _set_response(
                     )
                 else:
                     raise ValueError(
-                        f"errors field is required for response_action: errors"
+                        "errors field is required for response_action: errors"
                     )
             else:
                 body = {"response_action": response_action}

--- a/slack_bolt/context/respond/__init__.py
+++ b/slack_bolt/context/respond/__init__.py
@@ -1,2 +1,2 @@
 # Don't add async module imports here
-from .respond import Respond
+from .respond import Respond  # noqa: F401

--- a/slack_bolt/context/say/__init__.py
+++ b/slack_bolt/context/say/__init__.py
@@ -1,2 +1,2 @@
 # Don't add async module imports here
-from .say import Say
+from .say import Say  # noqa: F401

--- a/slack_bolt/kwargs_injection/__init__.py
+++ b/slack_bolt/kwargs_injection/__init__.py
@@ -5,5 +5,5 @@ For Workflow steps, checking `slack_bolt.workflows.step.utilities` as well shoul
 """
 
 # Don't add async module imports here
-from .args import Args
-from .utils import build_required_kwargs
+from .args import Args  # noqa: F401
+from .utils import build_required_kwargs  # noqa: F401

--- a/slack_bolt/kwargs_injection/utils.py
+++ b/slack_bolt/kwargs_injection/utils.py
@@ -1,7 +1,7 @@
 # pytype: skip-file
 import inspect
 import logging
-from typing import Callable, Dict, Optional, Any, Sequence, List
+from typing import Callable, Dict, Optional, Any, Sequence
 
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse

--- a/slack_bolt/lazy_listener/async_runner.py
+++ b/slack_bolt/lazy_listener/async_runner.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod, ABCMeta
 from logging import Logger
-from typing import Callable, Awaitable, Any, Coroutine
+from typing import Callable, Awaitable
 
 from slack_bolt.lazy_listener.async_internals import to_runnable_function
 from slack_bolt.request.async_request import AsyncBoltRequest

--- a/slack_bolt/listener/builtins.py
+++ b/slack_bolt/listener/builtins.py
@@ -1,5 +1,3 @@
-from slack_sdk.oauth import InstallationStore
-
 from slack_bolt.context.context import BoltContext
 from slack_sdk.oauth.installation_store.installation_store import InstallationStore
 

--- a/slack_bolt/listener_matcher/builtins.py
+++ b/slack_bolt/listener_matcher/builtins.py
@@ -29,8 +29,7 @@ if sys.version_info.major == 3 and sys.version_info.minor <= 6:
     from re import _pattern_type as Pattern
 else:
     from re import Pattern
-from typing import Callable, Awaitable, Any, Sequence, Optional, Union
-from typing import Union, Optional, Dict
+from typing import Callable, Awaitable, Any, Sequence, Optional, Union, Dict
 
 from slack_bolt.kwargs_injection import build_required_kwargs
 from slack_bolt.request import BoltRequest

--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -348,4 +348,7 @@ def debug_return_listener_middleware_response(
     listener_name: str, status: int, body: str, starting_time: float
 ) -> str:
     millis = int((time.time() - starting_time) * 1000)
-    return f"Responding with listener middleware's response - listener: {listener_name}, status: {status}, body: {body} ({millis} millis)"
+    return (
+        "Responding with listener middleware's response - "
+        f"listener: {listener_name}, status: {status}, body: {body} ({millis} millis)"
+    )

--- a/slack_bolt/middleware/__init__.py
+++ b/slack_bolt/middleware/__init__.py
@@ -6,13 +6,16 @@ It's also possible to run a middleware only for a particular listener.
 """
 
 # Don't add async module imports here
-from .authorization import SingleTeamAuthorization, MultiTeamsAuthorization
-from .custom_middleware import CustomMiddleware
-from .ignoring_self_events import IgnoringSelfEvents
-from .middleware import Middleware
-from .request_verification import RequestVerification
-from .ssl_check import SslCheck
-from .url_verification import UrlVerification
+from .authorization import (
+    SingleTeamAuthorization,
+    MultiTeamsAuthorization,
+)  # noqa: F401
+from .custom_middleware import CustomMiddleware  # noqa: F401
+from .ignoring_self_events import IgnoringSelfEvents  # noqa: F401
+from .middleware import Middleware  # noqa: F401
+from .request_verification import RequestVerification  # noqa: F401
+from .ssl_check import SslCheck  # noqa: F401
+from .url_verification import UrlVerification  # noqa: F401
 
 builtin_middleware_classes = [
     SslCheck,

--- a/slack_bolt/middleware/async_builtins.py
+++ b/slack_bolt/middleware/async_builtins.py
@@ -1,11 +1,11 @@
-from .ignoring_self_events.async_ignoring_self_events import (
+from .ignoring_self_events.async_ignoring_self_events import (  # noqa: F401
     AsyncIgnoringSelfEvents,
-)  # noqa
-from .request_verification.async_request_verification import (
+)
+from .request_verification.async_request_verification import (  # noqa: F401
     AsyncRequestVerification,
-)  # noqa
-from .ssl_check.async_ssl_check import AsyncSslCheck  # noqa
-from .url_verification.async_url_verification import AsyncUrlVerification  # noqa
-from .message_listener_matches.async_message_listener_matches import (
+)
+from .ssl_check.async_ssl_check import AsyncSslCheck  # noqa: F401
+from .url_verification.async_url_verification import AsyncUrlVerification  # noqa: F401
+from .message_listener_matches.async_message_listener_matches import (  # noqa: F401
     AsyncMessageListenerMatches,
-)  # noqa
+)

--- a/slack_bolt/middleware/authorization/__init__.py
+++ b/slack_bolt/middleware/authorization/__init__.py
@@ -1,4 +1,4 @@
 # Don't add async module imports here
-from .authorization import Authorization
-from .multi_teams_authorization import MultiTeamsAuthorization
-from .single_team_authorization import SingleTeamAuthorization
+from .authorization import Authorization  # noqa: F401
+from .multi_teams_authorization import MultiTeamsAuthorization  # noqa: F401
+from .single_team_authorization import SingleTeamAuthorization  # noqa: F401

--- a/slack_bolt/middleware/ssl_check/ssl_check.py
+++ b/slack_bolt/middleware/ssl_check/ssl_check.py
@@ -23,7 +23,7 @@ class SslCheck(Middleware):  # type: ignore
             verification_token: The verification token to check
                 (optional as it's already deprecated - https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation)
             base_logger: The base logger
-        """
+        """  # noqa: E501
         self.verification_token = verification_token
         self.logger = get_bolt_logger(SslCheck, base_logger=base_logger)
 

--- a/slack_bolt/oauth/internals.py
+++ b/slack_bolt/oauth/internals.py
@@ -91,7 +91,7 @@ body {{
 <p><a href="{url}"><img alt=""Add to Slack"" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a></p>
 </body>
 </html>
-"""
+"""  # noqa: E501
 
 
 # key: client_id, value: InstallationStore

--- a/slack_bolt/request/__init__.py
+++ b/slack_bolt/request/__init__.py
@@ -4,4 +4,4 @@ Refer to https://api.slack.com/apis/connections for the two types of connections
 This interface encapsulates the difference between the two.
 """
 # Don't add async module imports here
-from .request import BoltRequest
+from .request import BoltRequest  # noqa: F401

--- a/slack_bolt/response/__init__.py
+++ b/slack_bolt/response/__init__.py
@@ -6,4 +6,4 @@ the response data becomes an HTTP response data.
 Refer to https://api.slack.com/apis/connections for the two types of connections.
 """
 
-from .response import BoltResponse
+from .response import BoltResponse  # noqa: F401

--- a/slack_bolt/workflows/step/__init__.py
+++ b/slack_bolt/workflows/step/__init__.py
@@ -1,6 +1,6 @@
-from .step import WorkflowStep
-from .step_middleware import WorkflowStepMiddleware
-from .utilities.complete import Complete
-from .utilities.configure import Configure
-from .utilities.update import Update
-from .utilities.fail import Fail
+from .step import WorkflowStep  # noqa: F401
+from .step_middleware import WorkflowStepMiddleware  # noqa: F401
+from .utilities.complete import Complete  # noqa: F401
+from .utilities.configure import Configure  # noqa: F401
+from .utilities.update import Update  # noqa: F401
+from .utilities.fail import Fail  # noqa: F401

--- a/slack_bolt/workflows/step/async_step.py
+++ b/slack_bolt/workflows/step/async_step.py
@@ -230,11 +230,11 @@ class AsyncWorkflowStepBuilder:
             An `AsyncWorkflowStep` object
         """
         if self._edit is None:
-            raise BoltError(f"edit listener is not registered")
+            raise BoltError("edit listener is not registered")
         if self._save is None:
-            raise BoltError(f"save listener is not registered")
+            raise BoltError("save listener is not registered")
         if self._execute is None:
-            raise BoltError(f"execute listener is not registered")
+            raise BoltError("execute listener is not registered")
 
         return AsyncWorkflowStep(
             callback_id=self.callback_id,

--- a/slack_bolt/workflows/step/step.py
+++ b/slack_bolt/workflows/step/step.py
@@ -220,11 +220,11 @@ class WorkflowStepBuilder:
             WorkflowStep object
         """
         if self._edit is None:
-            raise BoltError(f"edit listener is not registered")
+            raise BoltError("edit listener is not registered")
         if self._save is None:
-            raise BoltError(f"save listener is not registered")
+            raise BoltError("save listener is not registered")
         if self._execute is None:
-            raise BoltError(f"execute listener is not registered")
+            raise BoltError("execute listener is not registered")
 
         return WorkflowStep(
             callback_id=self.callback_id,


### PR DESCRIPTION
This pull request enables Flake8 linter in the CI builds.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
