### PR TITLE
Remove 2020-resolver

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -39,23 +39,6 @@ $ python -m venv env_3.8.5
 $ source env_3.8.5/bin/activate
 ```
 
-### Additional settings for pip
-
-pip 20.2 introduced a new flag to test the upcoming change: https://discuss.python.org/t/announcement-pip-20-2-release/4863/2
-Turn on the feature on your local machine for testing it. Just running the following command helps you turn it on.
-
-```bash
-pip config set global.use-feature 2020-resolver
-```
-
-The following file should be generated.
-
-```yaml
-# ~/.config/pip/pip.conf
-[global]
-use-feature = 2020-resolver
-```
-
 ## Tasks
 
 ### Testing


### PR DESCRIPTION
The pip [22.3 release notes](https://pip.pypa.io/en/stable/news/#v22-3) mentions that [#11493](https://github.com/pypa/pip/pull/11493) removed the `--use-feature=2020-resolver` opt-in flag. This PR removes the instructions that asked contributors to add this flag.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
