### PR TITLE
Add context 'user_id' extraction for 'message_changed' and 'message_deleted' events 

### DIFF
--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -113,6 +113,9 @@ def extract_user_id(payload: Dict[str, Any]) -> Optional[str]:
         return payload.get("user_id")
     if payload.get("event") is not None:
         return extract_user_id(payload["event"])
+    if payload.get("message") is not None:
+        # message_changed: body["event"]["message"]
+        return extract_user_id(payload["message"])
     return None
 
 

--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -52,12 +52,12 @@ def extract_is_enterprise_install(payload: Dict[str, Any]) -> Optional[bool]:
 
 
 def extract_enterprise_id(payload: Dict[str, Any]) -> Optional[str]:
-    if payload.get("enterprise") is not None:
-        org = payload.get("enterprise")
+    org = payload.get("enterprise")
+    if org is not None:
         if isinstance(org, str):
             return org
         elif "id" in org:
-            return org.get("id")  # type: ignore
+            return org.get("id")
     if payload.get("authorizations") is not None and len(payload["authorizations"]) > 0:
         # To make Events API handling functioning also for shared channels,
         # we should use .authorizations[0].enterprise_id over .enterprise_id
@@ -103,12 +103,12 @@ def extract_team_id(payload: Dict[str, Any]) -> Optional[str]:
 
 
 def extract_user_id(payload: Dict[str, Any]) -> Optional[str]:
-    if payload.get("user") is not None:
-        user = payload.get("user")
+    user = payload.get("user")
+    if user is not None:
         if isinstance(user, str):
             return user
         elif "id" in user:
-            return user.get("id")  # type: ignore
+            return user.get("id")
     if "user_id" in payload:
         return payload.get("user_id")
     if payload.get("event") is not None:
@@ -120,12 +120,12 @@ def extract_user_id(payload: Dict[str, Any]) -> Optional[str]:
 
 
 def extract_channel_id(payload: Dict[str, Any]) -> Optional[str]:
-    if payload.get("channel") is not None:
-        channel = payload.get("channel")
+    channel = payload.get("channel")
+    if channel is not None:
         if isinstance(channel, str):
             return channel
         elif "id" in channel:
-            return channel.get("id")  # type: ignore
+            return channel.get("id")
     if "channel_id" in payload:
         return payload.get("channel_id")
     if payload.get("event") is not None:

--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -116,6 +116,9 @@ def extract_user_id(payload: Dict[str, Any]) -> Optional[str]:
     if payload.get("message") is not None:
         # message_changed: body["event"]["message"]
         return extract_user_id(payload["message"])
+    if payload.get("previous_message") is not None:
+        # message_deleted: body["event"]["previous_message"]
+        return extract_user_id(payload["previous_message"])
     return None
 
 

--- a/tests/scenario_tests/test_message_changed.py
+++ b/tests/scenario_tests/test_message_changed.py
@@ -1,0 +1,120 @@
+import json
+import time
+
+from slack_sdk.signature import SignatureVerifier
+from slack_sdk.web import WebClient
+
+from slack_bolt.app import App
+from slack_bolt.request import BoltRequest
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class TestMessageChanged:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = WebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    def setup_method(self):
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body,
+            timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        return {
+            "content-type": ["application/json"],
+            "x-slack-signature": [self.generate_signature(body, timestamp)],
+            "x-slack-request-timestamp": [timestamp],
+        }
+
+    def build_request(self, event_payload: dict) -> BoltRequest:
+        timestamp, body = str(int(time.time())), json.dumps(event_payload)
+        return BoltRequest(body=body, headers=self.build_headers(timestamp, body))
+
+    def test_user_and_channel_id_in_context(self):
+        app = App(client=self.web_client, signing_secret=self.signing_secret, process_before_response=True)
+
+        @app.event({"type": "message", "subtype": "message_changed"})
+        def handle_message_changed(context):
+            assert context.channel_id == "C111"
+            assert context.user_id == "U111"
+
+        request = self.build_request(event_payload)
+        response = app.dispatch(request)
+        assert response.status == 200
+
+
+event_payload = {
+    "token": "verification-token",
+    "team_id": "T111",
+    "enterprise_id": "E111",
+    "api_app_id": "A111",
+    "event": {
+        "type": "message",
+        "subtype": "message_changed",
+        "message": {
+            "type": "message",
+            "text": "updated message",
+            "user": "U111",
+            "team": "T111",
+            "edited": {"user": "U111", "ts": "1665102362.000000"},
+            "blocks": [
+                {
+                    "type": "rich_text",
+                    "block_id": "xwvU3",
+                    "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": "updated message"}]}],
+                }
+            ],
+        },
+        "previous_message": {
+            "type": "message",
+            "text": "original message",
+            "user": "U222",
+            "team": "T111",
+            "ts": "1665102338.901939",
+            "blocks": [
+                {
+                    "type": "rich_text",
+                    "block_id": "URf",
+                    "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": "original message"}]}],
+                }
+            ],
+        },
+        "channel": "C111",
+        "hidden": True,
+        "ts": "1665102362.013600",
+        "event_ts": "1665102362.013600",
+        "channel_type": "channel",
+    },
+    "type": "event_callback",
+    "event_id": "Ev111",
+    "event_time": 1665102362,
+    "authorizations": [
+        {
+            "enterprise_id": "E111",
+            "team_id": "T111",
+            "user_id": "U111",
+            "is_bot": True,
+            "is_enterprise_install": False,
+        }
+    ],
+    "is_ext_shared_channel": False,
+    "event_context": "1-message-T111-C111",
+}

