### PR TITLE
Fix #664 Django example installation store improvement

### DIFF
--- a/examples/django/oauth_app/slack_listeners.py
+++ b/examples/django/oauth_app/slack_listeners.py
@@ -13,11 +13,12 @@ from django.db.models import F
 from .slack_datastores import DjangoInstallationStore, DjangoOAuthStateStore
 
 logger = logging.getLogger(__name__)
-client_id, client_secret, signing_secret, scopes = (
+client_id, client_secret, signing_secret, scopes, user_scopes = (
     os.environ["SLACK_CLIENT_ID"],
     os.environ["SLACK_CLIENT_SECRET"],
     os.environ["SLACK_SIGNING_SECRET"],
     os.environ.get("SLACK_SCOPES", "commands").split(","),
+    os.environ.get("SLACK_USER_SCOPES", "search:read").split(","),
 )
 
 app = App(
@@ -26,6 +27,7 @@ app = App(
         client_id=client_id,
         client_secret=client_secret,
         scopes=scopes,
+        user_scopes=user_scopes,
         # If you want to test token rotation, enabling the following line will make it easy
         # token_rotation_expiration_minutes=1000000,
         installation_store=DjangoInstallationStore(


### PR DESCRIPTION
This pull request resolves #664 by improving the installation store in Django example app.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
