### PR TITLE
Improve the default handler when raise_error_for_unhandled_request is true

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -511,15 +511,18 @@ class App:
                         # This should not be an intentional handling in usual use cases.
                         resp = BoltResponse(status=404, body={"error": "no next() calls in middleware"})
                         if self._raise_error_for_unhandled_request is True:
-                            self._listener_runner.listener_error_handler.handle(
-                                error=BoltUnhandledRequestError(
+                            try:
+                                raise BoltUnhandledRequestError(
                                     request=req,
                                     current_response=resp,
                                     last_global_middleware_name=middleware.name,
-                                ),
-                                request=req,
-                                response=resp,
-                            )
+                                )
+                            except BoltUnhandledRequestError as e:
+                                self._listener_runner.listener_error_handler.handle(
+                                    error=e,
+                                    request=req,
+                                    response=resp,
+                                )
                             return resp
                         self._framework_logger.warning(warning_unhandled_by_global_middleware(middleware.name, req))
                         return resp
@@ -562,14 +565,17 @@ class App:
             if resp is None:
                 resp = BoltResponse(status=404, body={"error": "unhandled request"})
             if self._raise_error_for_unhandled_request is True:
-                self._listener_runner.listener_error_handler.handle(
-                    error=BoltUnhandledRequestError(
+                try:
+                    raise BoltUnhandledRequestError(
                         request=req,
                         current_response=resp,
-                    ),
-                    request=req,
-                    response=resp,
-                )
+                    )
+                except BoltUnhandledRequestError as e:
+                    self._listener_runner.listener_error_handler.handle(
+                        error=e,
+                        request=req,
+                        response=resp,
+                    )
                 return resp
             return self._handle_unmatched_requests(req, resp)
         except Exception as error:

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -535,15 +535,18 @@ class AsyncApp:
                         # This should not be an intentional handling in usual use cases.
                         resp = BoltResponse(status=404, body={"error": "no next() calls in middleware"})
                         if self._raise_error_for_unhandled_request is True:
-                            await self._async_listener_runner.listener_error_handler.handle(
-                                error=BoltUnhandledRequestError(
+                            try:
+                                raise BoltUnhandledRequestError(
                                     request=req,
                                     current_response=resp,
                                     last_global_middleware_name=middleware.name,
-                                ),
-                                request=req,
-                                response=resp,
-                            )
+                                )
+                            except BoltUnhandledRequestError as e:
+                                await self._async_listener_runner.listener_error_handler.handle(
+                                    error=e,
+                                    request=req,
+                                    response=resp,
+                                )
                             return resp
                         self._framework_logger.warning(warning_unhandled_by_global_middleware(middleware.name, req))
                         return resp
@@ -589,14 +592,17 @@ class AsyncApp:
             if resp is None:
                 resp = BoltResponse(status=404, body={"error": "unhandled request"})
             if self._raise_error_for_unhandled_request is True:
-                await self._async_listener_runner.listener_error_handler.handle(
-                    error=BoltUnhandledRequestError(
+                try:
+                    raise BoltUnhandledRequestError(
                         request=req,
                         current_response=resp,
-                    ),
-                    request=req,
-                    response=resp,
-                )
+                    )
+                except BoltUnhandledRequestError as e:
+                    await self._async_listener_runner.listener_error_handler.handle(
+                        error=e,
+                        request=req,
+                        response=resp,
+                    )
                 return resp
             return self._handle_unmatched_requests(req, resp)
 

--- a/slack_bolt/error/__init__.py
+++ b/slack_bolt/error/__init__.py
@@ -23,3 +23,6 @@ class BoltUnhandledRequestError(BoltError):
         self.body = request.body if request is not None else {}
         self.current_response = current_response
         self.last_global_middleware_name = last_global_middleware_name
+
+    def __str__(self) -> str:
+        return "unhandled request error"

--- a/tests/slack_bolt/error/test_errors.py
+++ b/tests/slack_bolt/error/test_errors.py
@@ -1,0 +1,19 @@
+from slack_bolt import BoltRequest
+from slack_bolt.error import BoltUnhandledRequestError
+
+
+class TestErrors:
+    def setup_method(self):
+        pass
+
+    def teardown_method(self):
+        pass
+
+    def test_say(self):
+        request = BoltRequest(body="foo=bar")
+        exception = BoltUnhandledRequestError(
+            request=request,
+            current_response={},
+            last_global_middleware_name="last_middleware",
+        )
+        assert str(exception) == "unhandled request error"


### PR DESCRIPTION
`raise_error_for_unhandled_request=True` is supposed to be used with a custom error handler. With that being said, the default behavior's logging could be confusing. To resolve the issue, this pull request chnges the internals to work with logger.exception better.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