--- a/tests/scenario_tests/test_message_deleted.py
+++ b/tests/scenario_tests/test_message_deleted.py
@@ -1,0 +1,100 @@
+import json
+import time
+
+from slack_sdk.signature import SignatureVerifier
+from slack_sdk.web import WebClient
+
+from slack_bolt.app import App
+from slack_bolt.request import BoltRequest
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class TestMessageDeleted:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = WebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    def setup_method(self):
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body,
+            timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        return {
+            "content-type": ["application/json"],
+            "x-slack-signature": [self.generate_signature(body, timestamp)],
+            "x-slack-request-timestamp": [timestamp],
+        }
+
+    def build_request(self, event_payload: dict) -> BoltRequest:
+        timestamp, body = str(int(time.time())), json.dumps(event_payload)
+        return BoltRequest(body=body, headers=self.build_headers(timestamp, body))
+
+    def test_user_and_channel_id_in_context(self):
+        app = App(client=self.web_client, signing_secret=self.signing_secret, process_before_response=True)
+
+        @app.event({"type": "message", "subtype": "message_deleted"})
+        def handle_message_deleted(context):
+            assert context.channel_id == "C111"
+            assert context.user_id == "U111"
+
+        request = self.build_request(event_payload)
+        response = app.dispatch(request)
+        assert response.status == 200
+
+
+event_payload = {
+    "token": "verification-token",
+    "team_id": "T111",
+    "enterprise_id": "E111",
+    "api_app_id": "A111",
+    "event": {
+        "type": "message",
+        "subtype": "message_deleted",
+        "previous_message": {
+            "type": "message",
+            "text": "Delete this message",
+            "user": "U111",
+            "team": "T111",
+            "ts": "1665368619.804829",
+        },
+        "channel": "C111",
+        "hidden": True,
+        "deleted_ts": "1665368619.804829",
+        "event_ts": "1665368629.007100",
+        "ts": "1665368629.007100",
+        "channel_type": "channel",
+    },
+    "type": "event_callback",
+    "event_id": "Ev111",
+    "event_time": 1665368629,
+    "authorizations": [
+        {
+            "enterprise_id": "E111",
+            "team_id": "T111",
+            "user_id": "U111",
+            "is_bot": True,
+            "is_enterprise_install": False,
+        }
+    ],
+    "is_ext_shared_channel": False,
+    "event_context": "1-message-T111-C111",
+}

--- a/tests/scenario_tests_async/test_message_changed.py
+++ b/tests/scenario_tests_async/test_message_changed.py
@@ -1,0 +1,127 @@
+import asyncio
+import json
+from time import time
+
+import pytest
+from slack_sdk.signature import SignatureVerifier
+from slack_sdk.web.async_client import AsyncWebClient
+
+from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.request.async_request import AsyncBoltRequest
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class TestAsyncMessageChanged:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = AsyncWebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    @pytest.fixture
+    def event_loop(self):
+        old_os_env = remove_os_env_temporarily()
+        try:
+            setup_mock_web_api_server(self)
+            loop = asyncio.get_event_loop()
+            yield loop
+            loop.close()
+            cleanup_mock_web_api_server(self)
+        finally:
+            restore_os_env(old_os_env)
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body,
+            timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        return {
+            "content-type": ["application/json"],
+            "x-slack-signature": [self.generate_signature(body, timestamp)],
+            "x-slack-request-timestamp": [timestamp],
+        }
+
+    def build_request(self, event_payload: dict) -> AsyncBoltRequest:
+        timestamp, body = str(int(time())), json.dumps(event_payload)
+        return AsyncBoltRequest(body=body, headers=self.build_headers(timestamp, body))
+
+    @pytest.mark.asyncio
+    async def test_user_and_channel_id_in_context(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret, process_before_response=True)
+
+        @app.event({"type": "message", "subtype": "message_changed"})
+        async def handle_message_changed(context):
+            assert context.channel_id == "C111"
+            assert context.user_id == "U111"
+
+        request = self.build_request(event_payload)
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+
+
+event_payload = {
+    "token": "verification-token",
+    "team_id": "T111",
+    "enterprise_id": "E111",
+    "api_app_id": "A111",
+    "event": {
+        "type": "message",
+        "subtype": "message_changed",
+        "message": {
+            "type": "message",
+            "text": "updated message",
+            "user": "U111",
+            "team": "T111",
+            "edited": {"user": "U111", "ts": "1665102362.000000"},
+            "blocks": [
+                {
+                    "type": "rich_text",
+                    "block_id": "xwvU3",
+                    "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": "updated message"}]}],
+                }
+            ],
+        },
+        "previous_message": {
+            "type": "message",
+            "text": "original message",
+            "user": "U222",
+            "team": "T111",
+            "ts": "1665102338.901939",
+            "blocks": [
+                {
+                    "type": "rich_text",
+                    "block_id": "URf",
+                    "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": "original message"}]}],
+                }
+            ],
+        },
+        "channel": "C111",
+        "hidden": True,
+        "ts": "1665102362.013600",
+        "event_ts": "1665102362.013600",
+        "channel_type": "channel",
+    },
+    "type": "event_callback",
+    "event_id": "Ev111",
+    "event_time": 1665102362,
+    "authorizations": [
+        {
+            "enterprise_id": "E111",
+            "team_id": "T111",
+            "user_id": "U111",
+            "is_bot": True,
+            "is_enterprise_install": False,
+        }
+    ],
+    "is_ext_shared_channel": False,
+    "event_context": "1-message-T111-C111",
+}

