### PR TITLE
Adding Handling views on close documentation

### DIFF
--- a/docs/_basic/listening_modals.md
+++ b/docs/_basic/listening_modals.md
@@ -26,6 +26,42 @@ def handle_submission(ack, body):
 Similarly, there are options for [displaying errors](https://api.slack.com/surfaces/modals/using#displaying_errors) in response to view submissions.
 Read more about view submissions in our <a href="https://api.slack.com/surfaces/modals/using#handling_submissions">API documentation</a>.
 
+---
+
+##### Handling views on close
+
+When listening for `view_closed` requests, you must pass `callback_id` and add a `notify_on_close` property to the view during creation. See below for an example of this:
+
+See the <a href="https://api.slack.com/surfaces/modals/using#modal_cancellations">API documentation</a> for more information about view_closed.
+
+```python
+
+client.views_open(
+    trigger_id=body.get("trigger_id"),
+    view={
+        "type": "modal",
+        "callback_id": "modal-id", # Used when calling view_closed
+        "title": {
+            "type": "plain_text",
+            "text": "Modal title"
+        },
+        "blocks": [],
+        "close": {
+            "type": "plain_text",
+            "text": "Cancel"
+        },
+        "notify_on_close": True,  # This attribute is required
+    }
+)
+
+# Handle a view_closed request
+@app.view_closed("modal-id")
+def handle_view_closed(ack, body, logger):
+    ack()
+    logger.info("--------------- view_closed handler called ---------------")
+    logger.info(body)
+```
+
 </div>
 
 <div>

--- a/docs/_basic/listening_modals.md
+++ b/docs/_basic/listening_modals.md
@@ -58,7 +58,6 @@ client.views_open(
 @app.view_closed("modal-id")
 def handle_view_closed(ack, body, logger):
     ack()
-    logger.info("--------------- view_closed handler called ---------------")
     logger.info(body)
 ```
 

--- a/docs/_basic/listening_modals.md
+++ b/docs/_basic/listening_modals.md
@@ -40,7 +40,7 @@ client.views_open(
     trigger_id=body.get("trigger_id"),
     view={
         "type": "modal",
-        "callback_id": "modal-id", # Used when calling view_closed
+        "callback_id": "modal-id",  # Used when calling view_closed
         "title": {
             "type": "plain_text",
             "text": "Modal title"


### PR DESCRIPTION
Adding Handling Views on close to documentation based on issue #762 with the provided example code provided in #624. Followed similar documentation layout based on the javascript docs. https://slack.dev/bolt-js/concepts#view-submissions


### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
