### PR TITLE
Fix #793 by adding pyramid_request property to Bolt context

### DIFF
--- a/slack_bolt/adapter/pyramid/handler.py
+++ b/slack_bolt/adapter/pyramid/handler.py
@@ -45,14 +45,34 @@ class SlackRequestHandler:
             if self.app.oauth_flow is not None:
                 oauth_flow: OAuthFlow = self.app.oauth_flow
                 if request.path == oauth_flow.install_path:
-                    bolt_resp = oauth_flow.handle_installation(to_bolt_request(request))
+                    bolt_req = _attach_pyramid_request_to_context(to_bolt_request(request))
+                    bolt_resp = oauth_flow.handle_installation(bolt_req)
                     return to_pyramid_response(bolt_resp)
                 elif request.path == oauth_flow.redirect_uri_path:
-                    bolt_resp = oauth_flow.handle_callback(to_bolt_request(request))
+                    bolt_req = _attach_pyramid_request_to_context(to_bolt_request(request))
+                    bolt_resp = oauth_flow.handle_callback(bolt_req)
                     return to_pyramid_response(bolt_resp)
         elif request.method == "POST":
-            bolt_req = to_bolt_request(request)
+            bolt_req = _attach_pyramid_request_to_context(to_bolt_request(request))
             bolt_resp = self.app.dispatch(bolt_req)
             return to_pyramid_response(bolt_resp)
 
         return Response(status=404, body="Not found")
+
+
+def _attach_pyramid_request_to_context(
+    bolt_req: BoltRequest,
+    request: Request,
+) -> BoltRequest:
+    # To enable developers to access request-scope attributes such as dbsession,
+    # this adapter exposes the underlying pyramid_request object to Bolt listeners
+    #
+    # Developers can access request props this way:
+    # @app.event("app_mention")
+    # def handle_app_mention_events(context, logger):
+    #     req = context["pyramid_request"]
+    #     all = req.dbsession.query(MyModel).all()
+    #     logger.info(all)
+    #
+    bolt_req.context["pyramid_request"] = request
+    return bolt_req

--- a/slack_bolt/adapter/pyramid/handler.py
+++ b/slack_bolt/adapter/pyramid/handler.py
@@ -45,15 +45,15 @@ class SlackRequestHandler:
             if self.app.oauth_flow is not None:
                 oauth_flow: OAuthFlow = self.app.oauth_flow
                 if request.path == oauth_flow.install_path:
-                    bolt_req = _attach_pyramid_request_to_context(to_bolt_request(request))
+                    bolt_req = _attach_pyramid_request_to_context(to_bolt_request(request), request)
                     bolt_resp = oauth_flow.handle_installation(bolt_req)
                     return to_pyramid_response(bolt_resp)
                 elif request.path == oauth_flow.redirect_uri_path:
-                    bolt_req = _attach_pyramid_request_to_context(to_bolt_request(request))
+                    bolt_req = _attach_pyramid_request_to_context(to_bolt_request(request), request)
                     bolt_resp = oauth_flow.handle_callback(bolt_req)
                     return to_pyramid_response(bolt_resp)
         elif request.method == "POST":
-            bolt_req = _attach_pyramid_request_to_context(to_bolt_request(request))
+            bolt_req = _attach_pyramid_request_to_context(to_bolt_request(request), request)
             bolt_resp = self.app.dispatch(bolt_req)
             return to_pyramid_response(bolt_resp)
 


### PR DESCRIPTION
This pull request resolves #793 by enhancing the built-in Pyramid adapter to have a reference to the underlying request object in Bolt's context object. In #793, the issue reporter used the name "request" for enhancing context objects, but I didn't follow the general name for safety (meaning future enhancement on the Bolt core side may cause some conflicts with the name). 

In general, exposing the raw request object's state as-is is not recommended in Bolt apps. With that being said, there is no reason to prevent developers from using a specific web framework in its typical way.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
