### PR TITLE
Enable developers to define app.message listener without args to capture all messages

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -736,7 +736,7 @@ class App:
 
     def message(
         self,
-        keyword: Union[str, Pattern],
+        keyword: Union[str, Pattern] = "",
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -767,7 +767,7 @@ class AsyncApp:
 
     def message(
         self,
-        keyword: Union[str, Pattern],
+        keyword: Union[str, Pattern] = "",
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:

--- a/tests/scenario_tests/test_message.py
+++ b/tests/scenario_tests/test_message.py
@@ -74,6 +74,40 @@ class TestMessage:
         time.sleep(1)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
+    def test_all_message_matching_1(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+
+        @app.message("")
+        def handle_all_new_messages(say):
+            say("Thanks!")
+
+        request = self.build_request2()
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert_auth_test_count(self, 1)
+        time.sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests["/chat.postMessage"] == 1
+
+    def test_all_message_matching_2(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+
+        @app.message()
+        def handle_all_new_messages(say):
+            say("Thanks!")
+
+        request = self.build_request2()
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert_auth_test_count(self, 1)
+        time.sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests["/chat.postMessage"] == 1
+
     def test_string_keyword_capturing(self):
         app = App(
             client=self.web_client,

--- a/tests/scenario_tests_async/test_message.py
+++ b/tests/scenario_tests_async/test_message.py
@@ -82,6 +82,42 @@ class TestAsyncMessage:
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     @pytest.mark.asyncio
+    async def test_all_message_matching_1(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+
+        @app.message("")
+        async def handle_all_new_messages(say):
+            await say("Thanks!")
+
+        request = self.build_request2()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        await asyncio.sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests["/chat.postMessage"] == 1
+
+    @pytest.mark.asyncio
+    async def test_all_message_matching_2(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+
+        @app.message()
+        async def handle_all_new_messages(say):
+            await say("Thanks!")
+
+        request = self.build_request2()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        await asyncio.sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests["/chat.postMessage"] == 1
+
+    @pytest.mark.asyncio
     async def test_string_keyword_capturing(self):
         app = AsyncApp(
             client=self.web_client,


### PR DESCRIPTION
This pull request enhances `app.message` listener to capture all new messages when defining it without arguments.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
