### PR TITLE
Add url, team, user to AuthorizeResult properties

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,42 +1,43 @@
-name: Run codecov
-
-on:
-  push:
-    branches: [main]
-  pull_request:
-
-jobs:
-  build:
-    # Avoiding -latest due to https://github.com/actions/setup-python/issues/162
-    runs-on: ubuntu-20.04
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        python-version: ["3.11"]
-    env:
-      # default: multiprocessing
-      # threading is more stable on GitHub Actions
-      BOLT_PYTHON_MOCK_SERVER_MODE: threading
-      BOLT_PYTHON_CODECOV_RUNNING: "1"
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python setup.py install
-          pip install -U pip
-          pip install -e ".[async]"
-          pip install -e ".[adapter]"
-          pip install -e ".[testing]"
-          pip install -e ".[adapter_testing]"
-      - name: Run all tests for codecov
-        run: |
-          pytest --cov=./slack_bolt/ --cov-report=xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
-          verbose: true
+# TODO: This CI job hangs as of April 2023
+#name: Run codecov
+#
+#on:
+#  push:
+#    branches: [main]
+#  pull_request:
+#
+#jobs:
+#  build:
+#    # Avoiding -latest due to https://github.com/actions/setup-python/issues/162
+#    runs-on: ubuntu-20.04
+#    timeout-minutes: 10
+#    strategy:
+#      matrix:
+#        python-version: ["3.11"]
+#    env:
+#      # default: multiprocessing
+#      # threading is more stable on GitHub Actions
+#      BOLT_PYTHON_MOCK_SERVER_MODE: threading
+#      BOLT_PYTHON_CODECOV_RUNNING: "1"
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up Python ${{ matrix.python-version }}
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: ${{ matrix.python-version }}
+#      - name: Install dependencies
+#        run: |
+#          python setup.py install
+#          pip install -U pip
+#          pip install -e ".[async]"
+#          pip install -e ".[adapter]"
+#          pip install -e ".[testing]"
+#          pip install -e ".[adapter_testing]"
+#      - name: Run all tests for codecov
+#        run: |
+#          pytest --cov=./slack_bolt/ --cov-report=xml
+#      - name: Upload coverage to Codecov
+#        uses: codecov/codecov-action@v3
+#        with:
+#          fail_ci_if_error: true
+#          verbose: true

--- a/slack_bolt/authorization/authorize_result.py
+++ b/slack_bolt/authorization/authorize_result.py
@@ -8,11 +8,16 @@ class AuthorizeResult(dict):
 
     enterprise_id: Optional[str]
     team_id: Optional[str]
+    team: Optional[str]  # since v1.18
+    url: Optional[str]  # since v1.18
+
     bot_id: Optional[str]
     bot_user_id: Optional[str]
     bot_token: Optional[str]
     bot_scopes: Optional[List[str]]  # since v1.17
+
     user_id: Optional[str]
+    user: Optional[str]  # since v1.18
     user_token: Optional[str]
     user_scopes: Optional[List[str]]  # since v1.17
 
@@ -21,6 +26,8 @@ class AuthorizeResult(dict):
         *,
         enterprise_id: Optional[str],
         team_id: Optional[str],
+        team: Optional[str] = None,
+        url: Optional[str] = None,
         # bot
         bot_user_id: Optional[str] = None,
         bot_id: Optional[str] = None,
@@ -28,6 +35,7 @@ class AuthorizeResult(dict):
         bot_scopes: Optional[Union[List[str], str]] = None,
         # user
         user_id: Optional[str] = None,
+        user: Optional[str] = None,
         user_token: Optional[str] = None,
         user_scopes: Optional[Union[List[str], str]] = None,
     ):
@@ -35,16 +43,21 @@ class AuthorizeResult(dict):
         Args:
             enterprise_id: Organization ID (Enterprise Grid) starting with `E`
             team_id: Workspace ID starting with `T`
+            team: Workspace name
+            url: Workspace slack.com URL
             bot_user_id: Bot user's User ID starting with either `U` or `W`
             bot_id: Bot ID starting with `B`
             bot_token: Bot user access token starting with `xoxb-`
             bot_scopes: The scopes associated with the bot token
             user_id: The request user ID
