### PR TITLE
Fix a #855 bug where user_scopes exist even when user token is absent

### DIFF
--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -207,10 +207,11 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
                     if latest_bot_installation.user_id != user_id:
                         # First off, remove the user token as the installer is a different user
                         user_token = None
+                        user_scopes = None
                         latest_bot_installation.user_token = None
                         latest_bot_installation.user_refresh_token = None
                         latest_bot_installation.user_token_expires_at = None
-                        latest_bot_installation.user_scopes = []
+                        latest_bot_installation.user_scopes = None
 
                         # try to fetch the request user's installation
                         # to reflect the user's access token if exists

--- a/slack_bolt/authorization/authorize.py
+++ b/slack_bolt/authorization/authorize.py
@@ -206,10 +206,11 @@ class InstallationStoreAuthorize(Authorize):
                     if latest_bot_installation.user_id != user_id:
                         # First off, remove the user token as the installer is a different user
                         user_token = None
+                        user_scopes = None
                         latest_bot_installation.user_token = None
                         latest_bot_installation.user_refresh_token = None
                         latest_bot_installation.user_token_expires_at = None
-                        latest_bot_installation.user_scopes = []
+                        latest_bot_installation.user_scopes = None
 
                         # try to fetch the request user's installation
                         # to reflect the user's access token if exists

--- a/tests/scenario_tests_async/test_app_actor_user_token.py
+++ b/tests/scenario_tests_async/test_app_actor_user_token.py
@@ -61,12 +61,12 @@ class TestApp:
             "x-slack-request-timestamp": [timestamp],
         }
 
-    def build_request(self) -> AsyncBoltRequest:
+    def build_request(self, team_id: str = "T014GJXU940") -> AsyncBoltRequest:
         timestamp, body = str(int(time())), json.dumps(
             {
-                "team_id": "T014GJXU940",
+                "team_id": team_id,
                 "enterprise_id": "E013Y3SHLAY",
-                "context_team_id": "T014GJXU940",
+                "context_team_id": team_id,
                 "context_enterprise_id": "E013Y3SHLAY",
                 "api_app_id": "A04TEM7H4S0",
                 "event": {
@@ -75,7 +75,7 @@ class TestApp:
                     "upload": False,
                     "user": "W013QGS7BPF",
                     "display_as_bot": False,
-                    "team": "T014GJXU940",
+                    "team": team_id,
                     "channel": "C04T3ACM40K",
                     "subtype": "file_share",
                 },
@@ -123,6 +123,41 @@ class TestApp:
             await say("What's up?")
 
         request = self.build_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+        await asyncio.sleep(1)  # wait a bit after auto ack()
+        assert self.mock_received_requests["/chat.postMessage"] == 1
+
+    @pytest.mark.asyncio
+    async def test_authorize_result_no_user_token(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            oauth_settings=AsyncOAuthSettings(
+                client_id="111.222",
+                client_secret="secret",
+                installation_store=MemoryInstallationStore(),
+                user_token_resolution="actor",
+            ),
+        )
+
+        @app.event("message")
+        async def handle_events(context: AsyncBoltContext, say: AsyncSay):
+            assert context.actor_enterprise_id == "E013Y3SHLAY"
+            assert context.actor_team_id == "T11111"
+            assert context.actor_user_id == "W013QGS7BPF"
+
+            assert context.authorize_result.bot_id == "BZYBOTHED"
+            assert context.authorize_result.bot_user_id == "W23456789"
+            assert context.authorize_result.bot_token == "xoxb-valid-2"
+            assert context.authorize_result.bot_scopes == ["commands", "chat:write"]
+            assert context.authorize_result.user_id is None
+            assert context.authorize_result.user_token is None
+            assert context.authorize_result.user_scopes is None
+            await say("What's up?")
+
+        request = self.build_request(team_id="T11111")
         response = await app.async_dispatch(request)
         assert response.status == 200
         await assert_auth_test_count_async(self, 1)


### PR DESCRIPTION
This pull request resolves a bug in #855 changes

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
