### PR TITLE
Maintain metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bolt ![Bolt logo](docs/assets/bolt-logo.svg) for Python
+# Bolt ![Bolt logo][bolt-image] for Python
 
 [![Python Version][python-version]][pypi-url]
 [![pypi package][pypi-image]][pypi-url]
@@ -184,7 +184,7 @@ If you otherwise get stuck, we're here to help. The following are the best ways 
   * [Issue Tracker](http://github.com/slackapi/bolt-python/issues) for questions, bug reports, feature requests, and general discussion related to Bolt for Python. Try searching for an existing issue before creating a new one.
   * [Email](mailto:support@slack.com) our developer support team: `support@slack.com`
 
-
+[bolt-image]: https://raw.githubusercontent.com/slackapi/bolt-python/main/docs/assets/bolt-logo.svg
 [pypi-image]: https://badge.fury.io/py/slack-bolt.svg
 [pypi-url]: https://pypi.org/project/slack-bolt/
 [codecov-image]: https://codecov.io/gh/slackapi/bolt-python/branch/main/graph/badge.svg

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bolt ![Bolt logo][bolt-image] for Python
+# Bolt ![Bolt logo](docs/assets/bolt-logo.svg) for Python
 
 [![Python Version][python-version]][pypi-url]
 [![pypi package][pypi-image]][pypi-url]
@@ -184,7 +184,7 @@ If you otherwise get stuck, we're here to help. The following are the best ways 
   * [Issue Tracker](http://github.com/slackapi/bolt-python/issues) for questions, bug reports, feature requests, and general discussion related to Bolt for Python. Try searching for an existing issue before creating a new one.
   * [Email](mailto:support@slack.com) our developer support team: `support@slack.com`
 
-[bolt-image]: https://raw.githubusercontent.com/slackapi/bolt-python/main/docs/assets/bolt-logo.svg
+
 [pypi-image]: https://badge.fury.io/py/slack-bolt.svg
 [pypi-url]: https://pypi.org/project/slack-bolt/
 [codecov-image]: https://codecov.io/gh/slackapi/bolt-python/branch/main/graph/badge.svg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack_bolt"
-dynamic = ["version", "readme", "dependencies"]
+dynamic = ["version", "readme", "dependencies", "authors"]
 description = "The Bolt Framework for Python"
 license = { text = "MIT" }
-authors = [{ name = "Slack Technologies, LLC", email = "opensource@slack.com" }]
 classifiers = [
 	"Programming Language :: Python :: 3.6",
 	"Programming Language :: Python :: 3.7",
@@ -24,7 +23,7 @@ requires-python = ">=3.6"
 
 
 [project.urls]
-homepage = "https://github.com/slackapi/bolt-python"
+Documentation = "https://slack.dev/bolt-python"
 
 [tool.setuptools.packages.find]
 include = ["slack_bolt*"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+; Legacy package configuration, prefer pyproject.toml over setup.cfg
+[metadata]
+url=https://github.com/slackapi/bolt-python
+author=Slack Technologies, LLC
+author_email=opensource@slack.com


### PR DESCRIPTION
During the implementation of [slack-sdk#1436](https://github.com/slackapi/python-slack-sdk/pull/1436) is was found that the metadata from `pip show slack-bolt` was not maintained in the changes introduced by #996

This PR aims to remedy this situation by introducing changes that maintain the output of `pip show slack-bolt`

Output:
```zsh
Name: slack-bolt
Version: 1.18.1
Summary: The Bolt Framework for Python
Home-page: https://github.com/slackapi/bolt-python
Author: Slack Technologies, LLC
Author-email: opensource@slack.com
License: MIT
Location: /.../env_3.11.2/lib/python3.11/site-packages
Requires: slack-sdk
```

This package was also deployed to [test.pypi/slack-bolt](https://test.pypi.org/project/slack-bolt/1.18.1b1/) no behaviors were noticed 

### Category

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
