### PR TITLE
Fix perform_bot_token_rotation call in AsyncInstallationStoreAuthorize

### DIFF
--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -244,7 +244,7 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
                             raise BoltError(self._config_error_message)
                         refreshed = await self.token_rotator.perform_bot_token_rotation(
                             bot=bot,
-                            token_rotation_expiration_minutes=self.token_rotation_expiration_minutes,
+                            minutes_before_expiration=self.token_rotation_expiration_minutes,
                         )
                         if refreshed is not None:
                             await self.installation_store.async_save_bot(refreshed)

--- a/slack_bolt/listener/async_listener.py
+++ b/slack_bolt/listener/async_listener.py
@@ -57,7 +57,7 @@ class AsyncListener(metaclass=ABCMeta):
         return (resp, False)
 
     @abstractmethod
-    async def run_ack_function(self, *, request: AsyncBoltRequest, response: BoltResponse) -> BoltResponse:
+    async def run_ack_function(self, *, request: AsyncBoltRequest, response: BoltResponse) -> Optional[BoltResponse]:
         """Runs all the registered middleware and then run the listener function.
 
         Args:

--- a/slack_bolt/listener/listener.py
+++ b/slack_bolt/listener/listener.py
@@ -55,7 +55,7 @@ class Listener(metaclass=ABCMeta):
         return (resp, False)
 
     @abstractmethod
-    def run_ack_function(self, *, request: BoltRequest, response: BoltResponse) -> BoltResponse:
+    def run_ack_function(self, *, request: BoltRequest, response: BoltResponse) -> Optional[BoltResponse]:
         """Runs all the registered middleware and then run the listener function.
 
         Args:


### PR DESCRIPTION
- Fix the following error by using the right kwarg for [python-slack-sdk](https://github.com/slackapi/python-slack-sdk/blob/v3.19.5/slack_sdk/oauth/token_rotation/async_rotator.py):
```
TypeError: AsyncTokenRotator.perform_token_rotation() got an unexpected keyword argument 'token_rotation_expiration_minutes'
```
- Also fixed a pytype type inconsistency which surfaced during `scripts/install_all_and_run_tests.sh` run

### Category

* [ ] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
