### PR TITLE
Introduce actor enterprise/team/user_id for Slack Connect events

### DIFF
--- a/slack_bolt/adapter/aws_lambda/lambda_s3_oauth_flow.py
+++ b/slack_bolt/adapter/aws_lambda/lambda_s3_oauth_flow.py
@@ -59,6 +59,7 @@ class LambdaS3OAuthFlow(OAuthFlow):
             client_secret=settings.client_secret,
             installation_store=settings.installation_store,
             bot_only=settings.installation_store_bot_only,
+            user_token_resolution=(settings.user_token_resolution if settings is not None else "authed_user"),
         )
 
         OAuthFlow.__init__(self, client=client, logger=logger, settings=settings)

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -238,6 +238,7 @@ class App:
                 logger=self._framework_logger,
                 bot_only=installation_store_bot_only,
                 client=self._client,  # for proxy use cases etc.
+                user_token_resolution=(settings.user_token_resolution if settings is not None else "authed_user"),
             )
 
         self._oauth_flow: Optional[OAuthFlow] = None
@@ -379,7 +380,13 @@ class App:
             else:
                 raise BoltError(error_token_required())
         else:
-            self._middleware_list.append(MultiTeamsAuthorization(authorize=self._authorize, base_logger=self._base_logger))
+            self._middleware_list.append(
+                MultiTeamsAuthorization(
+                    authorize=self._authorize,
+                    base_logger=self._base_logger,
+                    user_token_resolution=self._oauth_flow.settings.user_token_resolution,
+                )
+            )
         if ignoring_self_events_enabled is True:
             self._middleware_list.append(IgnoringSelfEvents(base_logger=self._base_logger))
         if url_verification_enabled is True:

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -243,6 +243,7 @@ class AsyncApp:
                 logger=self._framework_logger,
                 bot_only=installation_store_bot_only,
                 client=self._async_client,  # for proxy use cases etc.
+                user_token_resolution=(settings.user_token_resolution if settings is not None else "authed_user"),
             )
 
         self._async_oauth_flow: Optional[AsyncOAuthFlow] = None
@@ -374,7 +375,11 @@ class AsyncApp:
                 raise BoltError(error_token_required())
         else:
             self._async_middleware_list.append(
-                AsyncMultiTeamsAuthorization(authorize=self._async_authorize, base_logger=self._base_logger)
+                AsyncMultiTeamsAuthorization(
+                    authorize=self._async_authorize,
+                    base_logger=self._base_logger,
+                    user_token_resolution=self._async_oauth_flow.settings.user_token_resolution,
+                )
             )
 
         if ignoring_self_events_enabled is True:

--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -30,6 +30,10 @@ class AsyncAuthorize:
         enterprise_id: Optional[str],
         team_id: Optional[str],  # can be None for org-wide installed apps
         user_id: Optional[str],
+        # actor_* can be used only when user_token_resolution: "actor" is set
+        actor_enterprise_id: Optional[str] = None,
+        actor_team_id: Optional[str] = None,
+        actor_user_id: Optional[str] = None,
     ) -> Optional[AuthorizeResult]:
         raise NotImplementedError()
 
@@ -51,6 +55,10 @@ class AsyncCallableAuthorize(AsyncAuthorize):
         enterprise_id: Optional[str],
         team_id: Optional[str],  # can be None for org-wide installed apps
         user_id: Optional[str],
+        # actor_* can be used only when user_token_resolution: "actor" is set
+        actor_enterprise_id: Optional[str] = None,
+        actor_team_id: Optional[str] = None,
+        actor_user_id: Optional[str] = None,
     ) -> Optional[AuthorizeResult]:
         try:
             all_available_args = {
@@ -66,6 +74,9 @@ class AsyncCallableAuthorize(AsyncAuthorize):
                 "enterprise_id": enterprise_id,
                 "team_id": team_id,
                 "user_id": user_id,
+                "actor_enterprise_id": actor_enterprise_id,
+                "actor_team_id": actor_team_id,
+                "actor_user_id": actor_user_id,
             }
             for k, v in context.items():
                 if k not in all_available_args:
