### PR TITLE
Fix #892 by improving test code

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -24,19 +24,19 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-#      - name: Install dependencies
-#        run: |
-#          python setup.py install
-#          pip install -U pip
-#          pip install -e ".[async]"
-#          pip install -e ".[adapter]"
-#          pip install -e ".[testing]"
-#          pip install -e ".[adapter_testing]"
-#      - name: Run all tests for codecov
-#        run: |
-#          pytest --cov=./slack_bolt/ --cov-report=xml
-#      - name: Upload coverage to Codecov
-#        uses: codecov/codecov-action@v3
-#        with:
-#          fail_ci_if_error: true
-#          verbose: true
+      - name: Install dependencies
+        run: |
+          python setup.py install
+          pip install -U pip
+          pip install -e ".[async]"
+          pip install -e ".[adapter]"
+          pip install -e ".[testing]"
+          pip install -e ".[adapter_testing]"
+      - name: Run all tests for codecov
+        run: |
+          pytest --cov=./slack_bolt/ --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          verbose: true

--- a/tests/adapter_tests_async/socket_mode/test_async_aiohttp.py
+++ b/tests/adapter_tests_async/socket_mode/test_async_aiohttp.py
@@ -9,7 +9,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 from ...adapter_tests.socket_mode.mock_socket_mode_server import (
     start_socket_mode_server,
     stop_socket_mode_server_async,
@@ -29,7 +29,7 @@ class TestSocketModeAiohttp:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/adapter_tests_async/socket_mode/test_async_lazy_listeners.py
+++ b/tests/adapter_tests_async/socket_mode/test_async_lazy_listeners.py
@@ -9,7 +9,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 from ...adapter_tests.socket_mode.mock_socket_mode_server import (
     start_socket_mode_server,
     stop_socket_mode_server_async,
@@ -29,7 +29,7 @@ class TestSocketModeAiohttp:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/adapter_tests_async/socket_mode/test_async_websockets.py
+++ b/tests/adapter_tests_async/socket_mode/test_async_websockets.py
@@ -9,7 +9,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 from ...adapter_tests.socket_mode.mock_socket_mode_server import (
     start_socket_mode_server,
     stop_socket_mode_server_async,
@@ -29,7 +29,7 @@ class TestSocketModeWebsockets:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/adapter_tests_async/test_async_sanic.py
+++ b/tests/adapter_tests_async/test_async_sanic.py
@@ -17,7 +17,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestSanic:
@@ -39,7 +39,7 @@ class TestSanic:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_app.py
+++ b/tests/scenario_tests_async/test_app.py
@@ -19,7 +19,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncApp:
@@ -32,7 +32,7 @@ class TestAsyncApp:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_app_actor_user_token.py
+++ b/tests/scenario_tests_async/test_app_actor_user_token.py
@@ -23,7 +23,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestApp:
@@ -41,7 +41,7 @@ class TestApp:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_app_bot_only.py
+++ b/tests/scenario_tests_async/test_app_bot_only.py
@@ -22,7 +22,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAppBotOnly:
@@ -40,7 +40,7 @@ class TestAppBotOnly:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_app_custom_authorize.py
+++ b/tests/scenario_tests_async/test_app_custom_authorize.py
@@ -26,7 +26,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAppCustomAuthorize:
@@ -44,7 +44,7 @@ class TestAppCustomAuthorize:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_app_dispatch.py
+++ b/tests/scenario_tests_async/test_app_dispatch.py
@@ -9,7 +9,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncAppDispatch:
@@ -23,7 +23,7 @@ class TestAsyncAppDispatch:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_app_installation_store.py
+++ b/tests/scenario_tests_async/test_app_installation_store.py
@@ -23,7 +23,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestApp:
@@ -41,7 +41,7 @@ class TestApp:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_app_using_methods_in_class.py
+++ b/tests/scenario_tests_async/test_app_using_methods_in_class.py
@@ -18,7 +18,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAppUsingMethodsInClass:
@@ -36,7 +36,7 @@ class TestAppUsingMethodsInClass:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_attachment_actions.py
+++ b/tests/scenario_tests_async/test_attachment_actions.py
@@ -14,7 +14,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncAttachmentActions:
@@ -32,7 +32,7 @@ class TestAsyncAttachmentActions:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_authorize.py
+++ b/tests/scenario_tests_async/test_authorize.py
@@ -17,7 +17,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 valid_token = "xoxb-valid"
 valid_user_token = "xoxp-valid"
@@ -66,7 +66,7 @@ class TestAsyncAuthorize:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_block_actions.py
+++ b/tests/scenario_tests_async/test_block_actions.py
@@ -15,7 +15,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncBlockActions:
@@ -33,7 +33,7 @@ class TestAsyncBlockActions:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_block_actions_respond.py
+++ b/tests/scenario_tests_async/test_block_actions_respond.py
@@ -10,7 +10,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncBlockActionsRespond:
@@ -27,7 +27,7 @@ class TestAsyncBlockActionsRespond:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_block_suggestion.py
+++ b/tests/scenario_tests_async/test_block_suggestion.py
@@ -15,7 +15,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncBlockSuggestion:
@@ -33,7 +33,7 @@ class TestAsyncBlockSuggestion:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_dialogs.py
+++ b/tests/scenario_tests_async/test_dialogs.py
@@ -14,7 +14,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncAttachmentActions:
@@ -32,7 +32,7 @@ class TestAsyncAttachmentActions:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_error_handler.py
+++ b/tests/scenario_tests_async/test_error_handler.py
@@ -15,7 +15,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncErrorHandler:
@@ -33,7 +33,7 @@ class TestAsyncErrorHandler:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_events.py
+++ b/tests/scenario_tests_async/test_events.py
@@ -18,7 +18,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncEvents:
@@ -36,7 +36,7 @@ class TestAsyncEvents:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_events_ignore_self.py
+++ b/tests/scenario_tests_async/test_events_ignore_self.py
@@ -10,7 +10,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncEventsIgnoreSelf:
@@ -26,7 +26,7 @@ class TestAsyncEventsIgnoreSelf:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_events_org_apps.py
+++ b/tests/scenario_tests_async/test_events_org_apps.py
@@ -18,7 +18,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 valid_token = "xoxb-valid"
 
@@ -60,7 +60,7 @@ class TestAsyncOrgApps:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_events_request_verification.py
+++ b/tests/scenario_tests_async/test_events_request_verification.py
@@ -13,7 +13,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncEventsRequestVerification:
@@ -28,7 +28,7 @@ class TestAsyncEventsRequestVerification:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_events_shared_channels.py
+++ b/tests/scenario_tests_async/test_events_shared_channels.py
@@ -16,7 +16,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 valid_token = "xoxb-valid"
 
@@ -43,7 +43,7 @@ class TestAsyncEventsSharedChannels:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_events_socket_mode.py
+++ b/tests/scenario_tests_async/test_events_socket_mode.py
@@ -12,7 +12,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncEvents:
@@ -28,7 +28,7 @@ class TestAsyncEvents:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_events_token_revocations.py
+++ b/tests/scenario_tests_async/test_events_token_revocations.py
@@ -18,7 +18,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 valid_token = "xoxb-valid"
 
@@ -54,7 +54,7 @@ class TestEventsTokenRevocations:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_events_url_verification.py
+++ b/tests/scenario_tests_async/test_events_url_verification.py
@@ -13,7 +13,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncEventsUrlVerification:
@@ -28,7 +28,7 @@ class TestAsyncEventsUrlVerification:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_installation_store_authorize.py
+++ b/tests/scenario_tests_async/test_installation_store_authorize.py
@@ -19,7 +19,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 valid_token = "xoxb-valid"
 valid_user_token = "xoxp-valid"
@@ -69,7 +69,7 @@ class TestAsyncInstallationStoreAuthorize:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_lazy.py
+++ b/tests/scenario_tests_async/test_lazy.py
@@ -13,7 +13,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncLazy:
@@ -31,7 +31,7 @@ class TestAsyncLazy:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_listener_middleware.py
+++ b/tests/scenario_tests_async/test_listener_middleware.py
@@ -13,7 +13,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncListenerMiddleware:
@@ -31,7 +31,7 @@ class TestAsyncListenerMiddleware:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_message.py
+++ b/tests/scenario_tests_async/test_message.py
@@ -15,7 +15,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncMessage:
@@ -33,7 +33,7 @@ class TestAsyncMessage:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_message_bot.py
+++ b/tests/scenario_tests_async/test_message_bot.py
@@ -13,7 +13,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncMessage:
@@ -31,7 +31,7 @@ class TestAsyncMessage:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_message_changed.py
+++ b/tests/scenario_tests_async/test_message_changed.py
@@ -12,7 +12,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncMessageChanged:
@@ -30,7 +30,7 @@ class TestAsyncMessageChanged:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_message_deleted.py
+++ b/tests/scenario_tests_async/test_message_deleted.py
@@ -12,7 +12,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncMessageDeleted:
@@ -30,7 +30,7 @@ class TestAsyncMessageDeleted:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_message_file_share.py
+++ b/tests/scenario_tests_async/test_message_file_share.py
@@ -13,7 +13,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncMessageFileShare:
@@ -31,7 +31,7 @@ class TestAsyncMessageFileShare:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_message_thread_broadcast.py
+++ b/tests/scenario_tests_async/test_message_thread_broadcast.py
@@ -13,7 +13,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncMessageThreadBroadcast:
@@ -31,7 +31,7 @@ class TestAsyncMessageThreadBroadcast:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_middleware.py
+++ b/tests/scenario_tests_async/test_middleware.py
@@ -13,7 +13,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 # Note that async middleware system does not support instance methods n a class.
@@ -32,7 +32,7 @@ class TestAsyncMiddleware:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_shortcut.py
+++ b/tests/scenario_tests_async/test_shortcut.py
@@ -14,7 +14,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncShortcut:
@@ -32,7 +32,7 @@ class TestAsyncShortcut:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_slash_command.py
+++ b/tests/scenario_tests_async/test_slash_command.py
@@ -13,7 +13,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncSlashCommand:
@@ -31,7 +31,7 @@ class TestAsyncSlashCommand:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_ssl_check.py
+++ b/tests/scenario_tests_async/test_ssl_check.py
@@ -11,7 +11,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncSSLCheck:
@@ -29,7 +29,7 @@ class TestAsyncSSLCheck:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_view_closed.py
+++ b/tests/scenario_tests_async/test_view_closed.py
@@ -14,7 +14,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncViewClosed:
@@ -32,7 +32,7 @@ class TestAsyncViewClosed:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_view_submission.py
+++ b/tests/scenario_tests_async/test_view_submission.py
@@ -14,7 +14,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 body = {
@@ -204,7 +204,7 @@ class TestAsyncViewSubmission:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_web_client_customization.py
+++ b/tests/scenario_tests_async/test_web_client_customization.py
@@ -16,7 +16,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestWebClientCustomization:
@@ -34,7 +34,7 @@ class TestWebClientCustomization:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_workflow_steps.py
+++ b/tests/scenario_tests_async/test_workflow_steps.py
@@ -21,7 +21,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncWorkflowSteps:
@@ -39,7 +39,7 @@ class TestAsyncWorkflowSteps:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_workflow_steps_decorator_simple.py
+++ b/tests/scenario_tests_async/test_workflow_steps_decorator_simple.py
@@ -20,7 +20,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncWorkflowStepsDecorator:
@@ -41,7 +41,7 @@ class TestAsyncWorkflowStepsDecorator:
             self.app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret)
             self.app.step(copy_review_step)
 
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/scenario_tests_async/test_workflow_steps_decorator_with_args.py
+++ b/tests/scenario_tests_async/test_workflow_steps_decorator_with_args.py
@@ -21,7 +21,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncWorkflowStepsDecorator:
@@ -42,7 +42,7 @@ class TestAsyncWorkflowStepsDecorator:
             self.app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret)
             self.app.step(copy_review_step)
 
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/slack_bolt_async/authorization/test_async_authorize.py
+++ b/tests/slack_bolt_async/authorization/test_async_authorize.py
@@ -22,7 +22,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
     assert_auth_test_count_async,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 class TestAsyncAuthorize:
@@ -36,7 +36,7 @@ class TestAsyncAuthorize:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/slack_bolt_async/context/test_async_respond.py
+++ b/tests/slack_bolt_async/context/test_async_respond.py
@@ -2,6 +2,7 @@ import asyncio
 
 import pytest
 
+from tests.utils import get_event_loop
 from slack_bolt.context.respond.async_respond import AsyncRespond
 from tests.mock_web_api_server import (
     setup_mock_web_api_server,
@@ -13,7 +14,7 @@ class TestAsyncRespond:
     @pytest.fixture
     def event_loop(self):
         setup_mock_web_api_server(self)
-        loop = asyncio.get_event_loop()
+        loop = get_event_loop()
         yield loop
         loop.close()
         cleanup_mock_web_api_server(self)

--- a/tests/slack_bolt_async/context/test_async_say.py
+++ b/tests/slack_bolt_async/context/test_async_say.py
@@ -4,6 +4,7 @@ import pytest
 from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.web.async_slack_response import AsyncSlackResponse
 
+from tests.utils import get_event_loop
 from slack_bolt.context.say.async_say import AsyncSay
 from tests.mock_web_api_server import (
     setup_mock_web_api_server,
@@ -19,7 +20,7 @@ class TestAsyncSay:
         mock_api_server_base_url = "http://localhost:8888"
         self.web_client = AsyncWebClient(token=valid_token, base_url=mock_api_server_base_url)
 
-        loop = asyncio.get_event_loop()
+        loop = get_event_loop()
         yield loop
         loop.close()
         cleanup_mock_web_api_server(self)

--- a/tests/slack_bolt_async/middleware/authorization/test_single_team_authorization.py
+++ b/tests/slack_bolt_async/middleware/authorization/test_single_team_authorization.py
@@ -13,7 +13,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
 )
-from tests.utils import remove_os_env_temporarily, restore_os_env
+from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 
 
 async def next():
@@ -28,7 +28,7 @@ class TestSingleTeamAuthorization:
         old_os_env = remove_os_env_temporarily()
         try:
             setup_mock_web_api_server(self)
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
             yield loop
             loop.close()
             cleanup_mock_web_api_server(self)

--- a/tests/slack_bolt_async/middleware/request_verification/test_request_verification.py
+++ b/tests/slack_bolt_async/middleware/request_verification/test_request_verification.py
@@ -2,6 +2,7 @@ import asyncio
 from time import time
 
 import pytest
+from tests.utils import get_event_loop
 from slack_sdk.signature import SignatureVerifier
 
 from slack_bolt.middleware.request_verification.async_request_verification import (
@@ -34,7 +35,7 @@ class TestAsyncRequestVerification:
 
     @pytest.fixture
     def event_loop(self):
-        loop = asyncio.get_event_loop()
+        loop = get_event_loop()
         yield loop
         loop.close()
 

--- a/tests/slack_bolt_async/oauth/test_async_oauth_flow.py
+++ b/tests/slack_bolt_async/oauth/test_async_oauth_flow.py
@@ -4,6 +4,7 @@ from time import time
 from urllib.parse import quote
 
 import pytest
+from tests.utils import get_event_loop
 from slack_sdk.oauth.installation_store import FileInstallationStore
 from slack_sdk.oauth.state_store import FileOAuthStateStore
 from slack_sdk.oauth.state_store.async_state_store import AsyncOAuthStateStore
@@ -35,7 +36,7 @@ class TestAsyncOAuthFlow:
     @pytest.fixture
     def event_loop(self):
         setup_mock_web_api_server(self)
-        loop = asyncio.get_event_loop()
+        loop = get_event_loop()
         yield loop
         loop.close()
         cleanup_mock_web_api_server(self)

--- a/tests/slack_bolt_async/oauth/test_async_oauth_flow_sqlite3.py
+++ b/tests/slack_bolt_async/oauth/test_async_oauth_flow_sqlite3.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 from slack_sdk.web.async_client import AsyncWebClient
 
+from tests.utils import get_event_loop
 from slack_bolt import BoltResponse
 from slack_bolt.oauth.async_callback_options import (
     AsyncFailureArgs,
@@ -23,7 +24,7 @@ class TestAsyncOAuthFlowSQLite3:
     @pytest.fixture
     def event_loop(self):
         setup_mock_web_api_server(self)
-        loop = asyncio.get_event_loop()
+        loop = get_event_loop()
         yield loop
         loop.close()
         cleanup_mock_web_api_server(self)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
 import os
-
+import asyncio
 
 def remove_os_env_temporarily() -> dict:
     old_env = os.environ.copy()
@@ -27,3 +27,12 @@ def get_mock_server_mode() -> str:
         return "threading"
     else:
         return mode
+
+def get_event_loop():
+    try:
+        return asyncio.get_event_loop()
+    except RuntimeError as ex:
+        if "There is no current event loop in thread" in str(ex):
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            return loop


### PR DESCRIPTION
(Describe the goal of this PR. Mention any related Issue numbers)

Fixes #892 

This PR handles the exception when asyncio fails to get event loop from the main thread when the codecov CI job is run. Current changes tries to get an event loop, else it creates a new one and returns it. 

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