+            user: The request user's name
             user_token: User access token starting with `xoxp-`
             user_scopes: The scopes associated wth the user token
         """
         self["enterprise_id"] = self.enterprise_id = enterprise_id
         self["team_id"] = self.team_id = team_id
+        self["team"] = self.team = team
+        self["url"] = self.url = url
         # bot
         self["bot_user_id"] = self.bot_user_id = bot_user_id
         self["bot_id"] = self.bot_id = bot_id
@@ -54,6 +67,7 @@ class AuthorizeResult(dict):
         self["bot_scopes"] = self.bot_scopes = bot_scopes  # type: ignore
         # user
         self["user_id"] = self.user_id = user_id
+        self["user"] = self.user = user
         self["user_token"] = self.user_token = user_token
         if user_scopes is not None and isinstance(user_scopes, str):
             user_scopes = [scope.strip() for scope in user_scopes.split(",")]
@@ -76,17 +90,21 @@ class AuthorizeResult(dict):
         user_id: Optional[str] = (  # type:ignore
             auth_test_response.get("user_id") if auth_test_response.get("bot_id") is None else None
         )
-        # Since v1.28, user_id can be set when user_token w/ its auth.test response exists
+        user_name = auth_test_response.get("user")
         if user_id is None and user_auth_test_response is not None:
             user_id: Optional[str] = user_auth_test_response.get("user_id")  # type:ignore
+            user_name: Optional[str] = user_auth_test_response.get("user")  # type:ignore
 
         return AuthorizeResult(
             enterprise_id=auth_test_response.get("enterprise_id"),
             team_id=auth_test_response.get("team_id"),
+            team=auth_test_response.get("team"),
+            url=auth_test_response.get("url"),
             bot_id=auth_test_response.get("bot_id"),
             bot_user_id=bot_user_id,
             bot_scopes=bot_scopes,
             user_id=user_id,
+            user=user_name,
             bot_token=bot_token,
             user_token=user_token,
             user_scopes=user_scopes,

--- a/tests/scenario_tests/test_app_actor_user_token.py
+++ b/tests/scenario_tests/test_app_actor_user_token.py
@@ -169,6 +169,9 @@ class TestApp:
             assert context.authorize_result.user_id == "W99999"
             assert context.authorize_result.user_token == "xoxp-valid-actor-based"
             assert context.authorize_result.user_scopes == ["search:read", "chat:write"]
+            assert context.authorize_result.team_id == "T0G9PQBBK"
+            assert context.authorize_result.team == "Subarachnoid Workspace"
+            assert context.authorize_result.url == "https://subarachnoid.slack.com/"
             say("What's up?")
 
         response = app.dispatch(self.build_request())
@@ -196,14 +199,17 @@ class TestApp:
             assert context.actor_enterprise_id == "E013Y3SHLAY"
             assert context.actor_team_id == "T111111"
             assert context.actor_user_id == "W013QGS7BPF"
-
             assert context.authorize_result.bot_id == "BZYBOTHED"
             assert context.authorize_result.bot_user_id == "W23456789"
             assert context.authorize_result.bot_token == "xoxb-valid-2"
             assert context.authorize_result.bot_scopes == ["commands", "chat:write"]
+            assert context.authorize_result.user == "bot"
             assert context.authorize_result.user_id is None
             assert context.authorize_result.user_token is None
             assert context.authorize_result.user_scopes is None
+            assert context.authorize_result.team_id == "T0G9PQBBK"
+            assert context.authorize_result.team == "Subarachnoid Workspace"
+            assert context.authorize_result.url == "https://subarachnoid.slack.com/"
             say("What's up?")
 
         response = app.dispatch(self.build_request(team_id="T111111"))

--- a/tests/scenario_tests/test_app_installation_store.py
+++ b/tests/scenario_tests/test_app_installation_store.py
@@ -146,6 +146,9 @@ class TestApp:
             assert context.authorize_result.user_id == "W99999"
             assert context.authorize_result.user_token == "xoxp-valid"
             assert context.authorize_result.user_scopes == ["search:read"]
+            assert context.authorize_result.team_id == "T0G9PQBBK"
+            assert context.authorize_result.team == "Subarachnoid Workspace"
+            assert context.authorize_result.url == "https://subarachnoid.slack.com/"
             say("What's up?")
 
         response = app.dispatch(self.build_app_mention_request())

--- a/tests/scenario_tests_async/test_app_actor_user_token.py
+++ b/tests/scenario_tests_async/test_app_actor_user_token.py
@@ -120,6 +120,9 @@ class TestApp:
             assert context.authorize_result.user_id == "W99999"
             assert context.authorize_result.user_token == "xoxp-valid-actor-based"
             assert context.authorize_result.user_scopes == ["search:read", "chat:write"]
+            assert context.authorize_result.team_id == "T0G9PQBBK"
+            assert context.authorize_result.team == "Subarachnoid Workspace"
+            assert context.authorize_result.url == "https://subarachnoid.slack.com/"
             await say("What's up?")
 
         request = self.build_request()

--- a/tests/scenario_tests_async/test_app_installation_store.py
+++ b/tests/scenario_tests_async/test_app_installation_store.py
@@ -86,6 +86,9 @@ class TestApp:
             assert context.authorize_result.user_id == "W99999"
             assert context.authorize_result.user_token == "xoxp-valid"
             assert context.authorize_result.user_scopes == ["search:read"]
+            assert context.authorize_result.team_id == "T0G9PQBBK"
+            assert context.authorize_result.team == "Subarachnoid Workspace"
+            assert context.authorize_result.url == "https://subarachnoid.slack.com/"
             await say("What's up?")
 
         request = self.build_valid_app_mention_request()

--- a/tests/slack_bolt/authorization/test_authorize.py
+++ b/tests/slack_bolt/authorization/test_authorize.py
@@ -48,12 +48,22 @@ class TestAuthorize:
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 1)
 
         result = authorize(context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111")
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 2)
 
     def test_installation_store_cached_legacy(self):
@@ -71,12 +81,22 @@ class TestAuthorize:
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 1)
 
         result = authorize(context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111")
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 1)  # cached
 
     def test_installation_store_bot_only(self):
@@ -95,12 +115,22 @@ class TestAuthorize:
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 1)
 
         result = authorize(context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111")
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 2)
 
     def test_installation_store_cached_bot_only(self):
@@ -120,12 +150,22 @@ class TestAuthorize:
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 1)
 
         result = authorize(context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111")
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 1)  # cached
 
     def test_installation_store(self):
@@ -138,12 +178,22 @@ class TestAuthorize:
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token == "xoxp-valid"
+        assert result.user_id == "W99999"
+        assert result.user == "some-user"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 1)
 
         result = authorize(context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111")
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token == "xoxp-valid"
+        assert result.user_id == "W99999"
+        assert result.user == "some-user"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 2)
 
     def test_installation_store_cached(self):
@@ -160,12 +210,22 @@ class TestAuthorize:
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token == "xoxp-valid"
+        assert result.user_id == "W99999"
+        assert result.user == "some-user"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 1)
 
         result = authorize(context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111")
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token == "xoxp-valid"
+        assert result.user_id == "W99999"
+        assert result.user == "some-user"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 1)  # cached
 
     def test_fetch_different_user_token(self):
@@ -178,6 +238,11 @@ class TestAuthorize:
         assert result.bot_user_id == "W23456789"
         assert result.bot_token == "xoxb-valid"
         assert result.user_token == "xoxp-valid"
+        assert result.user_id == "W99999"
+        assert result.user == "some-user"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 1)
 
     def test_fetch_different_user_token_with_rotation(self):
@@ -209,6 +274,11 @@ class TestAuthorize:
         assert result.bot_user_id == "W23456789"
         assert result.bot_token == "xoxb-valid-refreshed"
         assert result.user_token == "xoxp-valid-refreshed"
+        assert result.user_id == "W99999"
+        assert result.user == "some-user"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 1)
 
     def test_remove_latest_user_token_if_it_is_not_relevant(self):
@@ -221,6 +291,11 @@ class TestAuthorize:
         assert result.bot_user_id == "W23456789"
         assert result.bot_token == "xoxb-valid"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 1)
 
     def test_rotate_only_bot_token(self):
@@ -252,6 +327,11 @@ class TestAuthorize:
         assert result.bot_user_id == "W23456789"
         assert result.bot_token == "xoxb-valid-refreshed"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         assert_auth_test_count(self, 1)
 
 

--- a/tests/slack_bolt_async/authorization/test_async_authorize.py
+++ b/tests/slack_bolt_async/authorization/test_async_authorize.py
@@ -66,12 +66,22 @@ class TestAsyncAuthorize:
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 1)
 
         result = await authorize(context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111")
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 2)
 
     @pytest.mark.asyncio
@@ -90,12 +100,22 @@ class TestAsyncAuthorize:
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 1)
 
         result = await authorize(context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111")
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 1)  # cached
 
     @pytest.mark.asyncio
@@ -115,12 +135,22 @@ class TestAsyncAuthorize:
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 1)
 
         result = await authorize(context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111")
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 2)
 
     @pytest.mark.asyncio
@@ -141,12 +171,22 @@ class TestAsyncAuthorize:
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 1)
 
         result = await authorize(context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111")
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 1)  # cached
 
     @pytest.mark.asyncio
@@ -161,6 +201,11 @@ class TestAsyncAuthorize:
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token == "xoxp-valid"
+        assert result.user_id == "W99999"
+        assert result.user == "some-user"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 1)
 
         result = await authorize(context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111")
@@ -185,12 +230,22 @@ class TestAsyncAuthorize:
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token == "xoxp-valid"
+        assert result.user_id == "W99999"
+        assert result.user == "some-user"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 1)
 
         result = await authorize(context=context, enterprise_id="E111", team_id="T0G9PQBBK", user_id="W11111")
         assert result.bot_id == "BZYBOTHED"
         assert result.bot_user_id == "W23456789"
         assert result.user_token == "xoxp-valid"
+        assert result.user_id == "W99999"
+        assert result.user == "some-user"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 1)  # cached
 
     @pytest.mark.asyncio
@@ -204,6 +259,11 @@ class TestAsyncAuthorize:
         assert result.bot_user_id == "W23456789"
         assert result.bot_token == "xoxb-valid"
         assert result.user_token == "xoxp-valid"
+        assert result.user_id == "W99999"
+        assert result.user == "some-user"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 1)
 
     @pytest.mark.asyncio
@@ -236,6 +296,11 @@ class TestAsyncAuthorize:
         assert result.bot_user_id == "W23456789"
         assert result.bot_token == "xoxb-valid-refreshed"
         assert result.user_token == "xoxp-valid-refreshed"
+        assert result.user_id == "W99999"
+        assert result.user == "some-user"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 1)
 
     @pytest.mark.asyncio
@@ -249,6 +314,11 @@ class TestAsyncAuthorize:
         assert result.bot_user_id == "W23456789"
         assert result.bot_token == "xoxb-valid"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 1)
 
     @pytest.mark.asyncio
@@ -281,6 +351,11 @@ class TestAsyncAuthorize:
         assert result.bot_user_id == "W23456789"
         assert result.bot_token == "xoxb-valid-refreshed"
         assert result.user_token is None
+        assert result.user_id is None
+        assert result.user == "bot"
+        assert result.team_id == "T0G9PQBBK"
+        assert result.team == "Subarachnoid Workspace"
+        assert result.url == "https://subarachnoid.slack.com/"
         await assert_auth_test_count_async(self, 1)
 
 


### PR DESCRIPTION
This pull request adds the following three properties to AuthorizeResult as optional ones.

* team: team's name
* url: team's slack.com domain URL
* user: user's name

These new properties are returned in auth.test API. There is no breaking change to existing apps. If they want to consume these properties, they can access them via `context.authorize_result.url` etc.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
