### PR TITLE
Improve socket mode tests

### DIFF
--- a/tests/adapter_tests/socket_mode/test_interactions_builtin.py
+++ b/tests/adapter_tests/socket_mode/test_interactions_builtin.py
@@ -27,7 +27,6 @@ class TestSocketModeBuiltin:
             base_url="http://localhost:8888",
         )
         start_socket_mode_server(self, 3011)
-        time.sleep(2)  # wait for the server
 
     def teardown_method(self):
         cleanup_mock_web_api_server(self)

--- a/tests/adapter_tests/socket_mode/test_interactions_websocket_client.py
+++ b/tests/adapter_tests/socket_mode/test_interactions_websocket_client.py
@@ -27,7 +27,6 @@ class TestSocketModeWebsocketClient:
             base_url="http://localhost:8888",
         )
         start_socket_mode_server(self, 3012)
-        time.sleep(2)  # wait for the server
 
     def teardown_method(self):
         cleanup_mock_web_api_server(self)

--- a/tests/adapter_tests/socket_mode/test_lazy_listeners.py
+++ b/tests/adapter_tests/socket_mode/test_lazy_listeners.py
@@ -27,7 +27,6 @@ class TestSocketModeLazyListeners:
             base_url="http://localhost:8888",
         )
         start_socket_mode_server(self, 3011)
-        time.sleep(2)  # wait for the server
 
     def teardown_method(self):
         cleanup_mock_web_api_server(self)

--- a/tests/adapter_tests_async/socket_mode/test_async_aiohttp.py
+++ b/tests/adapter_tests_async/socket_mode/test_async_aiohttp.py
@@ -39,7 +39,6 @@ class TestSocketModeAiohttp:
     @pytest.mark.asyncio
     async def test_events(self):
         start_socket_mode_server(self, 3021)
-        await asyncio.sleep(1)  # wait for the server
 
         app = AsyncApp(client=self.web_client)
 

--- a/tests/adapter_tests_async/socket_mode/test_async_lazy_listeners.py
+++ b/tests/adapter_tests_async/socket_mode/test_async_lazy_listeners.py
@@ -39,7 +39,6 @@ class TestSocketModeAiohttp:
     @pytest.mark.asyncio
     async def test_lazy_listeners(self):
         start_socket_mode_server(self, 3021)
-        await asyncio.sleep(1)  # wait for the server
 
         app = AsyncApp(client=self.web_client)
 

--- a/tests/adapter_tests_async/socket_mode/test_async_websockets.py
+++ b/tests/adapter_tests_async/socket_mode/test_async_websockets.py
@@ -39,7 +39,6 @@ class TestSocketModeWebsockets:
     @pytest.mark.asyncio
     async def test_events(self):
         start_socket_mode_server(self, 3022)
-        await asyncio.sleep(1)  # wait for the server
 
         app = AsyncApp(client=self.web_client)
 


### PR DESCRIPTION
The goal of this PR is to reduce the execution time of socket mode tests

From my local testing, running all tests took 4:32 minutes, with these change I was able to execute all test in 4:11 minutes

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
