### PR TITLE
Fix context.team_id for view interactions in a Slack Connect channel

### DIFF
--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -73,6 +73,12 @@ def extract_enterprise_id(payload: Dict[str, Any]) -> Optional[str]:
 
 
 def extract_team_id(payload: Dict[str, Any]) -> Optional[str]:
+    if payload.get("view") is not None and payload.get("view").get("app_installed_team_id") is not None:
+        # view_submission payloads can have `view.app_installed_team_id` when a modal view that was opened
+        # in a different workspace via some operations inside a Slack Connect channel.
+        # Note that the same for enterprise_id does not exist. When you need to know the enterprise_id as well,
+        # you have to run some query toward your InstallationStore to know the org where the team_id belongs to.
+        return payload.get("view").get("app_installed_team_id")
     if payload.get("team") is not None:
         # With org-wide installations, payload.team in interactivity payloads can be None
         # You need to extract either payload.user.team_id or payload.view.team_id as below

--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -73,12 +73,12 @@ def extract_enterprise_id(payload: Dict[str, Any]) -> Optional[str]:
 
 
 def extract_team_id(payload: Dict[str, Any]) -> Optional[str]:
-    if payload.get("view") is not None and payload.get("view").get("app_installed_team_id") is not None:
+    if payload.get("view", {}).get("app_installed_team_id") is not None:
         # view_submission payloads can have `view.app_installed_team_id` when a modal view that was opened
         # in a different workspace via some operations inside a Slack Connect channel.
         # Note that the same for enterprise_id does not exist. When you need to know the enterprise_id as well,
         # you have to run some query toward your InstallationStore to know the org where the team_id belongs to.
-        return payload.get("view").get("app_installed_team_id")
+        return payload.get("view")["app_installed_team_id"]
     if payload.get("team") is not None:
         # With org-wide installations, payload.team in interactivity payloads can be None
         # You need to extract either payload.user.team_id or payload.view.team_id as below

--- a/tests/slack_bolt/request/test_request.py
+++ b/tests/slack_bolt/request/test_request.py
@@ -84,14 +84,14 @@ class TestRequest:
     "id": "W111",
     "username": "primary-owner",
     "name": "primary-owner",
-    "team_id": "T_expected"
+    "team_id": "T_unexpected"
   },
   "api_app_id": "A111",
   "token": "fixed-value",
   "trigger_id": "1111.222.xxx",
   "view": {
     "id": "V111",
-    "team_id": "T_expected",
+    "team_id": "T_unexpected",
     "type": "modal",
     "blocks": [
       {
@@ -147,7 +147,7 @@ class TestRequest:
     "root_view_id": "V111",
     "app_id": "A111",
     "external_id": "",
-    "app_installed_team_id": "E111",
+    "app_installed_team_id": "T_expected",
     "bot_id": "B111"
   },
   "response_urls": [],
@@ -172,13 +172,13 @@ class TestRequest:
     "id": "W111",
     "username": "primary-owner",
     "name": "primary-owner",
-    "team_id": "T_expected"
+    "team_id": "T_unexpected"
   },
   "api_app_id": "A111",
   "token": "fixed-value",
   "view": {
     "id": "V111",
-    "team_id": "T_expected",
+    "team_id": "T_unexpected",
     "type": "modal",
     "blocks": [
       {
@@ -225,7 +225,7 @@ class TestRequest:
     "root_view_id": "V111",
     "app_id": "A111",
     "external_id": "",
-    "app_installed_team_id": "E111",
+    "app_installed_team_id": "T_expected",
     "bot_id": "B0302M47727"
   },
   "is_cleared": false,


### PR DESCRIPTION
This pull request resolves a bug where context.team_id can be invalid for view interactions (view_submission / view_closed) in a Slack Connect channel, which was reported at https://github.com/slackapi/bolt-js/issues/1614

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
