### PR TITLE
Add team param support to the /slack/install endpoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setuptools.setup(
     ),
     include_package_data=True,  # MANIFEST.in
     install_requires=[
-        "slack_sdk>=3.18.5,<4",
+        "slack_sdk>=3.20.2,<4",
     ],
     setup_requires=["pytest-runner==5.2"],
     tests_require=async_test_dependencies,

--- a/slack_bolt/oauth/async_oauth_flow.py
+++ b/slack_bolt/oauth/async_oauth_flow.py
@@ -194,7 +194,11 @@ class AsyncOAuthFlow:
         return await self.settings.state_store.async_issue()
 
     async def build_authorize_url(self, state: str, request: AsyncBoltRequest) -> str:
-        return self.settings.authorize_url_generator.generate(state)
+        team_ids: Optional[Sequence[str]] = request.query.get("team")
+        return self.settings.authorize_url_generator.generate(
+            state=state,
+            team=team_ids[0] if team_ids is not None else None,
+        )
 
     async def build_install_page_html(self, url: str, request: AsyncBoltRequest) -> str:
         return _build_default_install_page_html(url)

--- a/slack_bolt/oauth/oauth_flow.py
+++ b/slack_bolt/oauth/oauth_flow.py
@@ -192,7 +192,11 @@ class OAuthFlow:
         return self.settings.state_store.issue()
 
     def build_authorize_url(self, state: str, request: BoltRequest) -> str:
-        return self.settings.authorize_url_generator.generate(state)
+        team_ids: Optional[Sequence[str]] = request.query.get("team")
+        return self.settings.authorize_url_generator.generate(
+            state=state,
+            team=team_ids[0] if team_ids is not None else None,
+        )
 
     def build_install_page_html(self, url: str, request: BoltRequest) -> str:
         return _build_default_install_page_html(url)

--- a/tests/slack_bolt/oauth/test_oauth_flow.py
+++ b/tests/slack_bolt/oauth/test_oauth_flow.py
@@ -83,6 +83,26 @@ class TestOAuthFlow:
         assert "https://slack.com/oauth/v2/authorize?state=" in location_header
         assert resp.headers.get("set-cookie") is not None
 
+    def test_handle_installation_team_param(self):
+        oauth_flow = OAuthFlow(
+            settings=OAuthSettings(
+                client_id="111.222",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+                user_scopes=["search:read"],
+                installation_store=FileInstallationStore(),
+                install_page_rendering_enabled=False,  # disabled
+                state_store=FileOAuthStateStore(expiration_seconds=120),
+            )
+        )
+        req = BoltRequest(body="", query={"team": "T12345"})
+        resp = oauth_flow.handle_installation(req)
+        assert resp.status == 302
+        location_header = resp.headers.get("location")[0]
+        assert "https://slack.com/oauth/v2/authorize?state=" in location_header
+        assert "&team=T12345" in location_header
+        assert resp.headers.get("set-cookie") is not None
+
     def test_handle_installation_no_state_validation(self):
         oauth_flow = OAuthFlow(
             settings=OAuthSettings(

--- a/tests/slack_bolt_async/oauth/test_async_oauth_flow.py
+++ b/tests/slack_bolt_async/oauth/test_async_oauth_flow.py
@@ -131,6 +131,26 @@ class TestAsyncOAuthFlow:
         assert resp.headers.get("set-cookie") is not None
 
     @pytest.mark.asyncio
+    async def test_handle_installation_team_param(self):
+        oauth_flow = AsyncOAuthFlow(
+            settings=AsyncOAuthSettings(
+                client_id="111.222",
+                client_secret="xxx",
+                scopes=["chat:write", "commands"],
+                installation_store=FileInstallationStore(),
+                install_page_rendering_enabled=False,  # disabled
+                state_store=FileOAuthStateStore(expiration_seconds=120),
+            )
+        )
+        req = AsyncBoltRequest(body="", query={"team": "T12345"})
+        resp = await oauth_flow.handle_installation(req)
+        assert resp.status == 302
+        location_header = resp.headers.get("location")[0]
+        assert "https://slack.com/oauth/v2/authorize?state=" in location_header
+        assert "&team=T12345" in location_header
+        assert resp.headers.get("set-cookie") is not None
+
+    @pytest.mark.asyncio
     async def test_handle_installation_no_state_validation(self):
         oauth_flow = AsyncOAuthFlow(
             settings=AsyncOAuthSettings(


### PR DESCRIPTION
This pull request enhances the internals of OAuthFlow and AsyncAuthFlow. With the change, `/slack/install?team=T12345` relays the `team` parameter to Slack's authorize URL.

References:
* https://github.com/slackapi/python-slack-sdk/pull/1345
* https://api.slack.com/legacy/oauth#team_parameter

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