@@ -103,6 +114,8 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
     """
 
     authorize_result_cache: Dict[str, AuthorizeResult]
+    bot_only: bool
+    user_token_resolution: str
     find_installation_available: Optional[bool]
     find_bot_available: Optional[bool]
     token_rotator: Optional[AsyncTokenRotator]
@@ -122,10 +135,13 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
         bot_only: bool = False,
         cache_enabled: bool = False,
         client: Optional[AsyncWebClient] = None,
+        # Since v1.27, user token resolution can be actor ID based when the mode is enabled
+        user_token_resolution: str = "authed_user",
     ):
         self.logger = logger
         self.installation_store = installation_store
         self.bot_only = bot_only
+        self.user_token_resolution = user_token_resolution
         self.cache_enabled = cache_enabled
         self.authorize_result_cache = {}
         self.find_installation_available = None
@@ -147,6 +163,10 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
         enterprise_id: Optional[str],
         team_id: Optional[str],  # can be None for org-wide installed apps
         user_id: Optional[str],
+        # actor_* can be used only when user_token_resolution: "actor" is set
+        actor_enterprise_id: Optional[str] = None,
+        actor_team_id: Optional[str] = None,
+        actor_user_id: Optional[str] = None,
     ) -> Optional[AuthorizeResult]:
 
         if self.find_installation_available is None:
@@ -194,16 +214,34 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
 
                         # try to fetch the request user's installation
                         # to reflect the user's access token if exists
-                        this_user_installation = await self.installation_store.async_find_installation(
-                            enterprise_id=enterprise_id,
-                            team_id=team_id,
-                            user_id=user_id,
-                            is_enterprise_install=context.is_enterprise_install,
-                        )
+                        # try to fetch the request user's installation
+                        # to reflect the user's access token if exists
+                        if self.user_token_resolution == "actor":
+                            if actor_enterprise_id is not None or actor_team_id is not None:
+                                # Note that actor_team_id can be absent for app_mention events
+                                this_user_installation = await self.installation_store.async_find_installation(
+                                    enterprise_id=actor_enterprise_id,
+                                    team_id=actor_team_id,
+                                    user_id=actor_user_id,
+                                    is_enterprise_install=None,
+                                )
+                        else:
+                            this_user_installation = await self.installation_store.async_find_installation(
+                                enterprise_id=enterprise_id,
+                                team_id=team_id,
+                                user_id=user_id,
+                                is_enterprise_install=context.is_enterprise_install,
+                            )
                         if this_user_installation is not None:
                             user_token = this_user_installation.user_token
                             user_scopes = this_user_installation.user_scopes
-                            if latest_bot_installation.bot_token is None:
+                            if (
+                                latest_bot_installation.bot_token is None
+                                # enterprise_id/team_id can be different for Slack Connect channel events
+                                # when enabling user_token_resolution: "actor"
+                                and latest_bot_installation.enterprise_id == this_user_installation.enterprise_id
+                                and latest_bot_installation.team_id == this_user_installation.team_id
+                            ):
                                 # If latest_installation has a bot token, we never overwrite the value
                                 bot_token = this_user_installation.bot_token
                                 bot_scopes = this_user_installation.bot_scopes
@@ -213,7 +251,13 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
                             if refreshed is not None:
                                 user_token = refreshed.user_token
                                 user_scopes = refreshed.user_scopes
-                                if latest_bot_installation.bot_token is None:
+                                if (
+                                    latest_bot_installation.bot_token is None
+                                    # enterprise_id/team_id can be different for Slack Connect channel events
+                                    # when enabling user_token_resolution: "actor"
+                                    and latest_bot_installation.enterprise_id == this_user_installation.enterprise_id
+                                    and latest_bot_installation.team_id == this_user_installation.team_id
+                                ):
                                     # If latest_installation has a bot token, we never overwrite the value
                                     bot_token = refreshed.bot_token
                                     bot_scopes = refreshed.bot_scopes

--- a/slack_bolt/context/base_context.py
+++ b/slack_bolt/context/base_context.py
@@ -17,6 +17,9 @@ class BaseContext(dict):
         "is_enterprise_install",
         "team_id",
         "user_id",
+        "actor_enterprise_id",
+        "actor_team_id",
+        "actor_user_id",
         "channel_id",
         "response_url",
         "matches",
@@ -60,6 +63,30 @@ class BaseContext(dict):
     def user_id(self) -> Optional[str]:
         """The user ID associated ith this request."""
         return self.get("user_id")
+
+    @property
+    def actor_enterprise_id(self) -> Optional[str]:
+        """The action's actor's Enterprise Grid organization ID.
+        Note that this property is especially useful for handling events in Slack Connect channels.
+        That being said, it's not guaranteed to have a valid ID for all events due to server-side inconsistency.
+        """
+        return self.get("actor_enterprise_id")
+
+    @property
+    def actor_team_id(self) -> Optional[str]:
+        """The action's actor's workspace ID.
+        Note that this property is especially useful for handling events in Slack Connect channels.
+        That being said, it's not guaranteed to have a valid ID for all events due to server-side inconsistency.
+        """
+        return self.get("actor_team_id")
+
+    @property
+    def actor_user_id(self) -> Optional[str]:
+        """The action's actor's user ID.
+        Note that this property is especially useful for handling events in Slack Connect channels.
+        That being said, it's not guaranteed to have a valid ID for all events due to server-side inconsistency.
+        """
+        return self.get("actor_user_id")
 
     @property
     def channel_id(self) -> Optional[str]:

--- a/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
@@ -14,16 +14,24 @@ from ...authorization.async_authorize import AsyncAuthorize
 
 class AsyncMultiTeamsAuthorization(AsyncAuthorization):
     authorize: AsyncAuthorize
+    user_token_resolution: str
 
-    def __init__(self, authorize: AsyncAuthorize, base_logger: Optional[Logger] = None):
+    def __init__(
+        self,
+        authorize: AsyncAuthorize,
+        base_logger: Optional[Logger] = None,
+        user_token_resolution: str = "authed_user",
+    ):
         """Multi-workspace authorization.
 
         Args:
             authorize: The function to authorize incoming requests from Slack.
             base_logger: The base logger
