### PR TITLE
Update optional chalice dependency version range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,7 @@ setuptools.setup(
             # used only under src/slack_bolt/adapter
             "boto3<=2",
             "bottle>=0.12,<1",
-            # TODO: chalice 1.28 dropped Python 3.6 support
-            "chalice<=1.27.3",
+            "chalice>=1.28,<2" if sys.version_info.minor > 6 else "chalice<=1.27.3",
             "CherryPy>=18,<19",
             "Django>=3,<5",
             "falcon>=3.1.1,<4" if sys.version_info.minor >= 11 else "falcon>=2,<4",


### PR DESCRIPTION
This pull request updates the chalice version range to be more specific considering Python runtime verison.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
