### PR TITLE
Bump Sanic package to v22.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setuptools.setup(
             # async features heavily depends on aiohttp
             "aiohttp>=3,<4",
             # Socket Mode 3rd party implementation
-            "websockets>=8,<10",
+            "websockets>=10,<11" if sys.version_info.minor > 6 else "websockets>=8,<10",
         ],
         # pip install -e ".[adapter]"
         # NOTE: any of async ones requires pip install -e ".[async]" too
@@ -86,7 +86,7 @@ setuptools.setup(
             "Flask>=1,<3",
             "Werkzeug>=2,<3",
             "pyramid>=1,<3",
-            "sanic>=21,<22" if sys.version_info.minor > 6 else "sanic>=20,<21",
+            "sanic>=22,<23" if sys.version_info.minor > 6 else "sanic>=20,<21",
             "starlette>=0.14,<1",
             "tornado>=6,<7",
             # server


### PR DESCRIPTION
To make Bolt Python compatible with the latest version of Sanic (a problem noted in #726), the versions of Sanic and Websocket were bumped to the latest supported versions for python>=3.7 while preserving the versions needed for python=3.6.

#### Package compatibility list

- [websocket=9](https://pypi.org/project/websockets/9.1/)
- [websocket>=10](https://pypi.org/project/websockets/)
- [sanic=20](https://pypi.org/project/sanic/20.12.7/)
- [sanic>=22](https://pypi.org/project/sanic/)

#### Tests

Performed with Python 3.10.6.

* [x] The updated package versions properly install and run an async app as expected
* [x] No tests fail

### Category

* [ ] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.