### PR TITLE
Replace Flask-Sockets with aiohttp for testing 

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -25,7 +25,6 @@ jobs:
         run: |
           pip install -U pip
           pip install .
-          pip install -r requirements/async.txt
           pip install -r requirements/adapter.txt
           pip install -r requirements/testing.txt
           pip install -r requirements/adapter_testing.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           pip install -U pip
           pip install -r requirements.txt
-          pip install -r requirements/testing_without_asyncio
+          pip install -r requirements/testing_without_asyncio.txt
       - name: Run tests without aiohttp
         run: |
           pytest tests/slack_bolt/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           pip install -U pip
           pip install -r requirements.txt
-          pip install -r requirements/testing.txt
+          pip install -r requirements/testing_without_asyncio
       - name: Run tests without aiohttp
         run: |
           pytest tests/slack_bolt/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           pip install -U pip
           pip install -r requirements.txt
-          pip install -r requirements/testing_without_asyncio.txt
+          pip install -r requirements/testing.txt
       - name: Run tests without aiohttp
         run: |
           pytest tests/slack_bolt/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install synchronous dependencies
         run: |
           pip install -U pip
           pip install -r requirements.txt
@@ -28,11 +28,10 @@ jobs:
         run: |
           pytest tests/slack_bolt/
           pytest tests/scenario_tests/
-      - name: Run tests for Socket Mode adapters
+      - name: Install adapter dependencies
         run: |
           pip install -r requirements/adapter.txt
           pip install -r requirements/adapter_testing.txt
-          pytest tests/adapter_tests/socket_mode/
       - name: Run tests for HTTP Mode adapters (AWS)
         run: |
           pytest tests/adapter_tests/aws/
@@ -68,9 +67,15 @@ jobs:
       - name: Run tests for HTTP Mode adapters (Tornado)
         run: |
           pytest tests/adapter_tests/tornado/
-      - name: Run tests for HTTP Mode adapters (asyncio-based libraries)
+      - name: Install async dependencies
         run: |
           pip install -r requirements/async.txt
+      - name: Run tests for Socket Mode adapters
+        run: |
+          # Requires async test dependencies
+          pytest tests/adapter_tests/socket_mode/
+      - name: Run tests for HTTP Mode adapters (asyncio-based libraries)
+        run: |
           # Falcon supports Python 3.11 since its v3.1.1
           pip install "falcon>=3.1.1,<4"
           pytest tests/adapter_tests_async/

--- a/requirements/adapter_testing.txt
+++ b/requirements/adapter_testing.txt
@@ -1,6 +1,5 @@
 # pip install -r requirements/adapter_testing.txt
-moto>=3,<4                               # For AWS tests
+moto>=3,<5                               # For AWS tests
 docker>=5,<6                             # Used by moto
 boddle>=0.2,<0.3                         # For Bottle app tests
 sanic-testing>=0.7; python_version>"3.6"
-requests>=2,<3                           # For Starlette's TestClient

--- a/requirements/adapter_testing.txt
+++ b/requirements/adapter_testing.txt
@@ -2,7 +2,5 @@
 moto>=3,<4                               # For AWS tests
 docker>=5,<6                             # Used by moto
 boddle>=0.2,<0.3                         # For Bottle app tests
-Flask>=1,<2                              # TODO: Flask-Sockets is not yet compatible with Flask 2.x
-Werkzeug>=1,<2                           # TODO: Flask-Sockets is not yet compatible with Flask 2.x
 sanic-testing>=0.7; python_version>"3.6"
 requests>=2,<3                           # For Starlette's TestClient

--- a/requirements/async.txt
+++ b/requirements/async.txt
@@ -1,4 +1,3 @@
 # pip install -r requirements/async.txt
 aiohttp>=3,<4
-websockets>=8,<10; python_version=="3.6"
-websockets>=10,<11; python_version>"3.6"
+websockets<11

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,4 +1,4 @@
 # pip install -r requirements/testing.txt
 -r testing_without_asyncio.txt
-aiohttp<4
+-r async.txt
 pytest-asyncio<1;

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,7 +1,4 @@
 # pip install -r requirements/testing.txt
-pytest>=6.2.5,<7
-pytest-cov>=3,<5
+-r testing_without_asyncio.txt
 aiohttp<4
-black==22.8.0             # Until we drop Python 3.6 support, we have to stay with this version
-click<=8.0.4              # black is affected by https://github.com/pallets/click/issues/2225
 pytest-asyncio<1;

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,6 +1,8 @@
 # pip install -r requirements/testing.txt
