### PR TITLE
Fix #763 by improving the suggestion logging for view_closed patterns

### DIFF
--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -10,7 +10,8 @@ from slack_bolt.request.payload_utils import (
     is_options,
     is_shortcut,
     is_slash_command,
-    is_view,
+    is_view_submission,
+    is_view_closed,
     is_workflow_step_edit,
     is_workflow_step_save,
     is_workflow_step_execute,
@@ -241,13 +242,24 @@ app.step(ws)
     logger.info(body)
 """,
         )
-    if is_view(req.body):
+    if is_view_submission(req.body):
         # @app.view
         return _build_unhandled_request_suggestion(
             default_message,
             f"""
 @app.view("{req.body.get('view', {}).get('callback_id', 'modal-view-id')}")
-{'async ' if is_async else ''}def handle_view_events(ack, body, logger):
+{'async ' if is_async else ''}def handle_view_submission_events(ack, body, logger):
+    {'await ' if is_async else ''}ack()
+    logger.info(body)
+""",
+        )
+    if is_view_closed(req.body):
+        # @app.view
+        return _build_unhandled_request_suggestion(
+            default_message,
+            f"""
+@app.view_closed("{req.body.get('view', {}).get('callback_id', 'modal-view-id')}")
+{'async ' if is_async else ''}def handle_view_closed_events(ack, body, logger):
     {'await ' if is_async else ''}ack()
     logger.info(body)
 """,

--- a/tests/slack_bolt/logger/test_unmatched_suggestions.py
+++ b/tests/slack_bolt/logger/test_unmatched_suggestions.py
@@ -153,7 +153,7 @@ def handle_shortcuts(ack, body, logger):
 [Suggestion] You can handle this type of event with the following listener function:
 
 @app.view("view-id")
-def handle_view_events(ack, body, logger):
+def handle_view_submission_events(ack, body, logger):
     ack()
     logger.info(body)
 """
@@ -171,8 +171,8 @@ def handle_view_events(ack, body, logger):
 ---
 [Suggestion] You can handle this type of event with the following listener function:
 
-@app.view("view-id")
-def handle_view_events(ack, body, logger):
+@app.view_closed("view-id")
+def handle_view_closed_events(ack, body, logger):
     ack()
     logger.info(body)
 """

--- a/tests/slack_bolt_async/logger/test_unmatched_suggestions.py
+++ b/tests/slack_bolt_async/logger/test_unmatched_suggestions.py
@@ -153,7 +153,7 @@ async def handle_shortcuts(ack, body, logger):
 [Suggestion] You can handle this type of event with the following listener function:
 
 @app.view("view-id")
-async def handle_view_events(ack, body, logger):
+async def handle_view_submission_events(ack, body, logger):
     await ack()
     logger.info(body)
 """
@@ -171,8 +171,8 @@ async def handle_view_events(ack, body, logger):
 ---
 [Suggestion] You can handle this type of event with the following listener function:
 
-@app.view("view-id")
-async def handle_view_events(ack, body, logger):
+@app.view_closed("view-id")
+async def handle_view_closed_events(ack, body, logger):
     await ack()
     logger.info(body)
 """


### PR DESCRIPTION
This pull request resolves #763 

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
