### PR TITLE
Change to create a WebClient per request for safety

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -1206,21 +1206,25 @@ class App:
     def _init_context(self, req: BoltRequest):
         req.context["logger"] = get_bolt_app_logger(app_name=self.name, base_logger=self._base_logger)
         req.context["token"] = self._token
-        if self._token is not None:
-            # This WebClient instance can be safely singleton
-            req.context["client"] = self._client
-        else:
-            # Set a new dedicated instance for this request
-            client_per_request: WebClient = WebClient(
-                token=None,  # the token will be set later
-                base_url=self._client.base_url,
-                timeout=self._client.timeout,
-                ssl=self._client.ssl,
-                proxy=self._client.proxy,
-                headers=self._client.headers,
-                team_id=req.context.team_id,
-            )
-            req.context["client"] = client_per_request
+        # Prior to version 1.15, when the token is static, self._client was passed to `req.context`.
+        # The intention was to avoid creating a new instance per request
+        # in the interest of runtime performance/memory footprint optimization.
+        # However, developers may want to replace the token held by req.context.client in some situations.
+        # In this case, this behavior can result in thread-unsafe data modification on `self._client`.
+        # (`self._client` a.k.a. `app.clint` is a singleton object per an App instance)
+        # Thus, we've changed the behavior to create a new instance per request regardless of token argument
+        # in the App initialization starting v1.15.
+        # The overhead brought by this change is slight so that we believe that it is ignorable in any cases.
+        client_per_request: WebClient = WebClient(
+            token=self._token,  # this can be None, and it can be set later on
+            base_url=self._client.base_url,
+            timeout=self._client.timeout,
+            ssl=self._client.ssl,
+            proxy=self._client.proxy,
+            headers=self._client.headers,
+            team_id=req.context.team_id,
+        )
+        req.context["client"] = client_per_request
 
     @staticmethod
     def _to_listener_functions(

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -1211,7 +1211,7 @@ class App:
         # in the interest of runtime performance/memory footprint optimization.
         # However, developers may want to replace the token held by req.context.client in some situations.
         # In this case, this behavior can result in thread-unsafe data modification on `self._client`.
-        # (`self._client` a.k.a. `app.clint` is a singleton object per an App instance)
+        # (`self._client` a.k.a. `app.client` is a singleton object per an App instance)
         # Thus, we've changed the behavior to create a new instance per request regardless of token argument
         # in the App initialization starting v1.15.
         # The overhead brought by this change is slight so that we believe that it is ignorable in any cases.

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -1240,23 +1240,27 @@ class AsyncApp:
     def _init_context(self, req: AsyncBoltRequest):
         req.context["logger"] = get_bolt_app_logger(app_name=self.name, base_logger=self._base_logger)
         req.context["token"] = self._token
-        if self._token is not None:
-            # This AsyncWebClient instance can be safely singleton
-            req.context["client"] = self._async_client
-        else:
-            # Set a new dedicated instance for this request
-            client_per_request: AsyncWebClient = AsyncWebClient(
-                token=None,  # the token will be set later
-                base_url=self._async_client.base_url,
-                timeout=self._async_client.timeout,
-                ssl=self._async_client.ssl,
-                proxy=self._async_client.proxy,
-                session=self._async_client.session,
-                trust_env_in_session=self._async_client.trust_env_in_session,
-                headers=self._async_client.headers,
-                team_id=req.context.team_id,
-            )
-            req.context["client"] = client_per_request
+        # Prior to version 1.15, when the token is static, self._client was passed to `req.context`.
+        # The intention was to avoid creating a new instance per request
+        # in the interest of runtime performance/memory footprint optimization.
+        # However, developers may want to replace the token held by req.context.client in some situations.
+        # In this case, this behavior can result in thread-unsafe data modification on `self._client`.
+        # (`self._client` a.k.a. `app.clint` is a singleton object per an App instance)
+        # Thus, we've changed the behavior to create a new instance per request regardless of token argument
+        # in the App initialization starting v1.15.
+        # The overhead brought by this change is slight so that we believe that it is ignorable in any cases.
+        client_per_request: AsyncWebClient = AsyncWebClient(
+            token=self._token,  # this can be None, and it can be set later on
+            base_url=self._async_client.base_url,
+            timeout=self._async_client.timeout,
+            ssl=self._async_client.ssl,
+            proxy=self._async_client.proxy,
+            session=self._async_client.session,
+            trust_env_in_session=self._async_client.trust_env_in_session,
+            headers=self._async_client.headers,
+            team_id=req.context.team_id,
+        )
+        req.context["client"] = client_per_request
 
     @staticmethod
     def _to_listener_functions(

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -1245,7 +1245,7 @@ class AsyncApp:
         # in the interest of runtime performance/memory footprint optimization.
         # However, developers may want to replace the token held by req.context.client in some situations.
         # In this case, this behavior can result in thread-unsafe data modification on `self._client`.
-        # (`self._client` a.k.a. `app.clint` is a singleton object per an App instance)
+        # (`self._client` a.k.a. `app.client` is a singleton object per an App instance)
         # Thus, we've changed the behavior to create a new instance per request regardless of token argument
         # in the App initialization starting v1.15.
         # The overhead brought by this change is slight so that we believe that it is ignorable in any cases.


### PR DESCRIPTION
As we discussed at https://github.com/slackapi/bolt-python/pull/713, with the current implementation, `req.context.client` can be a singleton object in an `App` instance. This can be a cause of unexpected behaviors when a developer modify the properties such as token of the instance on the fly. This pull request improve the internals to be more robust even for such use cases.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
