### PR TITLE
Add message app.event example

### DIFF
--- a/examples/events_app.py
+++ b/examples/events_app.py
@@ -24,6 +24,11 @@ def event_test(body, say, logger):
 def say_something_to_reaction(say):
     say("OK!")
 
+    
+@app.event("message")
+def log_message_event(logger, body)
+    logger.info(body)
+
 
 @app.message("test")
 def test_message(logger, body):


### PR DESCRIPTION
Add an example of logging the 'message' app event as this wasn't something i could find when i needed it.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [ x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
