### PR TITLE
Improve token rotation error handling and installation error text

### DIFF
--- a/slack_bolt/middleware/authorization/async_internals.py
+++ b/slack_bolt/middleware/authorization/async_internals.py
@@ -1,3 +1,4 @@
+from slack_bolt.middleware.authorization.internals import _build_error_text
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 
@@ -18,5 +19,5 @@ def _build_error_response() -> BoltResponse:
     # show an ephemeral message to the end-user
     return BoltResponse(
         status=200,
-        body=":x: Please install this app into the workspace :bow:",
+        body=_build_error_text(),
     )

--- a/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
@@ -10,7 +10,6 @@ from .async_internals import _build_error_response, _is_no_auth_required
 from .internals import _is_no_auth_test_call_required, _build_error_text
 from ...authorization import AuthorizeResult
 from ...authorization.async_authorize import AsyncAuthorize
-from ...request.payload_utils import is_event
 
 
 class AsyncMultiTeamsAuthorization(AsyncAuthorization):
@@ -94,9 +93,6 @@ class AsyncMultiTeamsAuthorization(AsyncAuthorization):
                 )
                 if req.context.response_url is not None:
                     await req.context.respond(_build_error_text())
-                    return BoltResponse(status=200, body="")
-                if is_event(req.body) and req.context.channel_id is not None and req.context.token is not None:
-                    await req.context.say(_build_error_text())
                     return BoltResponse(status=200, body="")
                 return _build_error_response()
 

--- a/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
@@ -7,9 +7,10 @@ from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 from .async_authorization import AsyncAuthorization
 from .async_internals import _build_error_response, _is_no_auth_required
-from .internals import _is_no_auth_test_call_required
+from .internals import _is_no_auth_test_call_required, _build_error_text
 from ...authorization import AuthorizeResult
 from ...authorization.async_authorize import AsyncAuthorize
+from ...request.payload_utils import is_event
 
 
 class AsyncMultiTeamsAuthorization(AsyncAuthorization):
@@ -91,6 +92,12 @@ class AsyncMultiTeamsAuthorization(AsyncAuthorization):
                     "Although the app should be installed into this workspace, "
                     "the AuthorizeResult (returned value from authorize) for it was not found."
                 )
+                if req.context.response_url is not None:
+                    await req.context.respond(_build_error_text())
+                    return BoltResponse(status=200, body="")
+                if is_event(req.body) and req.context.channel_id is not None and req.context.token is not None:
+                    await req.context.say(_build_error_text())
+                    return BoltResponse(status=200, body="")
                 return _build_error_response()
 
         except SlackApiError as e:

--- a/slack_bolt/middleware/authorization/async_single_team_authorization.py
+++ b/slack_bolt/middleware/authorization/async_single_team_authorization.py
@@ -10,7 +10,6 @@ from slack_sdk.errors import SlackApiError
 from .async_internals import _build_error_response, _is_no_auth_required
 from .internals import _to_authorize_result, _is_no_auth_test_call_required, _build_error_text
 from ...authorization import AuthorizeResult
-from ...request.payload_utils import is_event
 
 
 class AsyncSingleTeamAuthorization(AsyncAuthorization):
@@ -60,9 +59,6 @@ class AsyncSingleTeamAuthorization(AsyncAuthorization):
                 self.logger.error("auth.test API call result is unexpectedly None")
                 if req.context.response_url is not None:
                     await req.context.respond(_build_error_text())
-                    return BoltResponse(status=200, body="")
-                if is_event(req.body) and req.context.channel_id is not None and req.context.token is not None:
-                    await req.context.say(_build_error_text())
                     return BoltResponse(status=200, body="")
                 return _build_error_response()
         except SlackApiError as e:

--- a/slack_bolt/middleware/authorization/internals.py
+++ b/slack_bolt/middleware/authorization/internals.py
@@ -43,11 +43,18 @@ def _is_no_auth_test_call_required(req: Union[BoltRequest, "AsyncBoltRequest"]) 
     return _is_no_auth_test_events(req)
 
 
+def _build_error_text() -> str:
+    return (
+        ":warning: We apologize, but for some unknown reason, your installation with this app is no longer available. "
+        "Please reinstall this app into your workspace :bow:"
+    )
+
+
 def _build_error_response() -> BoltResponse:
     # show an ephemeral message to the end-user
     return BoltResponse(
         status=200,
-        body=":x: Please install this app into the workspace :bow:",
+        body=_build_error_text(),
     )
 
 

--- a/slack_bolt/middleware/authorization/multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/multi_teams_authorization.py
@@ -11,9 +11,11 @@ from .internals import (
     _build_error_response,
     _is_no_auth_required,
     _is_no_auth_test_call_required,
+    _build_error_text,
 )
 from ...authorization import AuthorizeResult
 from ...authorization.authorize import Authorize
+from ...request.payload_utils import is_event
 
 
 class MultiTeamsAuthorization(Authorization):
