### PR TITLE
Fix #688 kwarg injection does not work with decorated functions

### DIFF
--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -14,6 +14,7 @@ from slack_bolt.authorization.async_authorize_args import AsyncAuthorizeArgs
 from slack_bolt.authorization import AuthorizeResult
 from slack_bolt.context.async_context import AsyncBoltContext
 from slack_bolt.error import BoltError
+from slack_bolt.util.utils import get_arg_names_of_callable
 
 
 class AsyncAuthorize:
@@ -42,7 +43,7 @@ class AsyncCallableAuthorize(AsyncAuthorize):
     def __init__(self, *, logger: Logger, func: Callable[..., Awaitable[AuthorizeResult]]):
         self.logger = logger
         self.func = func
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
 
     async def __call__(
         self,

--- a/slack_bolt/authorization/authorize.py
+++ b/slack_bolt/authorization/authorize.py
@@ -13,6 +13,7 @@ from slack_bolt.authorization.authorize_args import AuthorizeArgs
 from slack_bolt.authorization.authorize_result import AuthorizeResult
 from slack_bolt.context.context import BoltContext
 from slack_bolt.error import BoltError
+from slack_bolt.util.utils import get_arg_names_of_callable
 
 
 class Authorize:
@@ -46,7 +47,7 @@ class CallableAuthorize(Authorize):
     ):
         self.logger = logger
         self.func = func
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
 
     def __call__(
         self,

--- a/slack_bolt/lazy_listener/async_internals.py
+++ b/slack_bolt/lazy_listener/async_internals.py
@@ -5,6 +5,7 @@ from typing import Callable, Awaitable
 
 from slack_bolt.kwargs_injection.async_utils import build_async_required_kwargs
 from slack_bolt.request.async_request import AsyncBoltRequest
+from slack_bolt.util.utils import get_arg_names_of_callable
 
 
 async def to_runnable_function(
@@ -12,7 +13,7 @@ async def to_runnable_function(
     logger: Logger,
     request: AsyncBoltRequest,
 ):
-    arg_names = inspect.getfullargspec(internal_func).args
+    arg_names = get_arg_names_of_callable(internal_func)
 
     @wraps(internal_func)
     async def request_wired_wrapper() -> None:

--- a/slack_bolt/lazy_listener/internals.py
+++ b/slack_bolt/lazy_listener/internals.py
@@ -5,6 +5,7 @@ from typing import Callable
 
 from slack_bolt.kwargs_injection import build_required_kwargs
 from slack_bolt.request import BoltRequest
+from slack_bolt.util.utils import get_arg_names_of_callable
 
 
 def build_runnable_function(
@@ -12,7 +13,7 @@ def build_runnable_function(
     logger: Logger,
     request: BoltRequest,
 ) -> Callable[[], None]:
-    arg_names = inspect.getfullargspec(func).args
+    arg_names = get_arg_names_of_callable(func)
 
     @wraps(func)
     def request_wired_func_wrapper() -> None:

--- a/slack_bolt/listener/async_listener.py
+++ b/slack_bolt/listener/async_listener.py
@@ -6,6 +6,7 @@ from slack_bolt.middleware.async_middleware import AsyncMiddleware
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 from ..kwargs_injection.async_utils import build_async_required_kwargs
+from ..util.utils import get_arg_names_of_callable
 
 
 class AsyncListener(metaclass=ABCMeta):
@@ -107,7 +108,7 @@ class AsyncCustomListener(AsyncListener):
         self.matchers = matchers
         self.middleware = middleware
         self.auto_acknowledgement = auto_acknowledgement
-        self.arg_names = inspect.getfullargspec(ack_function).args
+        self.arg_names = get_arg_names_of_callable(ack_function)
         self.logger = get_bolt_app_logger(app_name, self.ack_function, base_logger)
 
     async def run_ack_function(

--- a/slack_bolt/listener/async_listener_completion_handler.py
+++ b/slack_bolt/listener/async_listener_completion_handler.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Any, Awaitable, Optional
 from slack_bolt.kwargs_injection.async_utils import build_async_required_kwargs
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
+from slack_bolt.util.utils import get_arg_names_of_callable
 
 
 class AsyncListenerCompletionHandler(metaclass=ABCMeta):
@@ -28,7 +29,7 @@ class AsyncCustomListenerCompletionHandler(AsyncListenerCompletionHandler):
     def __init__(self, logger: Logger, func: Callable[..., Awaitable[None]]):
         self.func = func
         self.logger = logger
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
 
     async def handle(
         self,

--- a/slack_bolt/listener/async_listener_error_handler.py
+++ b/slack_bolt/listener/async_listener_error_handler.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Any, Awaitable, Optional
 from slack_bolt.kwargs_injection.async_utils import build_async_required_kwargs
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
+from slack_bolt.util.utils import get_arg_names_of_callable
 
 
 class AsyncListenerErrorHandler(metaclass=ABCMeta):
@@ -30,7 +31,7 @@ class AsyncCustomListenerErrorHandler(AsyncListenerErrorHandler):
     def __init__(self, logger: Logger, func: Callable[..., Awaitable[Optional[BoltResponse]]]):
         self.func = func
         self.logger = logger
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
 
     async def handle(
         self,

--- a/slack_bolt/listener/async_listener_start_handler.py
+++ b/slack_bolt/listener/async_listener_start_handler.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Any, Awaitable, Optional
 from slack_bolt.kwargs_injection.async_utils import build_async_required_kwargs
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
+from slack_bolt.util.utils import get_arg_names_of_callable
 
 
 class AsyncListenerStartHandler(metaclass=ABCMeta):
@@ -28,7 +29,7 @@ class AsyncCustomListenerStartHandler(AsyncListenerStartHandler):
     def __init__(self, logger: Logger, func: Callable[..., Awaitable[None]]):
         self.func = func
         self.logger = logger
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
 
     async def handle(
         self,

--- a/slack_bolt/listener/custom_listener.py
+++ b/slack_bolt/listener/custom_listener.py
@@ -9,6 +9,7 @@ from slack_bolt.response import BoltResponse
 from .listener import Listener
 from ..logger import get_bolt_app_logger
 from ..middleware import Middleware
+from ..util.utils import get_arg_names_of_callable
 
 
 class CustomListener(Listener):
@@ -38,7 +39,7 @@ class CustomListener(Listener):
         self.matchers = matchers
         self.middleware = middleware
         self.auto_acknowledgement = auto_acknowledgement
-        self.arg_names = inspect.getfullargspec(ack_function).args
+        self.arg_names = get_arg_names_of_callable(ack_function)
         self.logger = get_bolt_app_logger(app_name, self.ack_function, base_logger)
 
     def run_ack_function(

--- a/slack_bolt/listener/listener_completion_handler.py
+++ b/slack_bolt/listener/listener_completion_handler.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Any, Optional
 from slack_bolt.kwargs_injection import build_required_kwargs
 from slack_bolt.request.request import BoltRequest
 from slack_bolt.response.response import BoltResponse
+from slack_bolt.util.utils import get_arg_names_of_callable
 
 
 class ListenerCompletionHandler(metaclass=ABCMeta):
@@ -28,7 +29,7 @@ class CustomListenerCompletionHandler(ListenerCompletionHandler):
     def __init__(self, logger: Logger, func: Callable[..., None]):
         self.func = func
         self.logger = logger
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
 
     def handle(
         self,

--- a/slack_bolt/listener/listener_error_handler.py
+++ b/slack_bolt/listener/listener_error_handler.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Any, Optional
 from slack_bolt.kwargs_injection import build_required_kwargs
 from slack_bolt.request.request import BoltRequest
 from slack_bolt.response.response import BoltResponse
+from slack_bolt.util.utils import get_arg_names_of_callable
 
 
 class ListenerErrorHandler(metaclass=ABCMeta):
@@ -30,7 +31,7 @@ class CustomListenerErrorHandler(ListenerErrorHandler):
     def __init__(self, logger: Logger, func: Callable[..., Optional[BoltResponse]]):
         self.func = func
         self.logger = logger
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
 
     def handle(
         self,

--- a/slack_bolt/listener/listener_start_handler.py
+++ b/slack_bolt/listener/listener_start_handler.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Any, Optional
 from slack_bolt.kwargs_injection import build_required_kwargs
 from slack_bolt.request.request import BoltRequest
 from slack_bolt.response.response import BoltResponse
+from slack_bolt.util.utils import get_arg_names_of_callable
 
 
 class ListenerStartHandler(metaclass=ABCMeta):
@@ -32,7 +33,7 @@ class CustomListenerStartHandler(ListenerStartHandler):
     def __init__(self, logger: Logger, func: Callable[..., None]):
         self.func = func
         self.logger = logger
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
 
     def handle(
         self,

--- a/slack_bolt/listener_matcher/async_listener_matcher.py
+++ b/slack_bolt/listener_matcher/async_listener_matcher.py
@@ -2,6 +2,7 @@ from abc import abstractmethod, ABCMeta
 
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
+from slack_bolt.util.utils import get_arg_names_of_callable
 
 
 class AsyncListenerMatcher(metaclass=ABCMeta):
@@ -38,7 +39,7 @@ class AsyncCustomListenerMatcher(AsyncListenerMatcher):
     def __init__(self, *, app_name: str, func: Callable[..., Awaitable[bool]], base_logger: Optional[Logger] = None):
         self.app_name = app_name
         self.func = func
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
         self.logger = get_bolt_app_logger(self.app_name, self.func, base_logger)
 
     async def async_matches(self, req: AsyncBoltRequest, resp: BoltResponse) -> bool:

--- a/slack_bolt/listener_matcher/builtins.py
+++ b/slack_bolt/listener_matcher/builtins.py
@@ -24,6 +24,7 @@ from slack_bolt.request.payload_utils import (
     is_workflow_step_save,
 )
 from ..logger.messages import error_message_event_type
+from ..util.utils import get_arg_names_of_callable
 
 if sys.version_info.major == 3 and sys.version_info.minor <= 6:
     from re import _pattern_type as Pattern
@@ -47,7 +48,7 @@ class BuiltinListenerMatcher(ListenerMatcher):
         base_logger: Optional[Logger] = None,
     ):
         self.func = func
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
         self.logger = get_bolt_logger(self.func, base_logger)
 
     def matches(self, req: BoltRequest, resp: BoltResponse) -> bool:

--- a/slack_bolt/listener_matcher/custom_listener_matcher.py
+++ b/slack_bolt/listener_matcher/custom_listener_matcher.py
@@ -7,6 +7,7 @@ from slack_bolt.logger import get_bolt_app_logger
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 from .listener_matcher import ListenerMatcher
+from ..util.utils import get_arg_names_of_callable
 
 
 class CustomListenerMatcher(ListenerMatcher):
@@ -18,7 +19,7 @@ class CustomListenerMatcher(ListenerMatcher):
     def __init__(self, *, app_name: str, func: Callable[..., bool], base_logger: Optional[Logger] = None):
         self.app_name = app_name
         self.func = func
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
         self.logger = get_bolt_app_logger(self.app_name, self.func, base_logger)
 
     def matches(self, req: BoltRequest, resp: BoltResponse) -> bool:

--- a/slack_bolt/middleware/async_custom_middleware.py
+++ b/slack_bolt/middleware/async_custom_middleware.py
@@ -7,7 +7,7 @@ from slack_bolt.logger import get_bolt_app_logger
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 from .async_middleware import AsyncMiddleware
-from slack_bolt.util.utils import get_name_for_callable
+from slack_bolt.util.utils import get_name_for_callable, get_arg_names_of_callable
 
 
 class AsyncCustomMiddleware(AsyncMiddleware):
@@ -29,7 +29,7 @@ class AsyncCustomMiddleware(AsyncMiddleware):
         else:
             raise ValueError("Async middleware function must be an async function")
 
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
         self.logger = get_bolt_app_logger(self.app_name, self.func, base_logger)
 
     async def async_process(

--- a/slack_bolt/middleware/async_middleware_error_handler.py
+++ b/slack_bolt/middleware/async_middleware_error_handler.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Any, Awaitable, Optional
 from slack_bolt.kwargs_injection.async_utils import build_async_required_kwargs
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
+from slack_bolt.util.utils import get_arg_names_of_callable
 
 
 class AsyncMiddlewareErrorHandler(metaclass=ABCMeta):
@@ -30,7 +31,7 @@ class AsyncCustomMiddlewareErrorHandler(AsyncMiddlewareErrorHandler):
     def __init__(self, logger: Logger, func: Callable[..., Awaitable[Optional[BoltResponse]]]):
         self.func = func
         self.logger = logger
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
 
     async def handle(
         self,

--- a/slack_bolt/middleware/custom_middleware.py
+++ b/slack_bolt/middleware/custom_middleware.py
@@ -7,7 +7,7 @@ from slack_bolt.logger import get_bolt_app_logger
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 from .middleware import Middleware
-from slack_bolt.util.utils import get_name_for_callable
+from slack_bolt.util.utils import get_name_for_callable, get_arg_names_of_callable
 
 
 class CustomMiddleware(Middleware):
@@ -19,7 +19,7 @@ class CustomMiddleware(Middleware):
     def __init__(self, *, app_name: str, func: Callable, base_logger: Optional[Logger] = None):
         self.app_name = app_name
         self.func = func
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
         self.logger = get_bolt_app_logger(self.app_name, self.func, base_logger)
 
     def process(

--- a/slack_bolt/middleware/middleware_error_handler.py
+++ b/slack_bolt/middleware/middleware_error_handler.py
@@ -6,6 +6,7 @@ from typing import Callable, Optional, Any, Dict
 from slack_bolt.kwargs_injection.utils import build_required_kwargs
 from slack_bolt.request.request import BoltRequest
 from slack_bolt.response.response import BoltResponse
+from slack_bolt.util.utils import get_arg_names_of_callable
 
 
 class MiddlewareErrorHandler(metaclass=ABCMeta):
@@ -30,7 +31,7 @@ class CustomMiddlewareErrorHandler(MiddlewareErrorHandler):
     def __init__(self, logger: Logger, func: Callable[..., Optional[BoltResponse]]):
         self.func = func
         self.logger = logger
-        self.arg_names = inspect.getfullargspec(func).args
+        self.arg_names = get_arg_names_of_callable(func)
 
     def handle(
         self,

--- a/slack_bolt/util/utils.py
+++ b/slack_bolt/util/utils.py
@@ -1,7 +1,8 @@
 import copy
+import inspect
 import sys
 from logging import Logger
-from typing import Optional, Union, Dict, Any, Sequence, Callable
+from typing import Optional, Union, Dict, Any, Sequence, Callable, List
 
 from slack_sdk import WebClient
 from slack_sdk.models import JsonObject
@@ -83,3 +84,7 @@ def get_name_for_callable(func: Callable) -> str:
         return func.__name__
     else:
         return f"{func.__class__.__module__}.{func.__class__.__name__}"
+
+
+def get_arg_names_of_callable(func: Callable) -> List[str]:
+    return inspect.getfullargspec(inspect.unwrap(func)).args


### PR DESCRIPTION
This pull request resolves #688 

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
