### PR TITLE
Add documention for injected 'args' param option

### DIFF
--- a/slack_bolt/kwargs_injection/args.py
+++ b/slack_bolt/kwargs_injection/args.py
@@ -27,6 +27,19 @@ class Args:
                 view={ ... }
             )
 
+    Alternatively, you can include a parameter named `args` and it will be injected with an instance of this class.
+
+        @app.action("link_button")
+        def handle_buttons(args):
+            args.logger.info(f"request body: {args.body}")
+            args.ack()
+            if args.context.channel_id is not None:
+                args.respond("Hi!")
+            args.client.views_open(
+                trigger_id=args.body["trigger_id"],
+                view={ ... }
+            )
+
     """
 
     client: WebClient

--- a/slack_bolt/kwargs_injection/async_args.py
+++ b/slack_bolt/kwargs_injection/async_args.py
@@ -26,6 +26,19 @@ class AsyncArgs:
                 view={ ... }
             )
 
+    Alternatively, you can include a parameter named `args` and it will be injected with an instance of this class.
+
+        @app.action("link_button")
+        async def handle_buttons(args):
+            args.logger.info(f"request body: {args.body}")
+            await args.ack()
+            if args.context.channel_id is not None:
+                await args.respond("Hi!")
+            await args.client.views_open(
+                trigger_id=args.body["trigger_id"],
+                view={ ... }
+            )
+
     """
 
     logger: Logger

--- a/slack_bolt/kwargs_injection/async_utils.py
+++ b/slack_bolt/kwargs_injection/async_utils.py
@@ -83,7 +83,7 @@ def build_async_required_kwargs(
         first_arg_name = required_arg_names[0]
         if first_arg_name in {"self", "cls"}:
             required_arg_names.pop(0)
-        elif first_arg_name not in all_available_args.keys():
+        elif first_arg_name not in all_available_args.keys() and first_arg_name != "args":
             if this_func is None:
                 logger.warning(warning_skip_uncommon_arg_name(first_arg_name))
                 required_arg_names.pop(0)
@@ -100,7 +100,7 @@ def build_async_required_kwargs(
             else:
                 logger.warning(f"Unknown Request object type detected ({type(request)})")
 
-        if name not in found_arg_names:
+        elif name not in found_arg_names:
             logger.warning(f"{name} is not a valid argument")
             kwargs[name] = None
     return kwargs

--- a/slack_bolt/kwargs_injection/utils.py
+++ b/slack_bolt/kwargs_injection/utils.py
@@ -83,7 +83,7 @@ def build_required_kwargs(
         first_arg_name = required_arg_names[0]
         if first_arg_name in {"self", "cls"}:
             required_arg_names.pop(0)
-        elif first_arg_name not in all_available_args.keys():
+        elif first_arg_name not in all_available_args.keys() and first_arg_name != "args":
             if this_func is None:
                 logger.warning(warning_skip_uncommon_arg_name(first_arg_name))
                 required_arg_names.pop(0)
@@ -100,7 +100,7 @@ def build_required_kwargs(
             else:
                 logger.warning(f"Unknown Request object type detected ({type(request)})")
 
-        if name not in found_arg_names:
+        elif name not in found_arg_names:
             logger.warning(f"{name} is not a valid argument")
             kwargs[name] = None
     return kwargs


### PR DESCRIPTION
(Describe the goal of this PR. Mention any related Issue numbers)

### Category 

* [X] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).


This pull request adds to the docstrings of the Args class the fact that you can use a parameter named 'args' to receive an instance of the Args class (linking to all the other arguments), as an alternative to naming each of the requested arguments one at a time.

This functionality is already implemented in line 97 of the `build_required_kwargs` method in both [sync](https://github.com/slackapi/bolt-python/blob/e580fda97e2ed3d9905f4e10f3821bf05049035b/slack_bolt/kwargs_injection/utils.py#L97
) and [async](https://github.com/slackapi/bolt-python/blob/e580fda97e2ed3d9905f4e10f3821bf05049035b/slack_bolt/kwargs_injection/async_utils.py#L97
) but is not presently documented anywhere I could find. The docs themselves just link to this docstring for more info on possible injectable params, and the docstring only mentions injecting its children but not itself.



