### PR TITLE
Fix #988 app.action listener should accept block_id-only constraints for bolt-js feature parity

### DIFF
--- a/slack_bolt/listener_matcher/builtins.py
+++ b/slack_bolt/listener_matcher/builtins.py
@@ -292,7 +292,7 @@ def action(
             return workflow_step_edit(constraints["callback_id"], asyncio)
 
         raise BoltError(f"type: {action_type} is unsupported")
-    elif "action_id" in constraints:
+    elif "action_id" in constraints or "block_id" in constraints:
         # The default value is "block_actions"
         return block_action(constraints, asyncio)
 
@@ -313,8 +313,11 @@ def _block_action(
     elif isinstance(constraints, dict):
         # block_id matching is optional
         block_id: Optional[Union[str, Pattern]] = constraints.get("block_id")
+        action_id: Optional[Union[str, Pattern]] = constraints.get("action_id")
+        if block_id is None and action_id is None:
+            return False
         block_id_matched = block_id is None or _matches(block_id, action.get("block_id"))
-        action_id_matched = _matches(constraints["action_id"], action["action_id"])
+        action_id_matched = action_id is None or _matches(action_id, action.get("action_id"))
         return block_id_matched and action_id_matched
 
 

--- a/tests/scenario_tests/test_block_actions.py
+++ b/tests/scenario_tests/test_block_actions.py
@@ -109,6 +109,15 @@ class TestBlockActions:
         assert response.status == 200
         assert_auth_test_count(self, 1)
 
+    def test_default_type_no_action_id(self):
+        app = App(client=self.web_client, signing_secret=self.signing_secret)
+        app.action({"block_id": "b"})(simple_listener)
+
+        request = self.build_valid_request()
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert_auth_test_count(self, 1)
+
     def test_default_type_and_unmatched_block_id(self):
         app = App(client=self.web_client, signing_secret=self.signing_secret)
         app.action({"action_id": "a", "block_id": "bbb"})(simple_listener)

--- a/tests/scenario_tests_async/test_block_actions.py
+++ b/tests/scenario_tests_async/test_block_actions.py
@@ -115,6 +115,19 @@ class TestAsyncBlockActions:
         await assert_auth_test_count_async(self, 1)
 
     @pytest.mark.asyncio
+    async def test_default_type_no_action_id(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        app.action({"block_id": "b"})(simple_listener)
+
+        request = self.build_valid_request()
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_auth_test_count_async(self, 1)
+
+    @pytest.mark.asyncio
     async def test_default_type_unmatched_block_id(self):
         app = AsyncApp(
             client=self.web_client,


### PR DESCRIPTION
This pull request resolves #988 

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
