### PR TITLE
Fix SocketMode Test

### DIFF
--- a/tests/adapter_tests/socket_mode/test_interactions_websocket_client.py
+++ b/tests/adapter_tests/socket_mode/test_interactions_websocket_client.py
@@ -57,10 +57,11 @@ class TestSocketModeWebsocketClient:
         )
         try:
             handler.client.wss_uri = "ws://localhost:3012/link"
+            handler.client.default_auto_reconnect_enabled = False
 
             handler.connect()
-            assert handler.client.is_connected() is True
             time.sleep(2)  # wait for the message receiver
+            assert handler.client.is_connected() is True
 
             handler.client.send_message("foo")
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 import os
 import asyncio
 
+
 def remove_os_env_temporarily() -> dict:
     old_env = os.environ.copy()
     os.environ.clear()
@@ -27,6 +28,7 @@ def get_mock_server_mode() -> str:
         return "threading"
     else:
         return mode
+
 
 def get_event_loop():
     try:


### PR DESCRIPTION
This PR aims to fix a broken tests that seems to have originated from a the  changes introduced by [1379 in the python sdk](https://github.com/slackapi/python-slack-sdk/issues/1379)

I think the changes made to the python sdk require the socket mode mock to wait for connection without retrying before testing if the connection is made

### Category 

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements 

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
