### PR TITLE
Issue #660: Replace HTML entities before markdownify in docs

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -49,7 +49,7 @@ sidebar_style: main
         <div class="section-wrapper">
           <h3 id="{{section.slug}}">{{ section.title }}</h3>
 
-          {{ section.content | markdownify }}
+          {{ section.content | replace: "&amp;", "&" | replace: "&lt;", "<" | replace: "&gt;", ">" | markdownify }}
 
           <hr>
         </div>


### PR DESCRIPTION
See Issue: (#660)

Hi -- I thought I'd take a look at #660 as a good first issue in the project. However, it ended up being more complicated than characters not being escaped correctly. 😅 

I believe this is being caused by an interaction between `kramdown` and `markdownify` in Github Pages specifically because this section is a code block nested inside of a `<div>` which in turn is nested inside of `<details>`.  Since the `<div>` in question has `markdown="0"` set, kramdown outputs this block as HTML, with the characters ">", "<", and "&" represented as `&gt;`, `&lt;` and `&amp;`. When it hits the markdownify, it's trying to do syntax highlighting, so it wraps the semicolon in a span and the HTML becomes malformed:

```html
Less than: &amp;gt<span class="p">;</span>
Greater than: &amp;lt<span class="p">;</span>
Ampersand: &amp;amp<span class="p">;</span>
```


This is not a pretty fix -- it turns those HTML entities back into their characters before converting the section to markdown. Based on what I tried, I think this should actually be addressed in one of those two libraries and how nested code blocks are handled, but this pr should fix your documentation if you'd like.

<img width="593" alt="Screen Shot 2022-07-26 at 1 20 30 PM" src="https://user-images.githubusercontent.com/967550/181082401-d81de069-fda1-447b-a673-a97f32763873.png">

 

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
