### PR TITLE
CI python 3.6 bug fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,16 +7,12 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    # Avoiding -latest due to https://github.com/actions/setup-python/issues/162
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        include:
-          - python-version: "3.6"
-            os: ubuntu-20.04
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
     env:
       # default: multiprocessing
       # threading is more stable on GitHub Actions

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,8 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
+        os:
+          - ubuntu-latest
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - python-version: "3.6"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,17 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        os:
+          - ubuntu-latest
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+        include:
+          - python-version: "3.6"
+            os: ubuntu-20.04
     env:
       # default: multiprocessing
       # threading is more stable on GitHub Actions
@@ -50,7 +60,7 @@ jobs:
           pytest tests/adapter_tests/django/
       - name: Run tests for HTTP Mode adapters (Falcon 3.x)
         run: |
-            pytest tests/adapter_tests/falcon/
+          pytest tests/adapter_tests/falcon/
       - name: Run tests for HTTP Mode adapters (Falcon 2.x)
         run: |
           # Falcon 2.x does not support Python 3.11 or newer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,6 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
         python-version:
           - "3.7"
           - "3.8"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version:
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - python-version: "3.6"
             os: ubuntu-20.04


### PR DESCRIPTION
From [this issue](https://github.com/actions/setup-python/issues/544) it was found that the ubuntu `latest-version` of the github action runner was updated to 22.04, there are no tarballs in 22.04 for any python 3.6.* versions.

This PR introduces a fix to allow us to run the python 3.6 test without issues.

### Category

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
