### PR TITLE
Add metadata to respond method

### DIFF
--- a/slack_bolt/context/respond/async_respond.py
+++ b/slack_bolt/context/respond/async_respond.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Sequence
+from typing import Optional, Union, Sequence, Dict, Any
 from ssl import SSLContext
 
 from slack_sdk.models.attachments import Attachment
@@ -35,6 +35,7 @@ class AsyncRespond:
         unfurl_links: Optional[bool] = None,
         unfurl_media: Optional[bool] = None,
         thread_ts: Optional[str] = None,
+        metadata: Dict[str, Any] = None,
     ) -> WebhookResponse:
         if self.response_url is not None:
             client = AsyncWebhookClient(
@@ -54,6 +55,7 @@ class AsyncRespond:
                     unfurl_links=unfurl_links,
                     unfurl_media=unfurl_media,
                     thread_ts=thread_ts,
+                    metadata=metadata,
                 )
                 return await client.send_dict(message)
             elif isinstance(text_or_whole_response, dict):

--- a/slack_bolt/context/respond/async_respond.py
+++ b/slack_bolt/context/respond/async_respond.py
@@ -35,7 +35,7 @@ class AsyncRespond:
         unfurl_links: Optional[bool] = None,
         unfurl_media: Optional[bool] = None,
         thread_ts: Optional[str] = None,
-        metadata: Dict[str, Any] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> WebhookResponse:
         if self.response_url is not None:
             client = AsyncWebhookClient(

--- a/slack_bolt/context/respond/internals.py
+++ b/slack_bolt/context/respond/internals.py
@@ -16,6 +16,7 @@ def _build_message(
     unfurl_links: Optional[bool] = None,
     unfurl_media: Optional[bool] = None,
     thread_ts: Optional[str] = None,
+    metadata: Dict[str, Any] = None,
 ) -> Dict[str, Any]:
     message = {"text": text}
     if blocks is not None and len(blocks) > 0:
@@ -34,4 +35,6 @@ def _build_message(
         message["unfurl_media"] = unfurl_media
     if thread_ts is not None:
         message["thread_ts"] = thread_ts
+    if metadata is not None:
+        message["metadata"] = metadata
     return message

--- a/slack_bolt/context/respond/internals.py
+++ b/slack_bolt/context/respond/internals.py
@@ -16,7 +16,7 @@ def _build_message(
     unfurl_links: Optional[bool] = None,
     unfurl_media: Optional[bool] = None,
     thread_ts: Optional[str] = None,
-    metadata: Dict[str, Any] = None,
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     message = {"text": text}
     if blocks is not None and len(blocks) > 0:

--- a/slack_bolt/context/respond/respond.py
+++ b/slack_bolt/context/respond/respond.py
@@ -35,7 +35,7 @@ class Respond:
         unfurl_links: Optional[bool] = None,
         unfurl_media: Optional[bool] = None,
         thread_ts: Optional[str] = None,
-        metadata: Dict[str, Any] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> WebhookResponse:
         if self.response_url is not None:
             client = WebhookClient(

--- a/slack_bolt/context/respond/respond.py
+++ b/slack_bolt/context/respond/respond.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Sequence
+from typing import Optional, Union, Sequence, Any, Dict
 from ssl import SSLContext
 
 from slack_sdk.models.attachments import Attachment
@@ -35,6 +35,7 @@ class Respond:
         unfurl_links: Optional[bool] = None,
         unfurl_media: Optional[bool] = None,
         thread_ts: Optional[str] = None,
+        metadata: Dict[str, Any] = None,
     ) -> WebhookResponse:
         if self.response_url is not None:
             client = WebhookClient(
@@ -55,6 +56,7 @@ class Respond:
                     unfurl_links=unfurl_links,
                     unfurl_media=unfurl_media,
                     thread_ts=thread_ts,
+                    metadata=metadata,
                 )
                 return client.send_dict(message)
             elif isinstance(text_or_whole_response, dict):

--- a/tests/slack_bolt/context/test_respond.py
+++ b/tests/slack_bolt/context/test_respond.py
@@ -29,3 +29,13 @@ class TestRespond:
         respond = Respond(response_url=response_url)
         response = respond(text="Hi there!", unfurl_media=True, unfurl_links=True)
         assert response.status_code == 200
+
+    def test_metadata(self):
+        response_url = "http://localhost:8888"
+        respond = Respond(response_url=response_url)
+        response = respond(
+            text="Hi there!",
+            response_type="in_channel",
+            metadata={"event_type": "foo", "event_payload": {"foo": "bar"}},
+        )
+        assert response.status_code == 200

--- a/tests/slack_bolt/context/test_respond_internals.py
+++ b/tests/slack_bolt/context/test_respond_internals.py
@@ -49,3 +49,11 @@ class TestRespondInternals:
         assert message is not None
         assert message.get("unfurl_links") is True
         assert message.get("unfurl_media") is True
+
+    def test_metadata(self):
+        message = _build_message(
+            text="Hi there!", response_type="in_channel", metadata={"event_type": "foo", "event_payload": {"foo": "bar"}}
+        )
+        assert message is not None
+        assert message.get("metadata").get("event_type") == "foo"
+        assert message.get("metadata").get("event_payload") == {"foo": "bar"}

--- a/tests/slack_bolt_async/context/test_async_respond.py
+++ b/tests/slack_bolt_async/context/test_async_respond.py
@@ -38,3 +38,14 @@ class TestAsyncRespond:
         respond = AsyncRespond(response_url=response_url)
         response = await respond(text="Hi there!", unfurl_media=True, unfurl_links=True)
         assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_metadata(self):
+        response_url = "http://localhost:8888"
+        respond = AsyncRespond(response_url=response_url)
+        response = await respond(
+            text="Hi there!",
+            response_type="in_channel",
+            metadata={"event_type": "foo", "event_payload": {"foo": "bar"}},
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
As pointed out at https://github.com/slackapi/bolt-js/issues/1819, metadata argument must be supported when posting a message using response_url

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
