### PR TITLE
[future beta] Adding async capabilities to remote functions interactivity

### DIFF
--- a/slack_bolt/middleware/async_builtins.py
+++ b/slack_bolt/middleware/async_builtins.py
@@ -9,6 +9,7 @@ from .url_verification.async_url_verification import AsyncUrlVerification
 from .message_listener_matches.async_message_listener_matches import (
     AsyncMessageListenerMatches,
 )
+from .attaching_function_token.async_attaching_function_token import AsyncAttachingFunctionToken
 
 __all__ = [
     "AsyncIgnoringSelfEvents",
@@ -16,4 +17,5 @@ __all__ = [
     "AsyncSslCheck",
     "AsyncUrlVerification",
     "AsyncMessageListenerMatches",
+    "AsyncAttachingFunctionToken",
 ]

--- a/slack_bolt/middleware/attaching_function_token/async_attaching_function_token.py
+++ b/slack_bolt/middleware/attaching_function_token/async_attaching_function_token.py
@@ -1,0 +1,20 @@
+from typing import Callable, Awaitable
+
+from slack_bolt.request.async_request import AsyncBoltRequest
+from slack_bolt.response import BoltResponse
+from slack_bolt.middleware.async_middleware import AsyncMiddleware
+
+
+class AsyncAttachingFunctionToken(AsyncMiddleware):  # type: ignore
+    async def async_process(
+        self,
+        *,
+        req: AsyncBoltRequest,
+        resp: BoltResponse,
+        # This method is not supposed to be invoked by bolt-python users
+        next: Callable[[], Awaitable[BoltResponse]],
+    ) -> BoltResponse:
+        if req.context.slack_function_bot_access_token is not None:
+            req.context.client.token = req.context.slack_function_bot_access_token
+
+        return await next()

--- a/slack_bolt/request/async_internals.py
+++ b/slack_bolt/request/async_internals.py
@@ -8,6 +8,7 @@ from slack_bolt.request.internals import (
     extract_user_id,
     extract_channel_id,
     extract_function_execution_id,
+    extract_slack_function_bot_access_token,
     debug_multiple_response_urls_detected,
 )
 
@@ -32,6 +33,9 @@ def build_async_context(
     function_execution_id = extract_function_execution_id(body)
     if function_execution_id:
         context["function_execution_id"] = function_execution_id
+    slack_function_bot_access_token = extract_slack_function_bot_access_token(body)
+    if slack_function_bot_access_token is not None:
+        context["slack_function_bot_access_token"] = slack_function_bot_access_token
     if "response_url" in body:
         context["response_url"] = body["response_url"]
     elif "response_urls" in body:

--- a/slack_bolt/slack_function/slack_function.py
+++ b/slack_bolt/slack_function/slack_function.py
@@ -20,16 +20,20 @@ class SlackFunction:
         callback_id: str,
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
+        asyncio: bool = False,
     ):
         self._register_listener = register_listener
         self._base_logger = base_logger
         self.callback_id = callback_id
         self.matchers = matchers
         self.middleware = middleware
+        self.asyncio = asyncio
 
     def register_listener(self, *args, **kwargs) -> None:
         functions = extract_listener_callables(kwargs) if kwargs else list(args)
-        primary_matcher = builtin_matchers.function_event(callback_id=self.callback_id, base_logger=self._base_logger)
+        primary_matcher = builtin_matchers.function_event(
+            callback_id=self.callback_id, base_logger=self._base_logger, asyncio=self.asyncio
+        )
         self.func = self._register_listener(functions, primary_matcher, self.matchers, self.middleware, True)
 
     def __call__(self, *args, **kwargs) -> Optional[Union[BoltResponse, Callable]]:
@@ -72,13 +76,14 @@ class SlackFunction:
 
         def __call__(*args, **kwargs):
             functions = extract_listener_callables(kwargs) if kwargs else list(args)
-            primary_matcher = builtin_matchers.function_action(self.callback_id, constraints, base_logger=self._base_logger)
+            primary_matcher = builtin_matchers.function_action(
+                self.callback_id, constraints, base_logger=self._base_logger, asyncio=self.asyncio
+            )
             return self._register_listener(list(functions), primary_matcher, matchers, middleware)
 
         return __call__
 
-        # -------------------------
-
+    # -------------------------
     # view
 
     def view(
@@ -133,7 +138,9 @@ class SlackFunction:
 
         def __call__(*args, **kwargs):
             functions = extract_listener_callables(kwargs) if kwargs else list(args)
-            primary_matcher = builtin_matchers.function_view(self.callback_id, constraints, base_logger=self._base_logger)
+            primary_matcher = builtin_matchers.function_view(
+                self.callback_id, constraints, base_logger=self._base_logger, asyncio=self.asyncio
+            )
             return self._register_listener(list(functions), primary_matcher, matchers, middleware)
 
         return __call__
@@ -149,7 +156,7 @@ class SlackFunction:
         def __call__(*args, **kwargs):
             functions = extract_listener_callables(kwargs) if kwargs else list(args)
             primary_matcher = builtin_matchers.function_view_submission(
-                self.callback_id, constraints, base_logger=self._base_logger
+                self.callback_id, constraints, base_logger=self._base_logger, asyncio=self.asyncio
             )
             return self._register_listener(list(functions), primary_matcher, matchers, middleware)
 
@@ -166,7 +173,7 @@ class SlackFunction:
         def __call__(*args, **kwargs):
             functions = extract_listener_callables(kwargs) if kwargs else list(args)
             primary_matcher = builtin_matchers.function_view_closed(
-                self.callback_id, constraints, base_logger=self._base_logger
+                self.callback_id, constraints, base_logger=self._base_logger, asyncio=self.asyncio
             )
             return self._register_listener(list(functions), primary_matcher, matchers, middleware)
 

--- a/tests/scenario_tests_async/test_function_block_action.py
+++ b/tests/scenario_tests_async/test_function_block_action.py
@@ -1,0 +1,286 @@
+import json
+import time
+import pytest
+
+from slack_sdk.web.async_client import AsyncWebClient
+from slack_sdk.signature import SignatureVerifier
+
+from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.request.async_request import AsyncBoltRequest
+from slack_bolt.context import BoltContext
+from slack_bolt.slack_function import SlackFunction
+
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+    assert_auth_test_count_async,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class TestFunctionBlockActions:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = AsyncWebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    def setup_method(self):
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body,
+            timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        return {
+            "content-type": ["application/json"],
+            "x-slack-signature": [self.generate_signature(body, timestamp)],
+            "x-slack-request-timestamp": [timestamp],
+        }
+
+    def build_request_from_body(self, message_body: dict) -> AsyncBoltRequest:
+        timestamp, body = str(int(time.time())), json.dumps(message_body)
+        return AsyncBoltRequest(body=body, headers=self.build_headers(timestamp, body))
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        func: SlackFunction = app.function("c")(func_listener)
+        func.action("a")(simple_listener)
+
+        request = self.build_request_from_body(function_action_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        assert self.mock_received_requests["/functions.completeSuccess"] == 1
+
+    @pytest.mark.asyncio
+    async def test_process_before_response(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            process_before_response=True,
+        )
+        func: SlackFunction = app.function("c")(func_listener)
+        func.action("a")(simple_listener)
+
+        request = self.build_request_from_body(function_action_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        assert self.mock_received_requests["/functions.completeSuccess"] == 1
+
+    @pytest.mark.asyncio
+    async def test_default_type(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret)
+        func: SlackFunction = app.function("c")(func_listener)
+        func.action({"action_id": "a", "block_id": "b"})(simple_listener)
+
+        request = self.build_request_from_body(function_action_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        assert self.mock_received_requests["/functions.completeSuccess"] == 1
+
+    @pytest.mark.asyncio
+    async def test_default_type_no_block_id(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret)
+        func: SlackFunction = app.function("c")(func_listener)
+        func.action({"action_id": "a"})(simple_listener)
+
+        request = self.build_request_from_body(function_action_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        assert self.mock_received_requests["/functions.completeSuccess"] == 1
+
+    @pytest.mark.asyncio
+    async def test_default_type_and_unmatched_block_id(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret)
+        func: SlackFunction = app.function("c")(func_listener)
+        func.action({"action_id": "a", "block_id": "bbb"})(simple_listener)
+
+        request = self.build_request_from_body(function_action_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        await assert_auth_test_count_async(self, 1)
+        assert "/functions.completeSuccess" not in self.mock_received_requests
+
+    @pytest.mark.asyncio
+    async def test_failure(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        request = self.build_request_from_body(function_action_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        await assert_auth_test_count_async(self, 1)
+
+        app.action("aaa")(simple_listener)
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        await assert_auth_test_count_async(self, 1)
+
+    @pytest.mark.asyncio
+    async def test_failure_2(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        request = self.build_request_from_body(function_action_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        await assert_auth_test_count_async(self, 1)
+
+        app.block_action("aaa")(simple_listener)
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        await assert_auth_test_count_async(self, 1)
+
+    @pytest.mark.asyncio
+    async def test_success_decorators(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+
+        @app.function("c")
+        async def func_listener_wrap(body):
+            return await func_listener(body)
+
+        @func_listener_wrap.action("a")
+        async def simple_listener_wrap(ack, complete, body, payload, action, client: AsyncWebClient, context: BoltContext):
+            await simple_listener(ack, complete, body, payload, action, client, context)
+
+        request = self.build_request_from_body(function_action_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        assert self.mock_received_requests["/functions.completeSuccess"] == 1
+
+    @pytest.mark.asyncio
+    async def test_success_deconstructed_decorators(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        func: SlackFunction = app.function("c")
+
+        @func
+        async def func_listener_wrap(body):
+            return await func_listener(body)
+
+        @func.action("a")
+        async def simple_listener_wrap(ack, complete, body, payload, action, client: AsyncWebClient, context: BoltContext):
+            await simple_listener(ack, complete, body, payload, action, client, context)
+
+        request = self.build_request_from_body(function_action_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        assert self.mock_received_requests["/functions.completeSuccess"] == 1
+
+    @pytest.mark.asyncio
+    async def test_success_mixed_decorators(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        func: SlackFunction = app.function("c")
+
+        @func
+        async def func_listener_wrap(body):
+            return await func_listener(body)
+
+        @func_listener_wrap.action("a")
+        async def simple_listener_wrap(ack, complete, body, payload, action, client: AsyncWebClient, context: BoltContext):
+            await simple_listener(ack, complete, body, payload, action, client, context)
+
+        request = self.build_request_from_body(function_action_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        assert self.mock_received_requests["/functions.completeSuccess"] == 1
+
+
+function_action_body = {
+    "type": "block_actions",
+    "user": {"id": "U111", "username": "primary-owner", "name": "primary-owner", "team_id": "T111"},
+    "api_app_id": "A111",
+    "token": "verification_token",
+    "container": {"type": "message", "message_ts": "111.222", "channel_id": "C111", "is_ephemeral": False},
+    "trigger_id": "111.222.valid",
+    "team": {"id": "T111", "domain": "bill-at-tools"},
+    "enterprise": None,
+    "is_enterprise_install": False,
+    "channel": {"id": "C111", "name": "directmessage"},
+    "state": {"values": {}},
+    "response_url": "https://hooks.slack.com/actions/T111/111/random-value",
+    "actions": [
+        {
+            "action_id": "a",
+            "block_id": "b",
+            "text": {"type": "plain_text", "text": "Button", "emoji": True},
+            "value": "click_me_123",
+            "type": "button",
+            "style": "primary",
+            "action_ts": "111.222.3",
+        }
+    ],
+    "function_data": {
+        "execution_id": "Fx111",
+        "inputs": {},
+        "function": {
+            "id": "Fn111",
+            "callback_id": "c",
+            "title": "A Title",
+            "description": "do the thing",
+            "type": "app",
+            "input_parameters": [],
+            "output_parameters": [],
+            "app_id": "A111",
+            "date_created": 1661459156,
+            "date_updated": 1661530445,
+            "date_deleted": 0,
+        },
+    },
+    "interactivity": {"interactor": {"secret": "S111", "id": "U111"}, "interactivity_pointer": "111.222.valid"},
+    "bot_access_token": "xwfp-valid",
+}
+
+
+async def func_listener(body):
+    assert body == function_action_body
+
+
+async def simple_listener(ack, complete, body, payload, action, client: AsyncWebClient, context: BoltContext):
+    assert body["trigger_id"] == "111.222.valid"
+    assert body["actions"][0] == payload
+    assert payload == action
+    assert action["action_id"] == "a"
+    assert context.bot_id == "BZYBOTHED"
+    assert context.bot_user_id == "W23456789"
+    assert context.bot_token == "xoxb-valid"
+    assert context.token == "xoxb-valid"
+    assert context.user_id == "U111"
+    assert context.user_token is None
+    assert context.slack_function_bot_access_token == "xwfp-valid"
+    assert context.client.token == "xwfp-valid"
+    assert client.token == "xwfp-valid"
+    await ack()
+    await complete()

--- a/tests/scenario_tests_async/test_function_decorators.py
+++ b/tests/scenario_tests_async/test_function_decorators.py
@@ -1,0 +1,106 @@
+from typing import Callable
+
+import pytest
+from slack_sdk.web.async_client import AsyncWebClient
+
+from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.context.ack.async_ack import AsyncAck
+
+from slack_bolt import BoltResponse
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class NoopAsyncAck(AsyncAck):
+    async def __call__(self) -> BoltResponse:
+        pass
+
+
+class TestAppDecorators:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    web_client = AsyncWebClient(token=valid_token, base_url=mock_api_server_base_url)
+
+    def setup_method(self):
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
+
+    @pytest.mark.asyncio
+    async def test_decorators(self):
+        app = AsyncApp(signing_secret=self.signing_secret, client=self.web_client)
+        ack = NoopAsyncAck()
+
+        @app.function("c")
+        async def handle_function_events(body: dict):
+            assert body is not None
+
+        @handle_function_events.action("some-func-action-id")
+        async def handle_function_action(ack: AsyncAck, body: dict):
+            assert body is not None
+            await ack()
+
+        await handle_function_action(ack, {})
+        assert isinstance(handle_function_action, Callable)
+
+        @handle_function_events.view("some-callback-id")
+        async def handle_views(ack: AsyncAck, body: dict):
+            assert body is not None
+            await ack()
+
+        await handle_views(ack, {})
+        assert isinstance(handle_views, Callable)
+
+        await handle_function_events({})
+        assert isinstance(handle_function_events, Callable)
+
+    @pytest.mark.asyncio
+    async def test_initialized_decorators(self):
+        app = AsyncApp(signing_secret=self.signing_secret, client=self.web_client)
+        ack = NoopAsyncAck()
+
+        func = app.function("c")
+
+        @func
+        async def handle_function_events(body: dict):
+            assert body is not None
+
+        @handle_function_events.action("some-func-action-id")
+        async def handle_function_action(ack: AsyncAck, body: dict):
+            assert body is not None
+            await ack()
+
+        await handle_function_action(ack, {})
+        assert isinstance(handle_function_action, Callable)
+
+        await handle_function_events({})
+        assert isinstance(handle_function_events, Callable)
+
+    @pytest.mark.asyncio
+    async def test_mixed_decorators(self):
+        app = AsyncApp(signing_secret=self.signing_secret, client=self.web_client)
+        ack = NoopAsyncAck()
+
+        func = app.function("c")
+
+        @func
+        async def handle_function_events(body: dict):
+            assert body is not None
+
+        @func.action("some-func-action-id")
+        async def handle_function_action(ack: AsyncAck, body: dict):
+            assert body is not None
+            await ack()
+
+        await handle_function_action(ack, {})
+        assert isinstance(handle_function_action, Callable)
+
+        await handle_function_events({})
+        assert isinstance(handle_function_events, Callable)

--- a/tests/scenario_tests_async/test_function_view_closed.py
+++ b/tests/scenario_tests_async/test_function_view_closed.py
@@ -1,0 +1,197 @@
+import json
+import time
+import pytest
+
+from slack_sdk.web.async_client import AsyncWebClient
+from slack_sdk.signature import SignatureVerifier
+
+from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.request.async_request import AsyncBoltRequest
+from slack_bolt.slack_function import SlackFunction
+
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+    assert_auth_test_count_async,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class TestFunctionViewClosed:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = AsyncWebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    def setup_method(self):
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body,
+            timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        return {
+            "content-type": ["application/x-www-form-urlencoded"],
+            "x-slack-signature": [self.generate_signature(body, timestamp)],
+            "x-slack-request-timestamp": [timestamp],
+        }
+
+    def build_request_from_body(self, message_body: dict) -> AsyncBoltRequest:
+        timestamp, body = str(int(time.time())), json.dumps(message_body)
+        return AsyncBoltRequest(body=body, headers=self.build_headers(timestamp, body))
+
+    @pytest.mark.asyncio
+    async def test_mock_server_is_running(self):
+        resp = await self.web_client.api_test()
+        assert resp != None
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        func: SlackFunction = app.function("c")
+        func.view({"type": "view_closed", "callback_id": "view-id"})(simple_listener)
+
+        request = self.build_request_from_body(function_view_closed_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        assert self.mock_received_requests["/functions.completeSuccess"] == 1
+
+    @pytest.mark.asyncio
+    async def test_success_view_closed(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        func: SlackFunction = app.function("c")
+        func.view_closed("view-id")(simple_listener)
+
+        request = self.build_request_from_body(function_view_closed_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        assert self.mock_received_requests["/functions.completeSuccess"] == 1
+
+    @pytest.mark.asyncio
+    async def test_failure_view(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        func: SlackFunction = app.function("c")
+
+        request = self.build_request_from_body(function_view_closed_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        await assert_auth_test_count_async(self, 1)
+
+        func.view({"type": "view_closed", "callback_id": "view-idddd"})(simple_listener)
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        await assert_auth_test_count_async(self, 1)
+
+    @pytest.mark.asyncio
+    async def test_failure_view_closed(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        request = self.build_request_from_body(function_view_closed_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        await assert_auth_test_count_async(self, 1)
+
+        func: SlackFunction = app.function("c")
+        func.view_closed("view-idddd")(simple_listener)
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        await assert_auth_test_count_async(self, 1)
+
+
+function_view_closed_body = {
+    "type": "view_closed",
+    "team": {"id": "T111", "domain": "workspace-domain"},
+    "enterprise": None,
+    "user": {"id": "U111", "name": "primary-owner", "team_id": "T111"},
+    "view": {
+        "id": "V111",
+        "team_id": "T111",
+        "app_id": "A111",
+        "app_installed_team_id": "T111",
+        "bot_id": "B111",
+        "title": {"type": "plain_text", "text": "Sample modal title", "emoji": True},
+        "type": "modal",
+        "blocks": [
+            {
+                "type": "input",
+                "block_id": "input_block_id",
+                "label": {"type": "plain_text", "text": "What are your hopes and dreams?", "emoji": True},
+                "optional": False,
+                "dispatch_action": False,
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "sample_input_id",
+                    "multiline": True,
+                    "dispatch_action_config": {"trigger_actions_on": ["on_enter_pressed"]},
+                },
+            }
+        ],
+        "close": None,
+        "submit": {"type": "plain_text", "text": "Submit", "emoji": True},
+        "state": {"values": {}},
+        "hash": "123.aBc1",
+        "private_metadata": "This is for you!",
+        "callback_id": "view-id",
+        "root_view_id": "V111",
+        "previous_view_id": None,
+        "clear_on_close": False,
+        "notify_on_close": True,
+        "external_id": "",
+    },
+    "api_app_id": "A111",
+    "is_cleared": False,
+    "bot_access_token": "xwfp-111",
+    "function_data": {
+        "execution_id": "Fx111",
+        "function": {"callback_id": "c"},
+        "inputs": {
+            "interactivity": {
+                "interactor": {
+                    "id": "U111",
+                    "secret": "NDA111",
+                },
+                "interactivity_pointer": "123.123.abc1",
+            },
+            "interactivity.interactor": {
+                "id": "U111",
+                "secret": "NDA111",
+            },
+            "interactivity.interactor.id": "U111",
+            "interactivity.interactor.secret": "NDA111",
+            "interactivity.interactivity_pointer": "123.123.abc1",
+        },
+    },
+}
+
+
+async def simple_listener(ack, body, payload, view, complete):
+    await ack()
+    assert body["view"] == payload
+    assert payload == view
+    assert view["private_metadata"] == "This is for you!"
+    await complete()

--- a/tests/scenario_tests_async/test_function_view_submission.py
+++ b/tests/scenario_tests_async/test_function_view_submission.py
@@ -1,0 +1,204 @@
+import json
+import time
+import pytest
+
+from slack_sdk.web.async_client import AsyncWebClient
+from slack_sdk.signature import SignatureVerifier
+
+from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.request.async_request import AsyncBoltRequest
+from slack_bolt.slack_function import SlackFunction
+
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+    assert_auth_test_count_async,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class TestFunctionViewSubmission:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = AsyncWebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    def setup_method(self):
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body,
+            timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        return {
+            "content-type": ["application/x-www-form-urlencoded"],
+            "x-slack-signature": [self.generate_signature(body, timestamp)],
+            "x-slack-request-timestamp": [timestamp],
+        }
+
+    def build_request_from_body(self, message_body: dict) -> AsyncBoltRequest:
+        timestamp, body = str(int(time.time())), json.dumps(message_body)
+        return AsyncBoltRequest(body=body, headers=self.build_headers(timestamp, body))
+
+    @pytest.mark.asyncio
+    async def test_mock_server_is_running(self):
+        resp = await self.web_client.api_test()
+        assert resp != None
+
+    @pytest.mark.asyncio
+    async def test_success_view(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        func: SlackFunction = app.function("c")
+        func.view("view-id")(simple_listener)
+
+        request = self.build_request_from_body(function_view_submission_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        assert self.mock_received_requests["/functions.completeSuccess"] == 1
+
+    @pytest.mark.asyncio
+    async def test_success_view_submission(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        func: SlackFunction = app.function("c")
+        func.view_submission("view-id")(simple_listener)
+
+        request = self.build_request_from_body(function_view_submission_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        assert self.mock_received_requests["/functions.completeSuccess"] == 1
+
+    @pytest.mark.asyncio
+    async def test_failure_view(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        request = self.build_request_from_body(function_view_submission_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        await assert_auth_test_count_async(self, 1)
+
+        func: SlackFunction = app.function("c")
+        func.view("view-idddd")(simple_listener)
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        await assert_auth_test_count_async(self, 1)
+
+    @pytest.mark.asyncio
+    async def test_failure_view_submission(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        request = self.build_request_from_body(function_view_submission_body)
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        await assert_auth_test_count_async(self, 1)
+
+        func: SlackFunction = app.function("c")
+        func.view_submission("view-idddd")(simple_listener)
+        response = await app.async_dispatch(request)
+        assert response.status == 404
+        await assert_auth_test_count_async(self, 1)
+
+
+function_view_submission_body = {
+    "type": "view_submission",
+    "team": {"id": "T111", "domain": "workspace-domain"},
+    "enterprise": None,
+    "user": {"id": "U111", "name": "primary-owner", "team_id": "T111"},
+    "view": {
+        "id": "V111",
+        "team_id": "T111",
+        "app_id": "A111",
+        "app_installed_team_id": "T111",
+        "bot_id": "B111",
+        "title": {"type": "plain_text", "text": "Sample modal title", "emoji": True},
+        "type": "modal",
+        "blocks": [
+            {
+                "type": "input",
+                "block_id": "input_block_id",
+                "label": {"type": "plain_text", "text": "What are your hopes and dreams?", "emoji": True},
+                "optional": False,
+                "dispatch_action": False,
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "sample_input_id",
+                    "multiline": True,
+                    "dispatch_action_config": {"trigger_actions_on": ["on_enter_pressed"]},
+                },
+            }
+        ],
+        "close": None,
+        "submit": {"type": "plain_text", "text": "Submit", "emoji": True},
+        "state": {"values": {"input_block_id": {"sample_input_id": {"type": "plain_text_input", "value": "hello world"}}}},
+        "hash": "123.abc",
+        "private_metadata": "This is for you!",
+        "callback_id": "view-id",
+        "root_view_id": "V111",
+        "previous_view_id": None,
+        "clear_on_close": False,
+        "notify_on_close": True,
+        "external_id": "",
+    },
+    "api_app_id": "A111",
+    "response_urls": [],
+    "bot_access_token": "xwfp-111",
+    "function_data": {
+        "execution_id": "Fx111",
+        "function": {"callback_id": "c"},
+        "inputs": {
+            "interactivity": {
+                "interactor": {
+                    "id": "U111",
+                    "secret": "NDA111",
+                },
+                "interactivity_pointer": "123.123.acb1",
+            },
+            "interactivity.interactor": {
+                "id": "U111",
+                "secret": "NDA111",
+            },
+            "interactivity.interactor.id": "U111",
+            "interactivity.interactor.secret": "NDA111",
+            "interactivity.interactivity_pointer": "123.123.acb1",
+        },
+    },
+    "interactivity": {
+        "interactor": {
+            "secret": "NDA111",
+            "id": "U111",
+        },
+        "interactivity_pointer": "123.123.acb1",
+    },
+}
+
+
+async def simple_listener(ack, body, payload, view, complete):
+    await ack()
+    assert body["interactivity"]["interactivity_pointer"] == "123.123.acb1"
+    assert body["view"] == payload
+    assert payload == view
+    assert view["private_metadata"] == "This is for you!"
+    await complete()


### PR DESCRIPTION
This PR aims to add async capabilities to remote functions interactivity.

This implementation exploits the existing synchronous source code in order to allow bolt-python remote function interactivity to be used asynchronously.

A similar approach to the steps [described here ](https://github.com/slackapi/bolt-python/pull/715#issue-1357832231) can be used in order to test the application locally.

NOTE: My main concern is with the `SlackFunction Object` currently the same class is used for synchronous and asynchronous implementation this means there are no specific DocString for asynchronous usage but this makes the code simpler to maintain. I thought we could release it like this and see if this is an issue in the async community, we can easily duplicate the class and add proper DocString if need be.

### Category

* [ ] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
