### PR TITLE
Fix #757 by using Falcon 3.1.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,15 +48,13 @@ jobs:
       - name: Run tests for HTTP Mode adapters (Django)
         run: |
           pytest tests/adapter_tests/django/
-      # TODO: Enable testing with Falcon 4.x + Python 3.11
-      # See also: https://github.com/slackapi/bolt-python/issues/757
       - name: Run tests for HTTP Mode adapters (Falcon 3.x)
         run: |
-          if [ ${{ matrix.python-version }} != "3.11" ]; then
             pytest tests/adapter_tests/falcon/
-          fi
       - name: Run tests for HTTP Mode adapters (Falcon 2.x)
         run: |
+          # Falcon 2.x does not support Python 3.11 or newer
+          # See also: https://github.com/slackapi/bolt-python/issues/757
           if [ ${{ matrix.python-version }} != "3.11" ]; then
             pip install "falcon<3"
             pytest tests/adapter_tests/falcon/
@@ -76,10 +74,6 @@ jobs:
       - name: Run tests for HTTP Mode adapters (asyncio-based libraries)
         run: |
           pip install -e ".[async]"
-          pip install "falcon>=3,<4"
-          if [ ${{ matrix.python-version }} == "3.11" ]; then
-            # TODO: Enable testing with Falcon 4.x + Python 3.11
-            # See also: https://github.com/slackapi/bolt-python/issues/757
-            rm -f tests/adapter_tests_async/test_async_falcon.py
-          fi
+          # Falcon supports Python 3.11 since its v3.1.1
+          pip install "falcon>=3.1.1,<4"
           pytest tests/adapter_tests_async/

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setuptools.setup(
             "click>=7,<8",  # for chalice
             "CherryPy>=18,<19",
             "Django>=3,<5",
-            "falcon>=2,<4",
+            "falcon>=3.11,<4" if sys.version_info.minor >= 11 else "falcon>=2,<4",
             "fastapi>=0.70.0,<1",
             "Flask>=1,<3",
             "Werkzeug>=2,<3",

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setuptools.setup(
             "click>=7,<8",  # for chalice
             "CherryPy>=18,<19",
             "Django>=3,<5",
-            "falcon>=3.11,<4" if sys.version_info.minor >= 11 else "falcon>=2,<4",
+            "falcon>=3.1.1,<4" if sys.version_info.minor >= 11 else "falcon>=2,<4",
             "fastapi>=0.70.0,<1",
             "Flask>=1,<3",
             "Werkzeug>=2,<3",


### PR DESCRIPTION
This pull request resolves #757 

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
