### PR TITLE
[Django 4.x] Fix never returning an existing installation or bot

### DIFF
--- a/examples/django/oauth_app/slack_datastores.py
+++ b/examples/django/oauth_app/slack_datastores.py
@@ -42,7 +42,6 @@ class DjangoInstallationStore(InstallationStore):
             SlackInstallation.objects.filter(client_id=self.client_id)
             .filter(enterprise_id=installation.enterprise_id)
             .filter(team_id=installation.team_id)
-            .filter(installed_at=i["installed_at"])
             .first()
         )
         if row_to_update is not None:

--- a/examples/django/oauth_app/slack_datastores.py
+++ b/examples/django/oauth_app/slack_datastores.py
@@ -66,7 +66,6 @@ class DjangoInstallationStore(InstallationStore):
             SlackBot.objects.filter(client_id=self.client_id)
             .filter(enterprise_id=bot.enterprise_id)
             .filter(team_id=bot.team_id)
-            .filter(installed_at=b["installed_at"])
             .first()
         )
         if row_to_update is not None:


### PR DESCRIPTION
The `installed_at` field should not be part of the filter, or we would never return an existing, older installation.

This fixes a recurring `MultipleObjectsReturned` error that whoever uses this example will face.

(Describe the goal of this PR. Mention any related Issue numbers)

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others (Django examples)

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
