### PR TITLE
Fix #683 IgnoringSelfEvents middleware does not filter out Message sent via response_url

### DIFF
--- a/slack_bolt/middleware/ignoring_self_events/async_ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/async_ignoring_self_events.py
@@ -15,8 +15,9 @@ class AsyncIgnoringSelfEvents(IgnoringSelfEvents, AsyncMiddleware):
         next: Callable[[], Awaitable[BoltResponse]],
     ) -> BoltResponse:
         auth_result = req.context.authorize_result
-        user_id = req.context.user_id if req.context.user_id is not None else req.context.bot_user_id
-        if self._is_self_event(auth_result, user_id, req.body):
+        # message events can have $.event.bot_id while it does not have its user_id
+        bot_id = req.body.get("event", {}).get("bot_id")
+        if self._is_self_event(auth_result, req.context.user_id, bot_id, req.body):
             self._debug_log(req.body)
             return await req.context.ack()
         else:

--- a/slack_bolt/middleware/ignoring_self_events/async_ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/async_ignoring_self_events.py
@@ -15,7 +15,8 @@ class AsyncIgnoringSelfEvents(IgnoringSelfEvents, AsyncMiddleware):
         next: Callable[[], Awaitable[BoltResponse]],
     ) -> BoltResponse:
         auth_result = req.context.authorize_result
-        if self._is_self_event(auth_result, req.context.user_id, req.body):
+        user_id = req.context.user_id if req.context.user_id is not None else req.context.bot_user_id
+        if self._is_self_event(auth_result, user_id, req.body):
             self._debug_log(req.body)
             return await req.context.ack()
         else:

--- a/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
@@ -48,7 +48,7 @@ class IgnoringSelfEvents(Middleware):
             auth_result is not None
             and (
                 (user_id is not None and user_id == auth_result.bot_user_id)
-                or (bot_id is not None and auth_result.bot_id == bot_id)
+                or (bot_id is not None and bot_id == auth_result.bot_id)  # for bot_message events
             )
             and body.get("event") is not None
             and body.get("event", {}).get("type") not in cls.events_that_should_be_kept

--- a/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
@@ -21,7 +21,8 @@ class IgnoringSelfEvents(Middleware):
         next: Callable[[], BoltResponse],
     ) -> BoltResponse:
         auth_result = req.context.authorize_result
-        if self._is_self_event(auth_result, req.context.user_id, req.body):
+        user_id = req.context.user_id if req.context.user_id is not None else req.context.bot_user_id
+        if self._is_self_event(auth_result, user_id, req.body):
             self._debug_log(req.body)
             return req.context.ack()
         else:
@@ -29,7 +30,7 @@ class IgnoringSelfEvents(Middleware):
 
     # -----------------------------------------
 
-    # Its an Events API event that isn't of type message,
+    # It's an Events API event that isn't of type message,
     # but the user ID might match our own app. Filter these out.
     # However, some events still must be fired, because they can make sense.
     events_that_should_be_kept = ["member_joined_channel", "member_left_channel"]

--- a/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
@@ -37,10 +37,19 @@ class IgnoringSelfEvents(Middleware):
     events_that_should_be_kept = ["member_joined_channel", "member_left_channel"]
 
     @classmethod
-    def _is_self_event(cls, auth_result: AuthorizeResult, user_id: str, bot_id: Optional[str], body: Dict[str, Any]):
+    def _is_self_event(
+        cls,
+        auth_result: AuthorizeResult,
+        user_id: Optional[str],
+        bot_id: Optional[str],
+        body: Dict[str, Any],
+    ):
         return (
             auth_result is not None
-            and ((user_id is not None and user_id == auth_result.bot_user_id) or auth_result.bot_id == bot_id)
+            and (
+                (user_id is not None and user_id == auth_result.bot_user_id)
+                or (bot_id is not None and auth_result.bot_id == bot_id)
+            )
             and body.get("event") is not None
             and body.get("event", {}).get("type") not in cls.events_that_should_be_kept
         )

--- a/tests/scenario_tests/test_events_ignore_self.py
+++ b/tests/scenario_tests/test_events_ignore_self.py
@@ -57,6 +57,20 @@ class TestEventsIgnoreSelf:
         # The listener should not be executed
         assert self.mock_received_requests.get("/chat.postMessage") is None
 