--r testing_without_asyncio.txt
-
+pytest>=6.2.5,<7
+pytest-cov>=3,<4
+aiohttp<4
+black==22.8.0             # Until we drop Python 3.6 support, we have to stay with this version
+click<=8.0.4              # black is affected by https://github.com/pallets/click/issues/2225
 pytest-asyncio>=0.16.0; python_version=="3.6"
 pytest-asyncio>=0.18.2,<1; python_version>"3.6"
-aiohttp>=3,<4

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,8 +1,7 @@
 # pip install -r requirements/testing.txt
 pytest>=6.2.5,<7
-pytest-cov>=3,<4
+pytest-cov>=3,<5
 aiohttp<4
 black==22.8.0             # Until we drop Python 3.6 support, we have to stay with this version
 click<=8.0.4              # black is affected by https://github.com/pallets/click/issues/2225
-pytest-asyncio>=0.16.0; python_version=="3.6"
-pytest-asyncio>=0.18.2,<1; python_version>"3.6"
+pytest-asyncio<1;

--- a/requirements/testing_without_asyncio.txt
+++ b/requirements/testing_without_asyncio.txt
@@ -1,0 +1,5 @@
+# pip install -r requirements/testing_without_asyncio.txt
+pytest>=6.2.5,<7
+pytest-cov>=3,<5
+black==22.8.0             # Until we drop Python 3.6 support, we have to stay with this version
+click<=8.0.4              # black is affected by https://github.com/pallets/click/issues/2225

--- a/requirements/testing_without_asyncio.txt
+++ b/requirements/testing_without_asyncio.txt
@@ -1,9 +1,0 @@
-# pip install -r requirements/testing_without_asyncio.txt
-pytest>=6.2.5,<7
-pytest-cov>=3,<4
-Flask-Sockets>=0.2,<1     # TODO: This module is not yet Flask 2.x compatible
-Werkzeug>=1,<2            # TODO: Flask-Sockets is not yet compatible with Flask 2.x
-itsdangerous==2.0.1       # TODO: Flask-Sockets is not yet compatible with Flask 2.x
-Jinja2==3.0.3             # https://github.com/pallets/flask/issues/4494
-black==22.8.0             # Until we drop Python 3.6 support, we have to stay with this version
-click<=8.0.4              # black is affected by https://github.com/pallets/click/issues/2225

--- a/tests/adapter_tests_async/socket_mode/test_async_aiohttp.py
+++ b/tests/adapter_tests_async/socket_mode/test_async_aiohttp.py
@@ -12,7 +12,7 @@ from tests.mock_web_api_server import (
 from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 from ...adapter_tests.socket_mode.mock_socket_mode_server import (
     start_socket_mode_server,
-    stop_socket_mode_server_async,
+    stop_socket_mode_server,
 )
 
 
@@ -71,4 +71,4 @@ class TestSocketModeAiohttp:
             assert result["command"] is True
         finally:
             await handler.client.close()
-            await stop_socket_mode_server_async(self)
+            stop_socket_mode_server(self)

--- a/tests/adapter_tests_async/socket_mode/test_async_lazy_listeners.py
+++ b/tests/adapter_tests_async/socket_mode/test_async_lazy_listeners.py
@@ -12,7 +12,7 @@ from tests.mock_web_api_server import (
 from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 from ...adapter_tests.socket_mode.mock_socket_mode_server import (
     start_socket_mode_server,
-    stop_socket_mode_server_async,
+    stop_socket_mode_server,
 )
 
 
@@ -80,4 +80,4 @@ class TestSocketModeAiohttp:
 
         finally:
             await handler.client.close()
-            await stop_socket_mode_server_async(self)
+            stop_socket_mode_server(self)

--- a/tests/adapter_tests_async/socket_mode/test_async_websockets.py
+++ b/tests/adapter_tests_async/socket_mode/test_async_websockets.py
@@ -12,7 +12,7 @@ from tests.mock_web_api_server import (
 from tests.utils import remove_os_env_temporarily, restore_os_env, get_event_loop
 from ...adapter_tests.socket_mode.mock_socket_mode_server import (
     start_socket_mode_server,
-    stop_socket_mode_server_async,
+    stop_socket_mode_server,
 )
 
 
@@ -71,4 +71,4 @@ class TestSocketModeWebsockets:
             assert result["command"] is True
         finally:
             await handler.client.close()
-            await stop_socket_mode_server_async(self)
+            stop_socket_mode_server(self)


### PR DESCRIPTION
This PR bring the logic from [slack-sdk #1445](https://github.com/slackapi/python-slack-sdk/pull/1445) to bolt python

`Flask-Sockets` [is deprecated](https://github.com/heroku-python/flask-sockets/issues/85) and it won't receive any fixes in the future, so it seems reasonable to replace it with some up-to-date library.
`aiohttp` has been chosen since it was already presented as an optional requirement.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
