### PR TITLE
Fix #721 Passing a global dict object without channel prop can cause issues among requests

### DIFF
--- a/slack_bolt/context/say/async_say.py
+++ b/slack_bolt/context/say/async_say.py
@@ -1,6 +1,7 @@
 from typing import Optional, Union, Dict, Sequence
 
 from slack_bolt.context.say.internals import _can_say
+from slack_bolt.util.utils import create_copy
 from slack_sdk.models.attachments import Attachment
 from slack_sdk.models.blocks import Block
 from slack_sdk.web.async_client import AsyncWebClient
@@ -45,7 +46,7 @@ class AsyncSay:
                     **kwargs,
                 )
             elif isinstance(text_or_whole_response, dict):
-                message: dict = text_or_whole_response
+                message: dict = create_copy(text_or_whole_response)
                 if "channel" not in message:
                     message["channel"] = channel or self.channel
                 return await self.client.chat_postMessage(**message)

--- a/slack_bolt/context/say/say.py
+++ b/slack_bolt/context/say/say.py
@@ -6,6 +6,7 @@ from slack_sdk.models.blocks import Block
 from slack_sdk.web import SlackResponse
 
 from slack_bolt.context.say.internals import _can_say
+from slack_bolt.util.utils import create_copy
 
 
 class Say:
@@ -46,7 +47,7 @@ class Say:
                     **kwargs,
                 )
             elif isinstance(text_or_whole_response, dict):
-                message: dict = text_or_whole_response
+                message: dict = create_copy(text_or_whole_response)
                 if "channel" not in message:
                     message["channel"] = channel or self.channel
                 return self.client.chat_postMessage(**message)

--- a/tests/slack_bolt/context/test_say.py
+++ b/tests/slack_bolt/context/test_say.py
@@ -43,3 +43,16 @@ class TestSay:
         say = Say(client=self.web_client, channel="C111")
         with pytest.raises(ValueError):
             say([])
+
+    def test_say_shared_dict_as_arg(self):
+        # this shared dict object must not be modified by say method
+        shared_template_dict = {"text": "Hi there!"}
+        say = Say(client=self.web_client, channel="C111")
+        response: SlackResponse = say(shared_template_dict)
+        assert response.status_code == 200
+        assert shared_template_dict.get("channel") is None
+
+        say = Say(client=self.web_client, channel="C222")
+        response: SlackResponse = say(shared_template_dict)
+        assert response.status_code == 200
+        assert shared_template_dict.get("channel") is None

--- a/tests/slack_bolt_async/context/test_async_say.py
+++ b/tests/slack_bolt_async/context/test_async_say.py
@@ -53,3 +53,17 @@ class TestAsyncSay:
         say = AsyncSay(client=self.web_client, channel="C111")
         with pytest.raises(ValueError):
             await say([])
+
+    @pytest.mark.asyncio
+    async def test_say_shared_dict_as_arg(self):
+        # this shared dict object must not be modified by say method
+        shared_template_dict = {"text": "Hi there!"}
+        say = AsyncSay(client=self.web_client, channel="C111")
+        response: AsyncSlackResponse = await say(shared_template_dict)
+        assert response.status_code == 200
+        assert shared_template_dict.get("channel") is None
+
+        say = AsyncSay(client=self.web_client, channel="C222")
+        response: AsyncSlackResponse = await say(shared_template_dict)
+        assert response.status_code == 200
+        assert shared_template_dict.get("channel") is None


### PR DESCRIPTION
This pull request resolves #721 

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