@@ -93,6 +95,12 @@ class MultiTeamsAuthorization(Authorization):
                     "Although the app should be installed into this workspace, "
                     "the AuthorizeResult (returned value from authorize) for it was not found."
                 )
+                if req.context.response_url is not None:
+                    req.context.respond(_build_error_text())
+                    return BoltResponse(status=200, body="")
+                if is_event(req.body) and req.context.channel_id is not None and req.context.token is not None:
+                    req.context.say(_build_error_text())
+                    return BoltResponse(status=200, body="")
                 return _build_error_response()
 
         except SlackApiError as e:

--- a/slack_bolt/middleware/authorization/multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/multi_teams_authorization.py
@@ -15,7 +15,6 @@ from .internals import (
 )
 from ...authorization import AuthorizeResult
 from ...authorization.authorize import Authorize
-from ...request.payload_utils import is_event
 
 
 class MultiTeamsAuthorization(Authorization):
@@ -97,9 +96,6 @@ class MultiTeamsAuthorization(Authorization):
                 )
                 if req.context.response_url is not None:
                     req.context.respond(_build_error_text())
-                    return BoltResponse(status=200, body="")
-                if is_event(req.body) and req.context.channel_id is not None and req.context.token is not None:
-                    req.context.say(_build_error_text())
                     return BoltResponse(status=200, body="")
                 return _build_error_response()
 

--- a/slack_bolt/middleware/authorization/single_team_authorization.py
+++ b/slack_bolt/middleware/authorization/single_team_authorization.py
@@ -15,7 +15,6 @@ from .internals import (
     _build_error_text,
 )
 from ...authorization import AuthorizeResult
-from ...request.payload_utils import is_event
 
 
 class SingleTeamAuthorization(Authorization):
@@ -75,9 +74,6 @@ class SingleTeamAuthorization(Authorization):
                 self.logger.error("auth.test API call result is unexpectedly None")
                 if req.context.response_url is not None:
                     req.context.respond(_build_error_text())
-                    return BoltResponse(status=200, body="")
-                if is_event(req.body) and req.context.channel_id is not None and req.context.token is not None:
-                    req.context.say(_build_error_text())
                     return BoltResponse(status=200, body="")
                 return _build_error_response()
         except SlackApiError as e:

--- a/tests/scenario_tests/test_authorize.py
+++ b/tests/scenario_tests/test_authorize.py
@@ -107,7 +107,7 @@ class TestAuthorize:
         request = self.build_valid_request()
         response = app.dispatch(request)
         assert response.status == 200
-        assert response.body == ":x: Please install this app into the workspace :bow:"
+        assert response.body == ""
         assert self.mock_received_requests.get("/auth.test") == None
 
     def test_bot_context_attributes(self):

--- a/tests/scenario_tests_async/test_authorize.py
+++ b/tests/scenario_tests_async/test_authorize.py
@@ -115,7 +115,7 @@ class TestAsyncAuthorize:
         request = self.build_valid_request()
         response = await app.async_dispatch(request)
         assert response.status == 200
-        assert response.body == ":x: Please install this app into the workspace :bow:"
+        assert response.body == ""
         assert self.mock_received_requests.get("/auth.test") == None
 
     @pytest.mark.asyncio

--- a/tests/slack_bolt/middleware/authorization/test_single_team_authorization.py
+++ b/tests/slack_bolt/middleware/authorization/test_single_team_authorization.py
@@ -1,6 +1,7 @@
 from slack_sdk import WebClient
 
 from slack_bolt.middleware import SingleTeamAuthorization
+from slack_bolt.middleware.authorization.internals import _build_error_text
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 from tests.mock_web_api_server import (
@@ -42,4 +43,4 @@ class TestSingleTeamAuthorization:
         resp = authorization.process(req=req, resp=resp, next=next)
 
         assert resp.status == 200
-        assert resp.body == ":x: Please install this app into the workspace :bow:"
+        assert resp.body == _build_error_text()

--- a/tests/slack_bolt_async/middleware/authorization/test_single_team_authorization.py
+++ b/tests/slack_bolt_async/middleware/authorization/test_single_team_authorization.py
@@ -6,6 +6,7 @@ from slack_sdk.web.async_client import AsyncWebClient
 from slack_bolt.middleware.authorization.async_single_team_authorization import (
     AsyncSingleTeamAuthorization,
 )
+from slack_bolt.middleware.authorization.internals import _build_error_text
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 from tests.mock_web_api_server import (
@@ -56,4 +57,4 @@ class TestSingleTeamAuthorization:
         resp = await authorization.async_process(req=req, resp=resp, next=next)
 
         assert resp.status == 200
-        assert resp.body == ":x: Please install this app into the workspace :bow:"
+        assert resp.body == _build_error_text()


### PR DESCRIPTION
This pull request improves the built-in middleware to better handle token rotation errors. Also, I've updated the built-in error text message in the scenario.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