+            user_token_resolution: "authed_user" or "actor"
         """
         self.authorize = authorize
         self.logger = get_bolt_logger(AsyncMultiTeamsAuthorization, base_logger=base_logger)
+        self.user_token_resolution = user_token_resolution
 
     async def async_process(
         self,
@@ -49,12 +57,24 @@ class AsyncMultiTeamsAuthorization(AsyncAuthorization):
             return await next()
 
         try:
-            auth_result: Optional[AuthorizeResult] = await self.authorize(
-                context=req.context,
-                enterprise_id=req.context.enterprise_id,
-                team_id=req.context.team_id,
-                user_id=req.context.user_id,
-            )
+            auth_result: Optional[AuthorizeResult] = None
+            if self.user_token_resolution == "actor":
+                auth_result = await self.authorize(
+                    context=req.context,
+                    enterprise_id=req.context.enterprise_id,
+                    team_id=req.context.team_id,
+                    user_id=req.context.user_id,
+                    actor_enterprise_id=req.context.actor_enterprise_id,
+                    actor_team_id=req.context.actor_team_id,
+                    actor_user_id=req.context.actor_user_id,
+                )
+            else:
+                auth_result = await self.authorize(
+                    context=req.context,
+                    enterprise_id=req.context.enterprise_id,
+                    team_id=req.context.team_id,
+                    user_id=req.context.user_id,
+                )
             if auth_result:
                 req.context.set_authorize_result(auth_result)
                 token = auth_result.bot_token or auth_result.user_token

--- a/slack_bolt/oauth/async_oauth_settings.py
+++ b/slack_bolt/oauth/async_oauth_settings.py
@@ -42,6 +42,7 @@ class AsyncOAuthSettings:
     installation_store: AsyncInstallationStore
     installation_store_bot_only: bool
     token_rotation_expiration_minutes: int
+    user_token_resolution: str
     authorize: AsyncAuthorize
     # state parameter related configurations
     state_validation_enabled: bool
@@ -76,6 +77,7 @@ class AsyncOAuthSettings:
         installation_store: Optional[AsyncInstallationStore] = None,
         installation_store_bot_only: bool = False,
         token_rotation_expiration_minutes: int = 120,
+        user_token_resolution: str = "authed_user",
         # state parameter related configurations
         state_validation_enabled: bool = True,
         state_store: Optional[AsyncOAuthStateStore] = None,
@@ -102,6 +104,11 @@ class AsyncOAuthSettings:
             installation_store: Specify the instance of `InstallationStore` (Default: `FileInstallationStore`)
             installation_store_bot_only: Use `InstallationStore#find_bot()` if True (Default: False)
             token_rotation_expiration_minutes: Minutes before refreshing tokens (Default: 2 hours)
+            user_token_resolution: The option to pick up a user token per request (Default: authed_user)
+                The available values are "authed_user" and "actor". When you want to resolve the user token per request
+                using the event's actor IDs, you can set "actor" instead. With this option, bolt-python tries to resolve
+                a user token for context.actor_enterprise/team/user_id. This can be useful for events in Slack Connect
+                channels. Note that actor IDs can be absent in some scenarios.
             state_validation_enabled: Set False if your OAuth flow omits the state parameter validation (Default: True)
             state_store: Specify the instance of `InstallationStore` (Default: `FileOAuthStateStore`)
             state_cookie_name: The cookie name that is set for installers' browser. (Default: "slack-app-oauth-state")
@@ -143,6 +150,7 @@ class AsyncOAuthSettings:
         self.authorization_url = authorization_url or "https://slack.com/oauth/v2/authorize"
         # Installation Management
         self.installation_store = installation_store or get_or_create_default_installation_store(client_id)
+        self.user_token_resolution = user_token_resolution or "authed_user"
         self.installation_store_bot_only = installation_store_bot_only
         self.token_rotation_expiration_minutes = token_rotation_expiration_minutes
         self.authorize = AsyncInstallationStoreAuthorize(
@@ -152,6 +160,7 @@ class AsyncOAuthSettings:
             token_rotation_expiration_minutes=self.token_rotation_expiration_minutes,
             installation_store=self.installation_store,
             bot_only=self.installation_store_bot_only,
+            user_token_resolution=user_token_resolution,
         )
         # state parameter related configurations
         self.state_validation_enabled = state_validation_enabled

--- a/slack_bolt/oauth/oauth_settings.py
+++ b/slack_bolt/oauth/oauth_settings.py
@@ -38,6 +38,7 @@ class OAuthSettings:
     installation_store_bot_only: bool
     token_rotation_expiration_minutes: int
     authorize: Authorize
+    user_token_resolution: str  # default: "authed_user"
     # state parameter related configurations
     state_validation_enabled: bool
     state_store: OAuthStateStore
@@ -71,6 +72,7 @@ class OAuthSettings:
         installation_store: Optional[InstallationStore] = None,
         installation_store_bot_only: bool = False,
         token_rotation_expiration_minutes: int = 120,
+        user_token_resolution: str = "authed_user",
         # state parameter related configurations
         state_validation_enabled: bool = True,
         state_store: Optional[OAuthStateStore] = None,
@@ -97,6 +99,11 @@ class OAuthSettings:
             installation_store: Specify the instance of `InstallationStore` (Default: `FileInstallationStore`)
             installation_store_bot_only: Use `InstallationStore#find_bot()` if True (Default: False)
             token_rotation_expiration_minutes: Minutes before refreshing tokens (Default: 2 hours)
+            user_token_resolution: The option to pick up a user token per request (Default: authed_user)
+                The available values are "authed_user" and "actor". When you want to resolve the user token per request
+                using the event's actor IDs, you can set "actor" instead. With this option, bolt-python tries to resolve
+                a user token for context.actor_enterprise/team/user_id. This can be useful for events in Slack Connect
+                channels. Note that actor IDs can be absent in some scenarios.
             state_validation_enabled: Set False if your OAuth flow omits the state parameter validation (Default: True)
             state_store: Specify the instance of `InstallationStore` (Default: `FileOAuthStateStore`)
             state_cookie_name: The cookie name that is set for installers' browser. (Default: "slack-app-oauth-state")
@@ -136,6 +143,7 @@ class OAuthSettings:
         self.authorization_url = authorization_url or "https://slack.com/oauth/v2/authorize"
         # Installation Management
         self.installation_store = installation_store or get_or_create_default_installation_store(client_id)
+        self.user_token_resolution = user_token_resolution or "authed_user"
         self.installation_store_bot_only = installation_store_bot_only
         self.token_rotation_expiration_minutes = token_rotation_expiration_minutes
         self.authorize = InstallationStoreAuthorize(
@@ -145,6 +153,7 @@ class OAuthSettings:
             token_rotation_expiration_minutes=self.token_rotation_expiration_minutes,
             installation_store=self.installation_store,
             bot_only=self.installation_store_bot_only,
+            user_token_resolution=user_token_resolution,
         )
         # state parameter related configurations
         self.state_validation_enabled = state_validation_enabled

--- a/slack_bolt/request/async_internals.py
+++ b/slack_bolt/request/async_internals.py
@@ -8,6 +8,9 @@ from slack_bolt.request.internals import (
     extract_user_id,
     extract_channel_id,
     debug_multiple_response_urls_detected,
+    extract_actor_enterprise_id,
+    extract_actor_team_id,
+    extract_actor_user_id,
 )
 
 
@@ -25,6 +28,16 @@ def build_async_context(
     user_id = extract_user_id(body)
     if user_id:
         context["user_id"] = user_id
+    # Actor IDs are useful for Events API on a Slack Connect channel
+    actor_enterprise_id = extract_actor_enterprise_id(body)
+    if actor_enterprise_id:
+        context["actor_enterprise_id"] = actor_enterprise_id
+    actor_team_id = extract_actor_team_id(body)
+    if actor_team_id:
+        context["actor_team_id"] = actor_team_id
+    actor_user_id = extract_actor_user_id(body)
+    if actor_user_id:
+        context["actor_user_id"] = actor_user_id
     channel_id = extract_channel_id(body)
     if channel_id:
         context["channel_id"] = channel_id

--- a/tests/scenario_tests/test_app_actor_user_token.py
+++ b/tests/scenario_tests/test_app_actor_user_token.py
@@ -1,0 +1,178 @@
+import datetime
+import json
+import logging
+from time import time, sleep
+from typing import Optional
+
+from slack_sdk import WebClient
+from slack_sdk.oauth import InstallationStore
+from slack_sdk.oauth.installation_store import Installation, Bot
+from slack_sdk.signature import SignatureVerifier
+
+from slack_bolt import App, BoltRequest, Say, BoltContext
+from slack_bolt.oauth.oauth_settings import OAuthSettings
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+    assert_auth_test_count,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class MemoryInstallationStore(InstallationStore):
+    @property
+    def logger(self) -> logging.Logger:
+        return logging.getLogger(__name__)
+
+    def save(self, installation: Installation):
+        pass
+
+    def find_bot(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Bot]:
+        return Bot(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T0G9PQBBK",
+            bot_token="xoxb-valid",
+            bot_id="B",
+            bot_user_id="W",
+            bot_scopes=["commands", "chat:write"],
+            installed_at=datetime.datetime.now().timestamp(),
+        )
+
+    def find_installation(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        user_id: Optional[str] = None,
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Installation]:
+        if team_id == "T0G9PQBBK":
+            return Installation(
+                app_id="A111",
+                enterprise_id="E111",
+                team_id="T0G9PQBBK",
+                bot_token="xoxb-valid-2",
+                bot_id="B",
+                bot_user_id="W",
+                bot_scopes=["commands", "chat:write"],
+                user_id="W11111",
+                installed_at=datetime.datetime.now().timestamp(),
+            )
+        if team_id == "T014GJXU940" and enterprise_id == "E013Y3SHLAY":
+            return Installation(
+                app_id="A111",
+                enterprise_id="E013Y3SHLAY",
+                team_id="T014GJXU940",
+                user_id="W11111",
+                user_token="xoxp-valid-actor-based",
+                user_scopes=["search:read", "chat:write"],
+                installed_at=datetime.datetime.now().timestamp(),
+            )
+        return None
+
+
+class TestApp:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = WebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    def setup_method(self):
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body,
+            timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        return {
+            "content-type": ["application/json"],
+            "x-slack-signature": [self.generate_signature(body, timestamp)],
+            "x-slack-request-timestamp": [timestamp],
+        }
+
+    def build_request(self):
+        timestamp, body = str(int(time())), json.dumps(
+            {
+                "team_id": "T014GJXU940",
+                "enterprise_id": "E013Y3SHLAY",
+                "context_team_id": "T014GJXU940",
+                "context_enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "message",
+                    "files": [],
+                    "upload": False,
+                    "user": "W013QGS7BPF",
+                    "display_as_bot": False,
+                    "team": "T014GJXU940",
+                    "channel": "C04T3ACM40K",
+                    "subtype": "file_share",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T0G9PQBBK",
+                        "user_id": "W23456789",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            }
+        )
+        return BoltRequest(body=body, headers=self.build_headers(timestamp, body))
+
+    def test_authorize_result(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            oauth_settings=OAuthSettings(
+                client_id="111.222",
+                client_secret="secret",
+                scopes=["commands", "chat:write"],
+                user_scopes=["search:read", "chat:write"],
+                installation_store=MemoryInstallationStore(),
+                user_token_resolution="actor",
+            ),
+        )
+
+        @app.event("message")
+        def handle_events(context: BoltContext, say: Say):
+            assert context.actor_enterprise_id == "E013Y3SHLAY"
+            assert context.actor_team_id == "T014GJXU940"
+            assert context.actor_user_id == "W013QGS7BPF"
+
+            assert context.authorize_result.bot_id == "BZYBOTHED"
+            assert context.authorize_result.bot_user_id == "W23456789"
+            assert context.authorize_result.bot_token == "xoxb-valid-2"
+            assert context.authorize_result.bot_scopes == ["commands", "chat:write"]
+            assert context.authorize_result.user_id == "W99999"
+            assert context.authorize_result.user_token == "xoxp-valid-actor-based"
+            assert context.authorize_result.user_scopes == ["search:read", "chat:write"]
+            say("What's up?")
+
+        response = app.dispatch(self.build_request())
+        assert response.status == 200
+        assert_auth_test_count(self, 1)
+        sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests["/chat.postMessage"] == 1

--- a/tests/scenario_tests_async/test_app_actor_user_token.py
+++ b/tests/scenario_tests_async/test_app_actor_user_token.py
@@ -1,0 +1,189 @@
+import asyncio
+import datetime
+import json
+import logging
+from time import time
+from typing import Optional
+
+import pytest
+from slack_sdk.oauth.installation_store import Installation, Bot
+from slack_sdk.oauth.installation_store.async_installation_store import (
+    AsyncInstallationStore,
+)
+from slack_sdk.signature import SignatureVerifier
+from slack_sdk.web.async_client import AsyncWebClient
+
+from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.context.async_context import AsyncBoltContext
+from slack_bolt.context.say.async_say import AsyncSay
+from slack_bolt.oauth.async_oauth_settings import AsyncOAuthSettings
+from slack_bolt.request.async_request import AsyncBoltRequest
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+    assert_auth_test_count_async,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class TestApp:
+    signing_secret = "secret"
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    signature_verifier = SignatureVerifier(signing_secret)
+    web_client = AsyncWebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    @pytest.fixture
+    def event_loop(self):
+        old_os_env = remove_os_env_temporarily()
+        try:
+            setup_mock_web_api_server(self)
+            loop = asyncio.get_event_loop()
+            yield loop
+            loop.close()
+            cleanup_mock_web_api_server(self)
+        finally:
+            restore_os_env(old_os_env)
+
+    def generate_signature(self, body: str, timestamp: str):
+        return self.signature_verifier.generate_signature(
+            body=body,
+            timestamp=timestamp,
+        )
+
+    def build_headers(self, timestamp: str, body: str):
+        return {
+            "content-type": ["application/json"],
+            "x-slack-signature": [self.generate_signature(body, timestamp)],
+            "x-slack-request-timestamp": [timestamp],
+        }
+
+    def build_request(self) -> AsyncBoltRequest:
+        timestamp, body = str(int(time())), json.dumps(
+            {
+                "team_id": "T014GJXU940",
+                "enterprise_id": "E013Y3SHLAY",
+                "context_team_id": "T014GJXU940",
+                "context_enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "message",
+                    "files": [],
+                    "upload": False,
+                    "user": "W013QGS7BPF",
+                    "display_as_bot": False,
+                    "team": "T014GJXU940",
+                    "channel": "C04T3ACM40K",
+                    "subtype": "file_share",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T0G9PQBBK",
+                        "user_id": "W23456789",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            }
+        )
+        return AsyncBoltRequest(body=body, headers=self.build_headers(timestamp, body))
+
+    @pytest.mark.asyncio
+    async def test_authorize_result(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            oauth_settings=AsyncOAuthSettings(
+                client_id="111.222",
+                client_secret="secret",
+                installation_store=MemoryInstallationStore(),
+                user_token_resolution="actor",
+            ),
+        )
+
+        @app.event("message")
+        async def handle_events(context: AsyncBoltContext, say: AsyncSay):
+            assert context.actor_enterprise_id == "E013Y3SHLAY"
+            assert context.actor_team_id == "T014GJXU940"
+            assert context.actor_user_id == "W013QGS7BPF"
+
+            assert context.authorize_result.bot_id == "BZYBOTHED"
+            assert context.authorize_result.bot_user_id == "W23456789"
+            assert context.authorize_result.bot_token == "xoxb-valid-2"
+            assert context.authorize_result.bot_scopes == ["commands", "chat:write"]
+            assert context.authorize_result.user_id == "W99999"
+            assert context.authorize_result.user_token == "xoxp-valid-actor-based"
+            assert context.authorize_result.user_scopes == ["search:read", "chat:write"]
+            await say("What's up?")
+
+        request = self.build_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        await asyncio.sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests["/chat.postMessage"] == 1
+
+
+class MemoryInstallationStore(AsyncInstallationStore):
+    @property
+    def logger(self) -> logging.Logger:
+        return logging.getLogger(__name__)
+
+    async def async_save(self, installation: Installation):
+        pass
+
+    async def async_find_bot(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Bot]:
+        return Bot(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T0G9PQBBK",
+            bot_token="xoxb-valid",
+            bot_id="B",
+            bot_user_id="W",
+            bot_scopes=["commands", "chat:write"],
+            installed_at=datetime.datetime.now().timestamp(),
+        )
+
+    async def async_find_installation(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        user_id: Optional[str] = None,
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Installation]:
+        if team_id == "T0G9PQBBK":
+            return Installation(
+                app_id="A111",
+                enterprise_id="E111",
+                team_id="T0G9PQBBK",
+                bot_token="xoxb-valid-2",
+                bot_id="B",
+                bot_user_id="W",
+                bot_scopes=["commands", "chat:write"],
+                user_id="W11111",
+                installed_at=datetime.datetime.now().timestamp(),
+            )
+        if team_id == "T014GJXU940" and enterprise_id == "E013Y3SHLAY":
+            return Installation(
+                app_id="A111",
+                enterprise_id="E013Y3SHLAY",
+                team_id="T014GJXU940",
+                user_id="W11111",
+                user_token="xoxp-valid-actor-based",
+                user_scopes=["search:read", "chat:write"],
+                installed_at=datetime.datetime.now().timestamp(),
+            )
+        return None

--- a/tests/slack_bolt/request/test_internals.py
+++ b/tests/slack_bolt/request/test_internals.py
@@ -7,6 +7,9 @@ from slack_bolt.request.internals import (
     extract_enterprise_id,
     parse_query,
     extract_is_enterprise_install,
+    extract_actor_enterprise_id,
+    extract_actor_team_id,
+    extract_actor_user_id,
 )
 
 
@@ -79,6 +82,173 @@ class TestRequestInternals:
         },
     ]
 
+    slack_connect_authorizations = [
+        {
+            "enterprise_id": "INSTALLED_ENTERPRISE_ID",
+            "team_id": "INSTALLED_TEAM_ID",
+            "user_id": "INSTALLED_BOT_USER_ID",
+            "is_bot": True,
+            "is_enterprise_install": False,
+        }
+    ]
+    slack_connect_events_api_no_actor_team_requests = [
+        {
+            "team_id": "INSTALLED_TEAM_ID",
+            "api_app_id": "A111",
+            "event": {
+                "type": "app_mention",
+                "text": "<@INSTALLED_BOT_USER_ID> hey",
+                "user": "USER_ID_ACTOR",
+                "ts": "1678451405.023359",
+                "team": "INSTALLED_TEAM_ID",
+                "user_team": "ENTERPRISE_ID_ACTOR",
+                "source_team": "ENTERPRISE_ID_ACTOR",
+                "user_profile": {"team": "ENTERPRISE_ID_ACTOR"},
+                "channel": "C111",
+                "event_ts": "1678451405.023359",
+            },
+            "type": "event_callback",
+            "authorizations": slack_connect_authorizations,
+            "is_ext_shared_channel": True,
+        },
+    ]
+    slack_connect_events_api_no_actor_enterprise_team_requests = [
+        {
+            "team_id": "INSTALLED_TEAM_ID",
+            "context_team_id": "INSTALLED_TEAM_ID",
+            "context_enterprise_id": "INSTALLED_ENTERPRISE_ID",
+            "api_app_id": "A111",
+            "event": {
+                "type": "reaction_added",
+                "user": "USER_ID_ACTOR",
+                "reaction": "eyes",
+                "item": {"type": "message", "channel": "C111", "ts": "1678453386.979699"},
+                "event_ts": "1678456876.000900",
+            },
+            "type": "event_callback",
+            "authorizations": slack_connect_authorizations,
+            "is_ext_shared_channel": True,
+        },
+        {
+            "enterprise_id": "INSTALLED_ENTERPRISE_ID",
+            "team_id": "INSTALLED_TEAM_ID",
+            "api_app_id": "A111",
+            "event": {
+                "file_id": "F111",
+                "user_id": "USER_ID_ACTOR",
+                "file": {"id": "F111"},
+                "channel_id": "C111",
+                "type": "file_shared",
+                "event_ts": "1678454981.170300",
+            },
+            "type": "event_callback",
+            "authorizations": slack_connect_authorizations,
+            "is_ext_shared_channel": True,
+        },
+        {
+            "team_id": "INSTALLED_TEAM_ID",
+            "context_team_id": "INSTALLED_TEAM_ID",
+            "context_enterprise_id": "INSTALLED_ENTERPRISE_ID",
+            "api_app_id": "A111",
+            "event": {
+                "type": "reaction_added",
+                "user": "USER_ID_ACTOR",
+                "reaction": "rocket",
+                "item": {"type": "message", "channel": "C111", "ts": "1678454602.316259"},
+                "event_ts": "1678454724.000600",
+            },
+            "type": "event_callback",
+            "authorizations": slack_connect_authorizations,
+            "is_ext_shared_channel": True,
+        },
+        {
+            "team_id": "TEAM_ID_ACTOR",
+            "enterprise_id": "ENTERPRISE_ID_ACTOR",
+            "context_team_id": "INSTALLED_TEAM_ID",
+            "context_enterprise_id": "INSTALLED_ENTERPRISE_ID",
+            "api_app_id": "A111",
+            "event": {
+                "type": "message_metadata_posted",
+                "app_id": "A222",
+                "bot_id": "B222",
+                "user_id": "USER_ID_ACTOR",  # Although this is always a bot's user ID, we can call it an actor
+                "team_id": "INSTALLED_TEAM_ID",
+                "channel_id": "C111",
+                "metadata": {"event_type": "task_created", "event_payload": {"id": "11223", "title": "Redesign Homepage"}},
+                "message_ts": "1678458906.527119",
+                "event_ts": "1678458906.527119",
+            },
+            "type": "event_callback",
+            "authorizations": slack_connect_authorizations,
+            "is_ext_shared_channel": True,
+        },
+    ]
+    slack_connect_events_api_requests = [
+        {
+            "team_id": "TEAM_ID_ACTOR",
+            "enterprise_id": "ENTERPRISE_ID_ACTOR",
+            "context_team_id": "INSTALLED_TEAM_ID",
+            "context_enterprise_id": "INSTALLED_ENTERPRISE_ID",
+            "api_app_id": "A111",
+            "event": {
+                "type": "message",
+                "text": "<@INSTALLED_BOT_USER_ID> Hey!",
+                "user": "USER_ID_ACTOR",
+                "ts": "1678455198.838499",
+                "team": "TEAM_ID_ACTOR",
+                "channel": "C111",
+                "event_ts": "1678455198.838499",
+                "channel_type": "channel",
+            },
+            "type": "event_callback",
+            "authorizations": slack_connect_authorizations,
+            "is_ext_shared_channel": True,
+        },
+        {
+            "team_id": "TEAM_ID_ACTOR",
+            "enterprise_id": "ENTERPRISE_ID_ACTOR",
+            "context_team_id": "INSTALLED_TEAM_ID",
+            "context_enterprise_id": "INSTALLED_ENTERPRISE_ID",
+            "api_app_id": "A111",
+            "event": {
+                "type": "message",
+                "text": "Hey!",
+                "user": "USER_ID_ACTOR",
+                "ts": "1678454365.204709",
+                "team": "TEAM_ID_ACTOR",
+                "channel": "C111",
+                "event_ts": "1678454365.204709",
+                "channel_type": "channel",
+            },
+            "type": "event_callback",
+            "authorizations": slack_connect_authorizations,
+            "is_ext_shared_channel": True,
+        },
+        {
+            "team_id": "TEAM_ID_ACTOR",
+            "enterprise_id": "ENTERPRISE_ID_ACTOR",
+            "context_team_id": "INSTALLED_TEAM_ID",
+            "context_enterprise_id": "INSTALLED_ENTERPRISE_ID",
+            "api_app_id": "A111",
+            "event": {
+                "type": "message",
+                "subtype": "channel_name",
+                "ts": "1678454602.316259",
+                "user": "USER_ID_ACTOR",
+                "text": "renamed",
+                "old_name": "old",
+                "name": "new",
+                "team": "TEAM_ID_ACTOR",
+                "channel": "C111",
+                "event_ts": "1678454602.316259",
+                "channel_type": "channel",
+            },
+            "type": "event_callback",
+            "authorizations": slack_connect_authorizations,
+            "is_ext_shared_channel": True,
+        },
+    ]
+
     def test_channel_id_extraction(self):
         for req in self.requests:
             channel_id = extract_channel_id(req)
@@ -126,6 +296,48 @@ class TestRequestInternals:
         assert extract_is_enterprise_install({"is_enterprise_install": "true"}) is True
         assert extract_is_enterprise_install({"is_enterprise_install": "false"}) is False
 
+    def test_actor_enterprise_id(self):
+        for req in self.requests:
+            enterprise_id = extract_actor_enterprise_id(req)
+            assert enterprise_id == "E111"
+        for req in self.slack_connect_events_api_requests:
+            enterprise_id = extract_actor_enterprise_id(req)
+            assert enterprise_id == "ENTERPRISE_ID_ACTOR"
+        for req in self.slack_connect_events_api_no_actor_team_requests:
+            enterprise_id = extract_actor_enterprise_id(req)
+            assert enterprise_id == "ENTERPRISE_ID_ACTOR"
+        for req in self.slack_connect_events_api_no_actor_enterprise_team_requests:
+            enterprise_id = extract_actor_enterprise_id(req)
+            assert enterprise_id is None
+
+    def test_actor_team_id(self):
+        for req in self.requests:
+            team_id = extract_actor_team_id(req)
+            assert team_id == "T111"
+        for req in self.slack_connect_events_api_requests:
+            team_id = extract_actor_team_id(req)
+            assert team_id == "TEAM_ID_ACTOR"
+        for req in self.slack_connect_events_api_no_actor_team_requests:
+            team_id = extract_actor_team_id(req)
+            assert team_id is None
+        for req in self.slack_connect_events_api_no_actor_enterprise_team_requests:
+            team_id = extract_actor_team_id(req)
+            assert team_id is None
+
+    def test_actor_user_id(self):
+        for req in self.requests:
+            user_id = extract_actor_user_id(req)
+            assert user_id == "U111"
+        for req in self.slack_connect_events_api_requests:
+            user_id = extract_actor_user_id(req)
+            assert user_id == "USER_ID_ACTOR"
+        for req in self.slack_connect_events_api_no_actor_team_requests:
+            user_id = extract_actor_user_id(req)
+            assert user_id == "USER_ID_ACTOR"
+        for req in self.slack_connect_events_api_no_actor_enterprise_team_requests:
+            user_id = extract_actor_user_id(req)
+            assert user_id is None
+
     def test_parse_query(self):
         expected = {"foo": ["bar"], "baz": ["123"]}
 
@@ -140,3 +352,648 @@ class TestRequestInternals:
 
         with pytest.raises(ValueError):
             parse_query({"foo": {"bar": "ZZZ"}, "baz": {"123": "111"}})
+
+    slack_connect_from_non_grid_test_patterns = [
+        (
+            {
+                "team_id": "T03E94MJU",
+                "context_team_id": "T014GJXU940",
+                "context_enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "message",
+                    "user": "U03E94MK0",
+                    "team": "T03E94MJU",
+                    "channel": "C04T3ACM40K",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            # context.enterprise_id/team_id/user_id,
+            (None, "T03E94MJU", "U03E94MK0"),
+            # context.actor_enterprise_id/team_id/user_id,
+            (None, "T03E94MJU", "U03E94MK0"),
+        ),
+        (
+            {
+                "team_id": "T03E94MJU",
+                "context_team_id": "T014GJXU940",
+                "context_enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "message",
+                    "user": "U03E94MK0",
+                    "team": "T03E94MJU",
+                    "channel": "C04T3ACM40K",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "U03E94MK0"),
+            (None, "T03E94MJU", "U03E94MK0"),
+        ),
+        (
+            {
+                "team_id": "T03E94MJU",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "app_mention",
+                    "text": "<@U04T5KKKLUE>",
+                    "user": "U03E94MK0",
+                    "team": "T03E94MJU",
+                    "channel": "C04T3ACM40K",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "U03E94MK0"),
+            (None, "T03E94MJU", "U03E94MK0"),
+        ),
+        (
+            {
+                "team_id": "T03E94MJU",
+                "context_team_id": "T014GJXU940",
+                "context_enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "message",
+                    "user": "U03E94MK0",
+                    "team": "T03E94MJU",
+                    "channel": "C04T3ACM40K",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "U03E94MK0"),
+            (None, "T03E94MJU", "U03E94MK0"),
+        ),
+        (
+            {
+                "team_id": "T014GJXU940",
+                "enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "app_mention",
+                    "user": "U03E94MK0",
+                    "team": "T014GJXU940",
+                    "user_team": "T03E94MJU",
+                    "source_team": "T03E94MJU",
+                    "user_profile": {"team": "T03E94MJU"},
+                    "channel": "C04T3ACM40K",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "U03E94MK0"),
+            (None, "T03E94MJU", "U03E94MK0"),
+        ),
+        (
+            {
+                "team_id": "T03E94MJU",
+                "context_team_id": "T014GJXU940",
+                "context_enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "message",
+                    "subtype": "channel_join",
+                    "user": "UL5CBM924",
+                    "team": "T03E94MJU",
+                    "inviter": "U03E94MK0",
+                    "channel": "C04T3ACM40K",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "UL5CBM924"),
+            (None, "T03E94MJU", "UL5CBM924"),
+        ),
+        (
+            {
+                "team_id": "T014GJXU940",
+                "enterprise_id": "E013Y3SHLAY",
+                "context_team_id": "T03E94MJU",
+                "context_enterprise_id": None,
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "member_joined_channel",
+                    "user": "UL5CBM924",
+                    "channel": "C04T3ACM40K",
+                    "team": "T03E94MJU",
+                    "inviter": "U03E94MK0",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "UL5CBM924"),
+            (None, "T03E94MJU", "UL5CBM924"),
+        ),
+        (
+            {
+                "team_id": "T014GJXU940",
+                "enterprise_id": "E013Y3SHLAY",
+                "context_team_id": "T03E94MJU",
+                "context_enterprise_id": None,
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "member_left_channel",
+                    "user": "UL5CBM924",
+                    "channel": "C04T3ACM40K",
+                    "team": "T03E94MJU",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "UL5CBM924"),
+            (None, "T03E94MJU", "UL5CBM924"),
+        ),
+        (
+            {
+                "team_id": "T03E94MJU",
+                "context_team_id": "T014GJXU940",
+                "context_enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "message",
+                    "subtype": "channel_leave",
+                    "user": "UL5CBM924",
+                    "team": "T03E94MJU",
+                    "channel": "C04T3ACM40K",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "UL5CBM924"),
+            (None, "T03E94MJU", "UL5CBM924"),
+        ),
+        (
+            {
+                "team_id": "T03E94MJU",
+                "context_team_id": "T014GJXU940",
+                "context_enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "message",
+                    "files": [],
+                    "upload": False,
+                    "user": "U03E94MK0",
+                    "display_as_bot": False,
+                    "team": "T03E94MJU",
+                    "channel": "C04T3ACM40K",
+                    "subtype": "file_share",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "U03E94MK0"),
+            (None, "T03E94MJU", "U03E94MK0"),
+        ),
+        (
+            {
+                "team_id": "T014GJXU940",
+                "enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "file_id": "F04TL3HA3PC",
+                    "user_id": "U03E94MK0",
+                    "file": {"id": "F04TL3HA3PC"},
+                    "channel_id": "C04T3ACM40K",
+                    "type": "file_shared",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "U03E94MK0"),
+            # Note that a complete set of actor IDs are not deterministic in this scenario
+            # So, we fall back to all None data for clarity
+            (None, None, None),
+        ),
+        (
+            {
+                "team_id": "T03E94MJU",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "file_id": "F04TL3HA3PC",
+                    "user_id": "U03E94MK0",
+                    "file": {"id": "F04TL3HA3PC"},
+                    "type": "file_public",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": False,
+            },
+            (None, "T03E94MJU", "U03E94MK0"),
+            (None, "T03E94MJU", "U03E94MK0"),
+        ),
+        (
+            {
+                "team_id": "T014GJXU940",
+                "enterprise_id": "E013Y3SHLAY",
+                "context_team_id": "T014GJXU940",
+                "context_enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "message_metadata_posted",
+                    "app_id": "A013TFN1T7C",
+                    "bot_id": "B013ZM43W3E",
+                    "user_id": "W013TN008CB",
+                    "team_id": "T014GJXU940",
+                    "channel_id": "C04T3ACM40K",
+                    "metadata": {
+                        "event_type": "task_created",
+                        "event_payload": {"id": "11223", "title": "Redesign Homepage"},
+                    },
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "W013TN008CB"),
+            # Note that a complete set of actor IDs are not deterministic in this scenario
+            # So, we fall back to all None data for clarity
+            (None, None, None),
+        ),
+        (
+            {
+                "team_id": "T014GJXU940",
+                "enterprise_id": "E013Y3SHLAY",
+                "context_team_id": "T014GJXU940",
+                "context_enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "bot_id": "B013ZM43W3E",
+                    "type": "message",
+                    "user": "W013TN008CB",
+                    "metadata": {
+                        "event_type": "task_created",
+                        "event_payload": {"id": "11223", "title": "Redesign Homepage"},
+                    },
+                    "app_id": "A013TFN1T7C",
+                    "team": "T014GJXU940",
+                    "bot_profile": {
+                        "id": "B013ZM43W3E",
+                        "app_id": "A013TFN1T7C",
+                        "team_id": "T014GJXU940",
+                    },
+                    "channel": "C04T3ACM40K",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "W013TN008CB"),
+            ("E013Y3SHLAY", "T014GJXU940", "W013TN008CB"),
+        ),
+    ]
+
+    slack_connect_from_grid_test_patterns = [
+        (
+            {
+                "team_id": "T03E94MJU",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "app_mention",
+                    "user": "W013QGS7BPF",
+                    "team": "T03E94MJU",
+                    "user_team": "E013Y3SHLAY",
+                    "source_team": "E013Y3SHLAY",
+                    "user_profile": {
+                        "team": "E013Y3SHLAY",
+                    },
+                    "channel": "C04T3ACM40K",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            # context.enterprise_id/team_id/user_id,
+            (None, "T03E94MJU", "W013QGS7BPF"),
+            # context.actor_enterprise_id/team_id/user_id,
+            ("E013Y3SHLAY", None, "W013QGS7BPF"),
+        ),
+        (
+            {
+                "team_id": "T014GJXU940",
+                "enterprise_id": "E013Y3SHLAY",
+                "context_team_id": "T014GJXU940",
+                "context_enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "message",
+                    "user": "W013QGS7BPF",
+                    "team": "T014GJXU940",
+                    "channel": "C04T3ACM40K",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "W013QGS7BPF"),
+            ("E013Y3SHLAY", "T014GJXU940", "W013QGS7BPF"),
+        ),
+        (
+            {
+                "team_id": "T014GJXU940",
+                "enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "file_id": "F04TDEYDCT0",
+                    "user_id": "W013QGS7BPF",
+                    "file": {"id": "F04TDEYDCT0"},
+                    "channel_id": "C04T3ACM40K",
+                    "type": "file_shared",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "W013QGS7BPF"),
+            (None, None, None),
+        ),
+        (
+            {
+                "team_id": "T014GJXU940",
+                "enterprise_id": "E013Y3SHLAY",
+                "context_team_id": "T014GJXU940",
+                "context_enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "message",
+                    "files": [],
+                    "upload": False,
+                    "user": "W013QGS7BPF",
+                    "display_as_bot": False,
+                    "team": "T014GJXU940",
+                    "channel": "C04T3ACM40K",
+                    "subtype": "file_share",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "W013QGS7BPF"),
+            ("E013Y3SHLAY", "T014GJXU940", "W013QGS7BPF"),
+        ),
+        (
+            {
+                "team_id": "T014GJXU940",
+                "enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "file_id": "F04TDEYDCT0",
+                    "user_id": "W013QGS7BPF",
+                    "file": {"id": "F04TDEYDCT0"},
+                    "type": "file_public",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": "E013Y3SHLAY",
+                        "team_id": "T014GJXU940",
+                        "user_id": "U04TDAM3YUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": False,
+            },
+            ("E013Y3SHLAY", "T014GJXU940", "W013QGS7BPF"),
+            ("E013Y3SHLAY", "T014GJXU940", "W013QGS7BPF"),
+        ),
+        (
+            {
+                "team_id": "T014GJXU940",
+                "enterprise_id": "E013Y3SHLAY",
+                "context_team_id": "T014GJXU940",
+                "context_enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "member_joined_channel",
+                    "user": "W013CV5UA87",
+                    "channel": "C04T3ACM40K",
+                    "team": "T014GJXU940",
+                    "inviter": "W013QGS7BPF",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "W013CV5UA87"),
+            ("E013Y3SHLAY", "T014GJXU940", "W013CV5UA87"),
+        ),
+        (
+            {
+                "team_id": "T014GJXU940",
+                "enterprise_id": "E013Y3SHLAY",
+                "context_team_id": "T014GJXU940",
+                "context_enterprise_id": "E013Y3SHLAY",
+                "api_app_id": "A04TEM7H4S0",
+                "event": {
+                    "type": "member_left_channel",
+                    "user": "W013CV5UA87",
+                    "channel": "C04T3ACM40K",
+                    "team": "E013Y3SHLAY",
+                },
+                "type": "event_callback",
+                "authorizations": [
+                    {
+                        "enterprise_id": None,
+                        "team_id": "T03E94MJU",
+                        "user_id": "U04T5KKKLUE",
+                        "is_bot": True,
+                        "is_enterprise_install": False,
+                    }
+                ],
+                "is_ext_shared_channel": True,
+            },
+            (None, "T03E94MJU", "W013CV5UA87"),
+            ("E013Y3SHLAY", "T014GJXU940", "W013CV5UA87"),
+        ),
+    ]
+
+    def test_slack_connect_patterns(self):
+        for (
+            request,
+            (enterprise_id, team_id, user_id),
+            (actor_enterprise_id, actor_team_id, actor_user_id),
+        ) in self.slack_connect_from_non_grid_test_patterns:
+            assert extract_enterprise_id(request) == enterprise_id
+            assert extract_team_id(request) == team_id
+            assert extract_user_id(request) == user_id
+            assert extract_actor_enterprise_id(request) == actor_enterprise_id
+            assert extract_actor_team_id(request) == actor_team_id
+            assert extract_actor_user_id(request) == actor_user_id
+
+        for (
+            request,
+            (enterprise_id, team_id, user_id),
+            (actor_enterprise_id, actor_team_id, actor_user_id),
+        ) in self.slack_connect_from_grid_test_patterns:
+            assert extract_enterprise_id(request) == enterprise_id
+            assert extract_team_id(request) == team_id
+            assert extract_user_id(request) == user_id
+            assert extract_actor_enterprise_id(request) == actor_enterprise_id
+            assert extract_actor_team_id(request) == actor_team_id
+            assert extract_actor_user_id(request) == actor_user_id


### PR DESCRIPTION
This pull request adds new standard properties to context object to help developers better handle events in a Slack Connect channel. This can be a breaking change to an existing app if the app use the same names in the context. Thus, this will be included in the next minor release.

To learn more on the context.team_id etc., checking the following resources is helpful:
* https://github.com/slackapi/java-slack-sdk/issues/629
* https://github.com/slackapi/bolt-python/pull/152

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