--- a/tests/scenario_tests_async/test_message_deleted.py
+++ b/tests/scenario_tests_async/test_message_deleted.py
@@ -1,0 +1,108 @@
+import asyncio
+import json
+from time import time
+
+import pytest
+from slack_sdk.signature import SignatureVerifier
+from slack_sdk.web.async_client import AsyncWebClient
+
+from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.request.async_request import AsyncBoltRequest
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class TestAsyncMessageDeleted:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = AsyncWebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    @pytest.fixture
+    def event_loop(self):
+        old_os_env = remove_os_env_temporarily()
+        try:
+            setup_mock_web_api_server(self)
+            loop = asyncio.get_event_loop()
+            yield loop
+            loop.close()
+            cleanup_mock_web_api_server(self)
+        finally:
+            restore_os_env(old_os_env)
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body,
+            timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        return {
+            "content-type": ["application/json"],
+            "x-slack-signature": [self.generate_signature(body, timestamp)],
+            "x-slack-request-timestamp": [timestamp],
+        }
+
+    def build_request(self, event_payload: dict) -> AsyncBoltRequest:
+        timestamp, body = str(int(time())), json.dumps(event_payload)
+        return AsyncBoltRequest(body=body, headers=self.build_headers(timestamp, body))
+
+    @pytest.mark.asyncio
+    async def test_user_and_channel_id_in_context(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret, process_before_response=True)
+
+        @app.event({"type": "message", "subtype": "message_deleted"})
+        async def handle_message_deleted(context, logger):
+            logger.error(context.user_id)
+            assert context.channel_id == "C111"
+            assert context.user_id == "U111"
+
+        request = self.build_request(event_payload)
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+
+
+event_payload = {
+    "token": "verification-token",
+    "team_id": "T111",
+    "enterprise_id": "E111",
+    "api_app_id": "A111",
+    "event": {
+        "type": "message",
+        "subtype": "message_deleted",
+        "previous_message": {
+            "type": "message",
+            "text": "Delete this message",
+            "user": "U111",
+            "team": "T111",
+            "ts": "1665368619.804829",
+        },
+        "channel": "C111",
+        "hidden": True,
+        "deleted_ts": "1665368619.804829",
+        "event_ts": "1665368629.007100",
+        "ts": "1665368629.007100",
+        "channel_type": "channel",
+    },
+    "type": "event_callback",
+    "event_id": "Ev111",
+    "event_time": 1665368629,
+    "authorizations": [
+        {
+            "enterprise_id": "E111",
+            "team_id": "T111",
+            "user_id": "U111",
+            "is_bot": True,
+            "is_enterprise_install": False,
+        }
+    ],
+    "is_ext_shared_channel": False,
+    "event_context": "1-message-T111-C111",
+}


### PR DESCRIPTION
I noticed that `context.user_id` was not being set for `message_changed` or `message_deleted` `message` subtype events. `user` is located in _payload_ → _event_ → _message_ for `message_changed` events, and in _payload_ → _event_ → _previous_message_ for `message_deleted` events.

The first and third commits are for `message_changed` (with tests); the fourth commit is for `message_deleted` (with tests).

The second commit addresses a typing issue I noticed by ensuring that `in` is not being compared to `None` (the original code would generate _"in" not supported for type "None"_ warnings. I also removed the `# type: ignore` comments on the associated `return` statements as they don't seem to be required.

### Category (place an `x` in each of the `[ ]`)

* [X] `slack_bolt.App` and/or its core components
* [X] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [X] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
