### PR TITLE
Fix #738 Add more keyword args to say utility

### DIFF
--- a/slack_bolt/context/say/async_say.py
+++ b/slack_bolt/context/say/async_say.py
@@ -1,5 +1,7 @@
 from typing import Optional, Union, Dict, Sequence
 
+from slack_sdk.models.metadata import Metadata
+
 from slack_bolt.context.say.internals import _can_say
 from slack_bolt.util.utils import create_copy
 from slack_sdk.models.attachments import Attachment
@@ -26,9 +28,18 @@ class AsyncSay:
         blocks: Optional[Sequence[Union[Dict, Block]]] = None,
         attachments: Optional[Sequence[Union[Dict, Attachment]]] = None,
         channel: Optional[str] = None,
+        as_user: Optional[bool] = None,
         thread_ts: Optional[str] = None,
+        reply_broadcast: Optional[bool] = None,
         unfurl_links: Optional[bool] = None,
         unfurl_media: Optional[bool] = None,
+        icon_emoji: Optional[str] = None,
+        icon_url: Optional[str] = None,
+        username: Optional[str] = None,
+        mrkdwn: Optional[bool] = None,
+        link_names: Optional[bool] = None,
+        parse: Optional[str] = None,  # none, full
+        metadata: Optional[Union[Dict, Metadata]] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
         if _can_say(self, channel):
@@ -40,9 +51,18 @@ class AsyncSay:
                     text=text,
                     blocks=blocks,
                     attachments=attachments,
+                    as_user=as_user,
                     thread_ts=thread_ts,
+                    reply_broadcast=reply_broadcast,
                     unfurl_links=unfurl_links,
                     unfurl_media=unfurl_media,
+                    icon_emoji=icon_emoji,
+                    icon_url=icon_url,
+                    username=username,
+                    mrkdwn=mrkdwn,
+                    link_names=link_names,
+                    parse=parse,
+                    metadata=metadata,
                     **kwargs,
                 )
             elif isinstance(text_or_whole_response, dict):

--- a/slack_bolt/context/say/say.py
+++ b/slack_bolt/context/say/say.py
@@ -3,6 +3,7 @@ from typing import Optional, Union, Dict, Sequence
 from slack_sdk import WebClient
 from slack_sdk.models.attachments import Attachment
 from slack_sdk.models.blocks import Block
+from slack_sdk.models.metadata import Metadata
 from slack_sdk.web import SlackResponse
 
 from slack_bolt.context.say.internals import _can_say
@@ -27,9 +28,18 @@ class Say:
         blocks: Optional[Sequence[Union[Dict, Block]]] = None,
         attachments: Optional[Sequence[Union[Dict, Attachment]]] = None,
         channel: Optional[str] = None,
+        as_user: Optional[bool] = None,
         thread_ts: Optional[str] = None,
+        reply_broadcast: Optional[bool] = None,
         unfurl_links: Optional[bool] = None,
         unfurl_media: Optional[bool] = None,
+        icon_emoji: Optional[str] = None,
+        icon_url: Optional[str] = None,
+        username: Optional[str] = None,
+        mrkdwn: Optional[bool] = None,
+        link_names: Optional[bool] = None,
+        parse: Optional[str] = None,  # none, full
+        metadata: Optional[Union[Dict, Metadata]] = None,
         **kwargs,
     ) -> SlackResponse:
         if _can_say(self, channel):
@@ -41,9 +51,18 @@ class Say:
                     text=text,
                     blocks=blocks,
                     attachments=attachments,
+                    as_user=as_user,
                     thread_ts=thread_ts,
+                    reply_broadcast=reply_broadcast,
                     unfurl_links=unfurl_links,
                     unfurl_media=unfurl_media,
+                    icon_emoji=icon_emoji,
+                    icon_url=icon_url,
+                    username=username,
+                    mrkdwn=mrkdwn,
+                    link_names=link_names,
+                    parse=parse,
+                    metadata=metadata,
                     **kwargs,
                 )
             elif isinstance(text_or_whole_response, dict):

--- a/tests/slack_bolt/context/test_say.py
+++ b/tests/slack_bolt/context/test_say.py
@@ -29,6 +29,11 @@ class TestSay:
         response: SlackResponse = say(text="Hi there!", unfurl_media=True, unfurl_links=True)
         assert response.status_code == 200
 
+    def test_say_reply_in_thread(self):
+        say = Say(client=self.web_client, channel="C111")
+        response: SlackResponse = say(text="Hi there!", thread_ts="111.222", reply_broadcast=True)
+        assert response.status_code == 200
+
     def test_say_dict(self):
         say = Say(client=self.web_client, channel="C111")
         response: SlackResponse = say({"text": "Hi!"})

--- a/tests/slack_bolt_async/context/test_async_say.py
+++ b/tests/slack_bolt_async/context/test_async_say.py
@@ -37,6 +37,12 @@ class TestAsyncSay:
         assert response.status_code == 200
 
     @pytest.mark.asyncio
+    async def test_say_reply_in_thread(self):
+        say = AsyncSay(client=self.web_client, channel="C111")
+        response: AsyncSlackResponse = await say(text="Hi there!", thread_ts="111.222", reply_broadcast=True)
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
     async def test_say_dict(self):
         say = AsyncSay(client=self.web_client, channel="C111")
         response: AsyncSlackResponse = await say({"text": "Hi!"})


### PR DESCRIPTION
This pull request resolves #738 

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