+    def test_not_self_events_response_url(self):
+        app = App(client=self.web_client)
+
+        @app.event("message")
+        def handle_app_mention(say):
+            say("What's up?")
+
+        request: BoltRequest = BoltRequest(body=different_app_response_url_message_event, mode="socket_mode")
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert_auth_test_count(self, 1)
+        sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests.get("/chat.postMessage") == 1
+
     def test_self_events_disabled(self):
         app = App(
             client=self.web_client,
@@ -109,7 +123,28 @@ response_url_message_event = {
         "subtype": "bot_message",
         "text": "Hi there! This is a reply using response_url.",
         "ts": "1658282075.825129",
-        "bot_id": "B111",
+        "bot_id": "BZYBOTHED",
+        "channel": "C111",
+        "event_ts": "1658282075.825129",
+        "channel_type": "channel",
+    },
+    "type": "event_callback",
+    "event_id": "Ev111",
+    "event_time": 1599616881,
+    "authed_users": ["W111"],
+}
+
+different_app_response_url_message_event = {
+    "token": "verification_token",
+    "team_id": "T111",
+    "enterprise_id": "E111",
+    "api_app_id": "A111",
+    "event": {
+        "type": "message",
+        "subtype": "bot_message",
+        "text": "Hi there! This is a reply using response_url.",
+        "ts": "1658282075.825129",
+        "bot_id": "B_DIFFERENT_ONE",
         "channel": "C111",
         "event_ts": "1658282075.825129",
         "channel_type": "channel",

--- a/tests/scenario_tests/test_events_ignore_self.py
+++ b/tests/scenario_tests/test_events_ignore_self.py
@@ -42,6 +42,21 @@ class TestEventsIgnoreSelf:
         # The listener should not be executed
         assert self.mock_received_requests.get("/chat.postMessage") is None
 
+    def test_self_events_response_url(self):
+        app = App(client=self.web_client)
+
+        @app.event("message")
+        def handle_app_mention(say):
+            say("What's up?")
+
+        request: BoltRequest = BoltRequest(body=response_url_message_event, mode="socket_mode")
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert_auth_test_count(self, 1)
+        sleep(1)  # wait a bit after auto ack()
+        # The listener should not be executed
+        assert self.mock_received_requests.get("/chat.postMessage") is None
+
     def test_self_events_disabled(self):
         app = App(
             client=self.web_client,
@@ -77,6 +92,27 @@ event_body = {
         "reaction": "heart_eyes",
         "item_user": "W111",
         "event_ts": "1599616881.000800",
+    },
+    "type": "event_callback",
+    "event_id": "Ev111",
+    "event_time": 1599616881,
+    "authed_users": ["W111"],
+}
+
+response_url_message_event = {
+    "token": "verification_token",
+    "team_id": "T111",
+    "enterprise_id": "E111",
+    "api_app_id": "A111",
+    "event": {
+        "type": "message",
+        "subtype": "bot_message",
+        "text": "Hi there! This is a reply using response_url.",
+        "ts": "1658282075.825129",
+        "bot_id": "B111",
+        "channel": "C111",
+        "event_ts": "1658282075.825129",
+        "channel_type": "channel",
     },
     "type": "event_callback",
     "event_id": "Ev111",

--- a/tests/scenario_tests_async/test_events_ignore_self.py
+++ b/tests/scenario_tests_async/test_events_ignore_self.py
@@ -46,6 +46,18 @@ class TestAsyncEventsIgnoreSelf:
         assert self.mock_received_requests.get("/chat.postMessage") is None
 
     @pytest.mark.asyncio
+    async def test_self_events_response_url(self):
+        app = AsyncApp(client=self.web_client)
+        app.event("message")(whats_up)
+        request = AsyncBoltRequest(body=response_url_message_event, mode="socket_mode")
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        await asyncio.sleep(1)  # wait a bit after auto ack()
+        # The listener should not be executed
+        assert self.mock_received_requests.get("/chat.postMessage") is None
+
+    @pytest.mark.asyncio
     async def test_self_events_disabled(self):
         app = AsyncApp(client=self.web_client, ignoring_self_events_enabled=False)
         app.event("reaction_added")(whats_up)
@@ -74,6 +86,28 @@ self_event = {
         "reaction": "heart_eyes",
         "item_user": "W111",
         "event_ts": "1599616881.000800",
+    },
+    "type": "event_callback",
+    "event_id": "Ev111",
+    "event_time": 1599616881,
+    "authed_users": ["W111"],
+}
+
+
+response_url_message_event = {
+    "token": "verification_token",
+    "team_id": "T111",
+    "enterprise_id": "E111",
+    "api_app_id": "A111",
+    "event": {
+        "type": "message",
+        "subtype": "bot_message",
+        "text": "Hi there! This is a reply using response_url.",
+        "ts": "1658282075.825129",
+        "bot_id": "B111",
+        "channel": "C111",
+        "event_ts": "1658282075.825129",
+        "channel_type": "channel",
     },
     "type": "event_callback",
     "event_id": "Ev111",

--- a/tests/scenario_tests_async/test_events_ignore_self.py
+++ b/tests/scenario_tests_async/test_events_ignore_self.py
@@ -58,6 +58,17 @@ class TestAsyncEventsIgnoreSelf:
         assert self.mock_received_requests.get("/chat.postMessage") is None
 
     @pytest.mark.asyncio
+    async def test_not_self_events_response_url(self):
+        app = AsyncApp(client=self.web_client)
+        app.event("message")(whats_up)
+        request = AsyncBoltRequest(body=different_app_response_url_message_event, mode="socket_mode")
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        await asyncio.sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests.get("/chat.postMessage") == 1
+
+    @pytest.mark.asyncio
     async def test_self_events_disabled(self):
         app = AsyncApp(client=self.web_client, ignoring_self_events_enabled=False)
         app.event("reaction_added")(whats_up)
@@ -104,7 +115,29 @@ response_url_message_event = {
         "subtype": "bot_message",
         "text": "Hi there! This is a reply using response_url.",
         "ts": "1658282075.825129",
-        "bot_id": "B111",
+        "bot_id": "BZYBOTHED",
+        "channel": "C111",
+        "event_ts": "1658282075.825129",
+        "channel_type": "channel",
+    },
+    "type": "event_callback",
+    "event_id": "Ev111",
+    "event_time": 1599616881,
+    "authed_users": ["W111"],
+}
+
+
+different_app_response_url_message_event = {
+    "token": "verification_token",
+    "team_id": "T111",
+    "enterprise_id": "E111",
+    "api_app_id": "A111",
+    "event": {
+        "type": "message",
+        "subtype": "bot_message",
+        "text": "Hi there! This is a reply using response_url.",
+        "ts": "1658282075.825129",
+        "bot_id": "B_DIFFERENT_ONE",
         "channel": "C111",
         "event_ts": "1658282075.825129",
         "channel_type": "channel",


### PR DESCRIPTION
This pull request resolves #683 

I've confirmed that the same issue does not exist in bolt-js and bolt-java.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
