### PR TITLE
remove unused multiprocessing test mode

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,7 +16,6 @@ jobs:
     env:
       # default: multiprocessing
       # threading is more stable on GitHub Actions
-      BOLT_PYTHON_MOCK_SERVER_MODE: threading
       BOLT_PYTHON_CODECOV_RUNNING: "1"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,8 +14,6 @@ jobs:
       matrix:
         python-version: ["3.11"]
     env:
-      # default: multiprocessing
-      # threading is more stable on GitHub Actions
       BOLT_PYTHON_CODECOV_RUNNING: "1"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
-    env:
-      # default: multiprocessing
-      # threading is more stable on GitHub Actions
-      BOLT_PYTHON_MOCK_SERVER_MODE: threading
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/tests/adapter_tests/socket_mode/mock_socket_mode_server.py
+++ b/tests/adapter_tests/socket_mode/mock_socket_mode_server.py
@@ -1,14 +1,10 @@
 import json
 import logging
-import sys
 import threading
 import time
 import requests
-from multiprocessing.context import Process
 from typing import List
 from unittest import TestCase
-
-from tests.utils import get_mock_server_mode
 
 socket_mode_envelopes = [
     """{"envelope_id":"57d6a792-4d35-4d0b-b6aa-3361493e1caf","payload":{"type":"shortcut","token":"xxx","action_ts":"1610198080.300836","team":{"id":"T111","domain":"seratch"},"user":{"id":"U111","username":"seratch","team_id":"T111"},"is_enterprise_install":false,"enterprise":null,"callback_id":"do-something","trigger_id":"111.222.xxx"},"type":"interactive","accepts_response_payload":false}""",
@@ -56,42 +52,11 @@ def start_thread_socket_mode_server(test: TestCase, port: int):
     return _start_thread_socket_mode_server
 
 
-def start_process_socket_mode_server(port: int):
-    logger = logging.getLogger(__name__)
-    app: Flask = Flask(__name__)
-    sockets: Sockets = Sockets(app)
-
-    envelopes_to_consume: List[str] = list(socket_mode_envelopes)
-
-    @sockets.route("/link")
-    def link(ws):
-        while not ws.closed:
-            message = ws.read_message()
-            if message is not None:
-                if len(envelopes_to_consume) > 0:
-                    e = envelopes_to_consume.pop(0)
-                    logger.debug(f"Send an envelope: {e}")
-                    ws.send(e)
-
-                logger.debug(f"Server received a message: {message}")
-                ws.send(message)
-
-    from gevent import pywsgi
-    from geventwebsocket.handler import WebSocketHandler
-
-    server = pywsgi.WSGIServer(("", port), app, handler_class=WebSocketHandler)
-    server.serve_forever(stop_timeout=1)
-
-
 def start_socket_mode_server(test, port: int):
-    if get_mock_server_mode() == "threading":
-        test.sm_thread = threading.Thread(target=start_thread_socket_mode_server(test, port))
-        test.sm_thread.daemon = True
-        test.sm_thread.start()
-        wait_for_socket_mode_server(port, 2)  # wait for the server
-    else:
-        test.sm_process = Process(target=start_process_socket_mode_server, kwargs={"port": port})
-        test.sm_process.start()
+    test.sm_thread = threading.Thread(target=start_thread_socket_mode_server(test, port))
+    test.sm_thread.daemon = True
+    test.sm_thread.start()
+    wait_for_socket_mode_server(port, 4)  # wait for the server
 
 
 def wait_for_socket_mode_server(port: int, secs: int):
@@ -100,39 +65,15 @@ def wait_for_socket_mode_server(port: int, secs: int):
         response = requests.get(url=f"http://localhost:{port}/state")
         if response.ok:
             break
+        time.sleep(0.01)
 
 
 def stop_socket_mode_server(test):
-    if get_mock_server_mode() == "threading":
-        print(test)
-        test.server.stop()
-        test.server.close()
-    else:
-        # terminate the process
-        test.sm_process.terminate()
-        test.sm_process.join()
-        # Python 3.6 does not have these methods
-        if sys.version_info.major == 3 and sys.version_info.minor > 6:
-            # cleanup the process's resources
-            test.sm_process.kill()
-            test.sm_process.close()
-
-        test.sm_process = None
+    print(test)
+    test.server.stop()
+    test.server.close()
 
 
 async def stop_socket_mode_server_async(test: TestCase):
-    if get_mock_server_mode() == "threading":
-        test.server.stop()
-        test.server.close()
-    else:
-        # terminate the process
-        test.sm_process.terminate()
-        test.sm_process.join()
-
-        # Python 3.6 does not have these methods
-        if sys.version_info.major == 3 and sys.version_info.minor > 6:
-            # cleanup the process's resources
-            test.sm_process.kill()
-            test.sm_process.close()
-
-        test.sm_process = None
+    test.server.stop()
+    test.server.close()

--- a/tests/adapter_tests/socket_mode/mock_socket_mode_server.py
+++ b/tests/adapter_tests/socket_mode/mock_socket_mode_server.py
@@ -69,7 +69,6 @@ def wait_for_socket_mode_server(port: int, secs: int):
 
 
 def stop_socket_mode_server(test):
-    print(test)
     test.server.stop()
     test.server.close()
 

--- a/tests/adapter_tests/socket_mode/mock_web_api_server.py
+++ b/tests/adapter_tests/socket_mode/mock_web_api_server.py
@@ -115,11 +115,6 @@ class MockHandler(SimpleHTTPRequestHandler):
         self._handle()
 
 
-#
-# threading
-#
-
-
 class MockServerThread(threading.Thread):
     def __init__(self, test: TestCase, handler: Type[SimpleHTTPRequestHandler] = MockHandler):
         threading.Thread.__init__(self)

--- a/tests/adapter_tests/socket_mode/mock_web_api_server.py
+++ b/tests/adapter_tests/socket_mode/mock_web_api_server.py
@@ -1,18 +1,13 @@
 import json
 import logging
 import re
-import sys
 import threading
 import time
 from http import HTTPStatus
 from http.server import HTTPServer, SimpleHTTPRequestHandler
-from multiprocessing.context import Process
 from typing import Type
 from unittest import TestCase
 from urllib.parse import urlparse, parse_qs
-from urllib.request import Request, urlopen
-
-from tests.utils import get_mock_server_mode
 
 
 class MockHandler(SimpleHTTPRequestHandler):
@@ -121,54 +116,6 @@ class MockHandler(SimpleHTTPRequestHandler):
 
 
 #
-# multiprocessing
-#
-
-
-class MockServerProcessTarget:
-    def __init__(self, handler: Type[SimpleHTTPRequestHandler] = MockHandler):
-        self.handler = handler
-
-    def run(self):
-        self.handler.received_requests = {}
-        self.server = HTTPServer(("localhost", 8888), self.handler)
-        try:
-            self.server.serve_forever(0.05)
-        finally:
-            self.server.server_close()
-
-    def stop(self):
-        self.handler.received_requests = {}
-        self.server.shutdown()
-        self.join()
-
-
-class MonitorThread(threading.Thread):
-    def __init__(self, test: TestCase, handler: Type[SimpleHTTPRequestHandler] = MockHandler):
-        threading.Thread.__init__(self, daemon=True)
-        self.handler = handler
-        self.test = test
-        self.test.mock_received_requests = None
-        self.is_running = True
-
-    def run(self) -> None:
-        while self.is_running:
-            try:
-                req = Request(f"{self.test.server_url}/received_requests.json")
-                resp = urlopen(req, timeout=1)
-                self.test.mock_received_requests = json.loads(resp.read().decode("utf-8"))
-            except Exception as e:
-                # skip logging for the initial request
-                if self.test.mock_received_requests is not None:
-                    logging.getLogger(__name__).exception(e)
-            time.sleep(0.01)
-
-    def stop(self):
-        self.is_running = False
-        self.join()
-
-
-#
 # threading
 #
 
@@ -197,52 +144,15 @@ class MockServerThread(threading.Thread):
 
 
 def setup_mock_web_api_server(test: TestCase):
-    if get_mock_server_mode() == "threading":
-        test.server_started = threading.Event()
-        test.thread = MockServerThread(test)
-        test.thread.start()
-        test.server_started.wait()
-    else:
-        # start a mock server as another process
-        target = MockServerProcessTarget()
-        test.server_url = "http://localhost:8888"
-        test.host, test.port = "localhost", 8888
-        test.process = Process(target=target.run, daemon=True)
-        test.process.start()
-        time.sleep(0.1)
-
-        # start a thread in the current process
-        # this thread fetches mock_received_requests from the remote process
-        test.monitor_thread = MonitorThread(test)
-        test.monitor_thread.start()
-        count = 0
-        # wait until the first successful data retrieval
-        while test.mock_received_requests is None:
-            time.sleep(0.01)
-            count += 1
-            if count >= 100:
-                raise Exception("The mock server is not yet running!")
+    test.server_started = threading.Event()
+    test.thread = MockServerThread(test)
+    test.thread.start()
+    test.server_started.wait()
 
 
 def cleanup_mock_web_api_server(test: TestCase):
-    if get_mock_server_mode() == "threading":
-        test.thread.stop()
-        test.thread = None
-    else:
-        # stop the thread to fetch mock_received_requests from the remote process
-        test.monitor_thread.stop()
-
-        # terminate the process
-        test.process.terminate()
-        test.process.join()
-
-        # Python 3.6 does not have these methods
-        if sys.version_info.major == 3 and sys.version_info.minor > 6:
-            # cleanup the process's resources
-            test.process.kill()
-            test.process.close()
-
-        test.process = None
+    test.thread.stop()
+    test.thread = None
 
 
 def assert_auth_test_count(test: TestCase, expected_count: int):

--- a/tests/adapter_tests/socket_mode/test_interactions_builtin.py
+++ b/tests/adapter_tests/socket_mode/test_interactions_builtin.py
@@ -34,7 +34,6 @@ class TestSocketModeBuiltin:
         stop_socket_mode_server(self)
 
     def test_interactions(self):
-
         app = App(client=self.web_client)
 
         result = {"shortcut": False, "command": False}

--- a/tests/mock_web_api_server.py
+++ b/tests/mock_web_api_server.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import logging
-import sys
 import threading
 import time
 from http import HTTPStatus
@@ -9,11 +8,6 @@ from http.server import HTTPServer, SimpleHTTPRequestHandler
 from typing import Type, Optional
 from unittest import TestCase
 from urllib.parse import urlparse, parse_qs, ParseResult
-
-from multiprocessing import Process
-from urllib.request import urlopen, Request
-
-from tests.utils import get_mock_server_mode
 
 
 class MockHandler(SimpleHTTPRequestHandler):
@@ -235,54 +229,6 @@ class MockHandler(SimpleHTTPRequestHandler):
 
 
 #
-# multiprocessing
-#
-
-
-class MockServerProcessTarget:
-    def __init__(self, handler: Type[SimpleHTTPRequestHandler] = MockHandler):
-        self.handler = handler
-
-    def run(self):
-        self.handler.received_requests = {}
-        self.server = HTTPServer(("localhost", 8888), self.handler)
-        try:
-            self.server.serve_forever(0.05)
-        finally:
-            self.server.server_close()
-
-    def stop(self):
-        self.handler.received_requests = {}
-        self.server.shutdown()
-        self.join()
-
-
-class MonitorThread(threading.Thread):
-    def __init__(self, test: TestCase, handler: Type[SimpleHTTPRequestHandler] = MockHandler):
-        threading.Thread.__init__(self, daemon=True)
-        self.handler = handler
-        self.test = test
-        self.test.mock_received_requests = None
-        self.is_running = True
-
-    def run(self) -> None:
-        while self.is_running:
-            try:
-                req = Request(f"{self.test.server_url}/received_requests.json")
-                resp = urlopen(req, timeout=1)
-                self.test.mock_received_requests = json.loads(resp.read().decode("utf-8"))
-            except Exception as e:
-                # skip logging for the initial request
-                if self.test.mock_received_requests is not None:
-                    logging.getLogger(__name__).exception(e)
-            time.sleep(0.01)
-
-    def stop(self):
-        self.is_running = False
-        self.join()
-
-
-#
 # threading
 #
 
@@ -313,53 +259,15 @@ class MockServerThread(threading.Thread):
 
 
 def setup_mock_web_api_server(test: TestCase):
-    if get_mock_server_mode() == "threading":
-        test.server_started = threading.Event()
-        test.thread = MockServerThread(test)
-        test.thread.start()
-        test.server_started.wait()
-    else:
-        # start a mock server as another process
-        target = MockServerProcessTarget()
-        test.server_url = "http://localhost:8888"
-        test.host, test.port = "localhost", 8888
-        test.process = Process(target=target.run, daemon=True)
-        test.process.start()
-
-        time.sleep(0.1)
-
-        # start a thread in the current process
-        # this thread fetches mock_received_requests from the remote process
-        test.monitor_thread = MonitorThread(test)
-        test.monitor_thread.start()
-        count = 0
-        # wait until the first successful data retrieval
-        while test.mock_received_requests is None:
-            time.sleep(0.01)
-            count += 1
-            if count >= 100:
-                raise Exception("The mock server is not yet running!")
+    test.server_started = threading.Event()
+    test.thread = MockServerThread(test)
+    test.thread.start()
+    test.server_started.wait()
 
 
 def cleanup_mock_web_api_server(test: TestCase):
-    if get_mock_server_mode() == "threading":
-        test.thread.stop()
-        test.thread = None
-    else:
-        # stop the thread to fetch mock_received_requests from the remote process
-        test.monitor_thread.stop()
-
-        # terminate the process
-        test.process.terminate()
-        test.process.join()
-
-        # Python 3.6 does not have these methods
-        if sys.version_info.major == 3 and sys.version_info.minor > 6:
-            # cleanup the process's resources
-            test.process.kill()
-            test.process.close()
-
-        test.process = None
+    test.thread.stop()
+    test.thread = None
 
 
 def assert_auth_test_count(test: TestCase, expected_count: int):

--- a/tests/mock_web_api_server.py
+++ b/tests/mock_web_api_server.py
@@ -228,11 +228,6 @@ class MockHandler(SimpleHTTPRequestHandler):
         return request_body
 
 
-#
-# threading
-#
-
-
 class MockServerThread(threading.Thread):
     def __init__(self, test: TestCase, handler: Type[SimpleHTTPRequestHandler] = MockHandler):
         threading.Thread.__init__(self)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,21 +15,6 @@ def restore_os_env(old_env: dict) -> None:
     os.environ.update(old_env)
 
 
-def get_mock_server_mode() -> str:
-    """Returns a str representing the mode.
-
-    :return: threading/multiprocessing
-    """
-    mode = os.environ.get("BOLT_PYTHON_MOCK_SERVER_MODE")
-    if mode is None:
-        # We used to use "multiprocessing"" for macOS until Big Sur 11.1
-        # Since 11.1, the "multiprocessing" mode started failing a lot...
-        # Therefore, we switched the default mode back to "threading".
-        return "threading"
-    else:
-        return mode
-
-
 def get_event_loop():
     try:
         return asyncio.get_event_loop()


### PR DESCRIPTION
This PR aims to remove the logic that implements the multiprocessing testing mode (in favor of the threading mode). This mode is no longer used in CI/CD or development.

This PR paves the path to implement similar changes brought to the slack-sdk in [#1445](https://github.com/slackapi/python-slack-sdk/pull/1445/files) that replaces the Flask-Sockets dependency with aiohttp

### Category

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
