### PR TITLE
impr: Improve reliability of test

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          apt-get install libev-dev
+          sudo apt-get install -y libev-dev
           pip install -U pip
           pip install .
           pip install -r requirements/adapter.txt

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,6 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          apt-get install libev-dev
           pip install -U pip
           pip install .
           pip install -r requirements/async.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install synchronous dependencies
         run: |
-          apt-get install libev-dev
+          sudo apt-get install -y libev-dev
           pip install -U pip
           pip install -r requirements.txt
           pip install -r requirements/testing_without_asyncio.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          apt-get install libev-dev
           pip install -U pip
           pip install -r requirements.txt
           pip install -r requirements/testing_without_asyncio.txt

--- a/requirements/testing_without_asyncio.txt
+++ b/requirements/testing_without_asyncio.txt
@@ -7,3 +7,4 @@ itsdangerous==2.0.1       # TODO: Flask-Sockets is not yet compatible with Flask
 Jinja2==3.0.3             # https://github.com/pallets/flask/issues/4494
 black==22.8.0             # Until we drop Python 3.6 support, we have to stay with this version
 click<=8.0.4              # black is affected by https://github.com/pallets/click/issues/2225
+bjoern<4                  # this requires libev

--- a/tests/mock_web_api_server.py
+++ b/tests/mock_web_api_server.py
@@ -271,7 +271,7 @@ def cleanup_mock_web_api_server(test: TestCase):
 
 
 def assert_auth_test_count(test: TestCase, expected_count: int):
-    time.sleep(0.1)
+    # time.sleep(0.01)
     retry_count = 0
     error = None
     while retry_count < 3:
@@ -282,14 +282,14 @@ def assert_auth_test_count(test: TestCase, expected_count: int):
             error = e
             retry_count += 1
             # waiting for mock_received_requests updates
-            time.sleep(0.1)
+            # time.sleep(0.01)
 
     if error is not None:
         raise error
 
 
 async def assert_auth_test_count_async(test: TestCase, expected_count: int):
-    await asyncio.sleep(0.1)
+    # await asyncio.sleep(0.01)
     retry_count = 0
     error = None
     while retry_count < 3:
@@ -300,7 +300,7 @@ async def assert_auth_test_count_async(test: TestCase, expected_count: int):
             error = e
             retry_count += 1
             # waiting for mock_received_requests updates
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0.01)
 
     if error is not None:
         raise error

--- a/tests/mock_web_api_server.py
+++ b/tests/mock_web_api_server.py
@@ -14,12 +14,10 @@ from wsgiref.headers import Headers
 
 import bjoern
 
-INVALID_AUTH = json.dumps(
-    {
-        "ok": False,
-        "error": "invalid_auth",
-    }
-)
+INVALID_AUTH = {
+    "ok": False,
+    "error": "invalid_auth",
+}
 
 OAUTH_V2_ACCESS_RESPONSE = json.dumps(
     {

--- a/tests/mock_web_api_server.py
+++ b/tests/mock_web_api_server.py
@@ -525,7 +525,7 @@ def assert_auth_test_count(test: TestCase, expected_count: int):
     while retry_count < 3:
         try:
             received_requests = MockReceivedRequests()
-            received_requests["/auth.test"] == expected_count
+            received_requests.get("/auth.test", 0) == expected_count
             break
         except Exception as e:
             error = e
@@ -544,7 +544,7 @@ async def assert_auth_test_count_async(test: TestCase, expected_count: int):
     while retry_count < 3:
         try:
             received_requests = MockReceivedRequests()
-            received_requests["/auth.test"] == expected_count
+            received_requests.get("/auth.test", 0) == expected_count
             break
         except Exception as e:
             error = e

--- a/tests/mock_web_api_server.py
+++ b/tests/mock_web_api_server.py
@@ -1,31 +1,280 @@
 import asyncio
+from io import BytesIO
 import json
 import logging
 import threading
 import time
+from http.client import responses
 from http import HTTPStatus
 from http.server import HTTPServer, SimpleHTTPRequestHandler
-from typing import Type, Optional
+from typing import Callable, Dict, List, Tuple, Type, Optional
 from unittest import TestCase
+from urllib import request
+from urllib.error import URLError
 from urllib.parse import urlparse, parse_qs, ParseResult
+from urllib.request import urlopen
+from wsgiref.headers import Headers
+import bjoern
+from multiprocessing import Process
 
 
-class MockHandler(SimpleHTTPRequestHandler):
-    protocol_version = "HTTP/1.1"
-    default_request_version = "HTTP/1.1"
+# class MockHandler(SimpleHTTPRequestHandler):
+#     protocol_version = "HTTP/1.1"
+#     default_request_version = "HTTP/1.1"
+#     logger = logging.getLogger(__name__)
+#     received_requests = {}
+
+#     def is_valid_token(self):
+#         return "Authorization" in self.headers and str(self.headers["Authorization"]).startswith("Bearer xoxb-")
+
+#     def is_valid_user_token(self):
+#         return "Authorization" in self.headers and str(self.headers["Authorization"]).startswith("Bearer xoxp-")
+
+#     def set_common_headers(self):
+#         self.send_header("content-type", "application/json;charset=utf-8")
+#         self.send_header("connection", "close")
+#         self.end_headers()
+
+#     invalid_auth = {
+#         "ok": False,
+#         "error": "invalid_auth",
+#     }
+
+#     oauth_v2_access_response = """
+# {
+#     "ok": true,
+#     "access_token": "xoxb-17653672481-19874698323-pdFZKVeTuE8sk7oOcBrzbqgy",
+#     "token_type": "bot",
+#     "scope": "chat:write,commands",
+#     "bot_user_id": "U0KRQLJ9H",
+#     "app_id": "A0KRD7HC3",
+#     "team": {
+#         "name": "Slack Softball Team",
+#         "id": "T9TK3CUKW"
+#     },
+#     "enterprise": {
+#         "name": "slack-sports",
+#         "id": "E12345678"
+#     },
+#     "authed_user": {
+#         "id": "U1234",
+#         "scope": "chat:write",
+#         "access_token": "xoxp-1234",
+#         "token_type": "user"
+#     }
+# }
+# """
+#     oauth_v2_access_bot_refresh_response = """
+#     {
+#         "ok": true,
+#         "app_id": "A0KRD7HC3",
+#         "access_token": "xoxb-valid-refreshed",
+#         "expires_in": 43200,
+#         "refresh_token": "xoxe-1-valid-bot-refreshed",
+#         "token_type": "bot",
+#         "scope": "chat:write,commands",
+#         "bot_user_id": "U0KRQLJ9H",
+#         "team": {
+#             "name": "Slack Softball Team",
+#             "id": "T9TK3CUKW"
+#         },
+#         "enterprise": {
+#             "name": "slack-sports",
+#             "id": "E12345678"
+#         }
+#     }
+# """
+#     oauth_v2_access_user_refresh_response = """
+#         {
+#             "ok": true,
+#             "app_id": "A0KRD7HC3",
+#             "access_token": "xoxp-valid-refreshed",
+#             "expires_in": 43200,
+#             "refresh_token": "xoxe-1-valid-user-refreshed",
+#             "token_type": "user",
+#             "scope": "search:read",
+#             "team": {
+#                 "name": "Slack Softball Team",
+#                 "id": "T9TK3CUKW"
+#             },
+#             "enterprise": {
+#                 "name": "slack-sports",
+#                 "id": "E12345678"
+#             }
+#         }
+#     """
+#     bot_auth_test_response = """
+# {
+#     "ok": true,
+#     "url": "https://subarachnoid.slack.com/",
+#     "team": "Subarachnoid Workspace",
+#     "user": "bot",
+#     "team_id": "T0G9PQBBK",
+#     "user_id": "W23456789",
+#     "bot_id": "BZYBOTHED"
+# }
+# """
+
+#     user_auth_test_response = """
+# {
+#     "ok": true,
+#     "url": "https://subarachnoid.slack.com/",
+#     "team": "Subarachnoid Workspace",
+#     "user": "some-user",
+#     "team_id": "T0G9PQBBK",
+#     "user_id": "W99999"
+# }
+# """
+
+#     def _handle(self):
+#         parsed_path: ParseResult = urlparse(self.path)
+#         path = parsed_path.path
+#         self.received_requests[path] = self.received_requests.get(path, 0) + 1
+#         try:
+#             if path == "/webhook":
+#                 self.send_response(200)
+#                 self.set_common_headers()
+#                 self.wfile.write("OK".encode("utf-8"))
+#                 return
+
+#             if path == "/received_requests.json":
+#                 self.send_response(200)
+#                 self.set_common_headers()
+#                 self.wfile.write(json.dumps(self.received_requests).encode("utf-8"))
+#                 return
+
+#             body = {"ok": True}
+#             if path == "/oauth.v2.access":
+#                 if self.headers.get("authorization") is not None:
+#                     request_body = self._parse_request_body(
+#                         parsed_path=parsed_path,
+#                         content_len=int(self.headers.get("Content-Length") or 0),
+#                     )
+#                     self.logger.info(f"request body: {request_body}")
+
+#                     if request_body.get("grant_type") == "refresh_token":
+#                         refresh_token = request_body.get("refresh_token")
+#                         if refresh_token is not None:
+#                             if "bot-valid" in refresh_token:
+#                                 self.send_response(200)
+#                                 self.set_common_headers()
+#                                 body = self.oauth_v2_access_bot_refresh_response
+#                                 self.wfile.write(body.encode("utf-8"))
+#                                 return
+#                             if "user-valid" in refresh_token:
+#                                 self.send_response(200)
+#                                 self.set_common_headers()
+#                                 body = self.oauth_v2_access_user_refresh_response
+#                                 self.wfile.write(body.encode("utf-8"))
+#                                 return
+#                     elif request_body.get("code") is not None:
+#                         self.send_response(200)
+#                         self.set_common_headers()
+#                         self.wfile.write(self.oauth_v2_access_response.encode("utf-8"))
+#                         return
+
+#             if self.is_valid_user_token():
+#                 if path == "/auth.test":
+#                     self.send_response(200)
+#                     self.set_common_headers()
+#                     self.wfile.write(self.user_auth_test_response.encode("utf-8"))
+#                     return
+
+#             if self.is_valid_token():
+#                 if path == "/auth.test":
+#                     self.send_response(200)
+#                     self.set_common_headers()
+#                     self.wfile.write(self.bot_auth_test_response.encode("utf-8"))
+#                     return
+
+#                 request_body = self._parse_request_body(
+#                     parsed_path=parsed_path,
+#                     content_len=int(self.headers.get("Content-Length") or 0),
+#                 )
+#                 self.logger.info(f"request: {path} {request_body}")
+
+#                 header = self.headers["authorization"]
+#                 pattern = str(header).split("xoxb-", 1)[1]
+#                 if pattern.isnumeric():
+#                     self.send_response(int(pattern))
+#                     self.set_common_headers()
+#                     self.wfile.write("""{"ok":false}""".encode("utf-8"))
+#                     return
+#             else:
+#                 body = self.invalid_auth
+
+#             self.send_response(HTTPStatus.OK)
+#             self.set_common_headers()
+#             self.wfile.write(json.dumps(body).encode("utf-8"))
+#             self.wfile.close()
+
+#         except Exception as e:
+#             self.logger.error(str(e), exc_info=True)
+#             raise
+
+#     def do_GET(self):
+#         self._handle()
+
+#     def do_POST(self):
+#         self._handle()
+
+#     def _parse_request_body(self, parsed_path: str, content_len: int) -> Optional[dict]:
+#         post_body = self.rfile.read(content_len)
+#         request_body = None
+#         if post_body:
+#             try:
+#                 post_body = post_body.decode("utf-8")
+#                 if post_body.startswith("{"):
+#                     request_body = json.loads(post_body)
+#                 else:
+#                     request_body = {k: v[0] for k, v in parse_qs(post_body).items()}
+#             except UnicodeDecodeError:
+#                 pass
+#         else:
+#             if parsed_path and parsed_path.query:
+#                 request_body = {k: v[0] for k, v in parse_qs(parsed_path.query).items()}
+#         return request_body
+
+
+class FakeWSGIResponse:
+    def __init__(self, status: int, headers: List[Tuple[str, str]], body: str):
+        self.status = status
+        self.headers = headers
+        self.body = body
+
+    @property
+    def status_line(self) -> str:
+        return f"{str(self.status)} {responses[self.status]}"
+
+
+class WSGIEnviron:
+    def __init__(self, environ: dict):
+        self.environ = environ
+
+    def get_path(self) -> str:
+        return self.environ["PATH_INFO"]
+
+    def get_method(self) -> str:
+        return self.environ["REQUEST_METHOD"]
+
+    def get_content_length(self) -> int:
+        return int(self.environ.get("CONTENT_LENGTH", 0))
+
+    def get_header(self, header: str) -> str:
+        key = header.replace("-", "_").upper()
+        return self.environ[f"HTTP_{key}"]
+
+    def body(self) -> BytesIO:
+        try:
+            return self.environ["wsgi.input"]
+        except KeyError:
+            return BytesIO()
+
+
+class MockWSGIHandler:
     logger = logging.getLogger(__name__)
-    received_requests = {}
 
-    def is_valid_token(self):
-        return "Authorization" in self.headers and str(self.headers["Authorization"]).startswith("Bearer xoxb-")
-
-    def is_valid_user_token(self):
-        return "Authorization" in self.headers and str(self.headers["Authorization"]).startswith("Bearer xoxp-")
-
-    def set_common_headers(self):
-        self.send_header("content-type", "application/json;charset=utf-8")
-        self.send_header("connection", "close")
-        self.end_headers()
+    received_requests: Dict[str, int] = {}
 
     invalid_auth = {
         "ok": False,
@@ -118,100 +367,86 @@ class MockHandler(SimpleHTTPRequestHandler):
 }
 """
 
-    def _handle(self):
-        parsed_path: ParseResult = urlparse(self.path)
+    def is_valid_token(self, environ: WSGIEnviron):
+        try:
+            return environ.get_header("Authorization").startswith("Bearer xoxb-")
+        except KeyError:
+            return False
+
+    def is_valid_user_token(self, environ: WSGIEnviron):
+        try:
+            return environ.get_header("Authorization").startswith("Bearer xoxp-")
+        except KeyError:
+            return False
+
+    def _handle(self, environ: WSGIEnviron) -> FakeWSGIResponse:
+        parsed_path: ParseResult = urlparse(environ.get_path())
         path = parsed_path.path
         self.received_requests[path] = self.received_requests.get(path, 0) + 1
         try:
+            if path == "/health":
+                return FakeWSGIResponse(200, self.get_common_headers(), "OK")
+
             if path == "/webhook":
-                self.send_response(200)
-                self.set_common_headers()
-                self.wfile.write("OK".encode("utf-8"))
-                return
+                return FakeWSGIResponse(200, self.get_common_headers(), "OK")
 
             if path == "/received_requests.json":
-                self.send_response(200)
-                self.set_common_headers()
-                self.wfile.write(json.dumps(self.received_requests).encode("utf-8"))
-                return
+                return FakeWSGIResponse(200, self.get_common_headers(), json.dumps(self.received_requests))
 
             body = {"ok": True}
             if path == "/oauth.v2.access":
-                if self.headers.get("authorization") is not None:
+                if environ.get_header("authorization") is not None:
                     request_body = self._parse_request_body(
                         parsed_path=parsed_path,
-                        content_len=int(self.headers.get("Content-Length") or 0),
+                        body=environ.body(),
+                        content_len=environ.get_content_length(),
                     )
-                    self.logger.info(f"request body: {request_body}")
+                    # self.logger.info(f"request body: {request_body}")
 
                     if request_body.get("grant_type") == "refresh_token":
                         refresh_token = request_body.get("refresh_token")
                         if refresh_token is not None:
                             if "bot-valid" in refresh_token:
-                                self.send_response(200)
-                                self.set_common_headers()
-                                body = self.oauth_v2_access_bot_refresh_response
-                                self.wfile.write(body.encode("utf-8"))
-                                return
+                                return FakeWSGIResponse(
+                                    200, self.get_common_headers(), self.oauth_v2_access_bot_refresh_response
+                                )
                             if "user-valid" in refresh_token:
-                                self.send_response(200)
-                                self.set_common_headers()
-                                body = self.oauth_v2_access_user_refresh_response
-                                self.wfile.write(body.encode("utf-8"))
-                                return
+                                return FakeWSGIResponse(
+                                    200, self.get_common_headers(), self.oauth_v2_access_user_refresh_response
+                                )
                     elif request_body.get("code") is not None:
-                        self.send_response(200)
-                        self.set_common_headers()
-                        self.wfile.write(self.oauth_v2_access_response.encode("utf-8"))
-                        return
+                        return FakeWSGIResponse(200, self.get_common_headers(), self.oauth_v2_access_response)
 
-            if self.is_valid_user_token():
+            if self.is_valid_user_token(environ):
                 if path == "/auth.test":
-                    self.send_response(200)
-                    self.set_common_headers()
-                    self.wfile.write(self.user_auth_test_response.encode("utf-8"))
-                    return
+                    return FakeWSGIResponse(200, self.get_common_headers(), self.user_auth_test_response)
 
-            if self.is_valid_token():
+            if self.is_valid_token(environ):
                 if path == "/auth.test":
-                    self.send_response(200)
-                    self.set_common_headers()
-                    self.wfile.write(self.bot_auth_test_response.encode("utf-8"))
-                    return
+                    return FakeWSGIResponse(200, self.get_common_headers(), self.bot_auth_test_response)
 
                 request_body = self._parse_request_body(
                     parsed_path=parsed_path,
-                    content_len=int(self.headers.get("Content-Length") or 0),
+                    body=environ.body(),
+                    content_len=environ.get_content_length(),
                 )
                 self.logger.info(f"request: {path} {request_body}")
 
-                header = self.headers["authorization"]
+                header = environ.get_header("authorization")
                 pattern = str(header).split("xoxb-", 1)[1]
                 if pattern.isnumeric():
-                    self.send_response(int(pattern))
-                    self.set_common_headers()
-                    self.wfile.write("""{"ok":false}""".encode("utf-8"))
-                    return
+                    return FakeWSGIResponse(int(pattern), self.get_common_headers(), """{"ok":false}""")
             else:
                 body = self.invalid_auth
 
-            self.send_response(HTTPStatus.OK)
-            self.set_common_headers()
-            self.wfile.write(json.dumps(body).encode("utf-8"))
-            self.wfile.close()
+            return FakeWSGIResponse(200, self.get_common_headers(), json.dumps(body))
 
         except Exception as e:
             self.logger.error(str(e), exc_info=True)
             raise
 
-    def do_GET(self):
-        self._handle()
-
-    def do_POST(self):
-        self._handle()
-
-    def _parse_request_body(self, parsed_path: str, content_len: int) -> Optional[dict]:
-        post_body = self.rfile.read(content_len)
+    def _parse_request_body(self, parsed_path: str, body: BytesIO, content_len: int) -> Optional[dict]:
+        post_body = body.read(content_len)
         request_body = None
         if post_body:
             try:
@@ -227,42 +462,60 @@ class MockHandler(SimpleHTTPRequestHandler):
                 request_body = {k: v[0] for k, v in parse_qs(parsed_path.query).items()}
         return request_body
 
+    def get_common_headers(self, headers: List[Tuple[str, str]] = []) -> Headers:
+        headers.append(("content-type", "application/json;charset=utf-8"))
+        headers.append(("connection", "close"))
+        return headers
 
-class MockServerThread(threading.Thread):
-    def __init__(self, test: TestCase, handler: Type[SimpleHTTPRequestHandler] = MockHandler):
-        threading.Thread.__init__(self)
-        self.handler = handler
-        self.test = test
+    def __call__(self, environ: dict, start_response: Callable):
+        response = self._handle(WSGIEnviron(environ))
 
-    def run(self):
-        self.server = HTTPServer(("localhost", 8888), self.handler)
-        self.test.mock_received_requests = self.handler.received_requests
-        self.test.server_url = "http://localhost:8888"
-        self.test.host, self.test.port = self.server.socket.getsockname()
-        self.test.server_started.set()  # threading.Event()
+        start_response(response.status_line, response.headers)
+        return response.body.encode("utf-8")
 
-        self.test = None
-        try:
-            self.server.serve_forever(0.05)
-        finally:
-            self.server.server_close()
 
-    def stop(self):
-        self.handler.received_requests = {}
-        self.server.shutdown()
-        self.join()
+def start_fake_server_thread(test: TestCase, port: int):
+    test.handler = MockWSGIHandler()
+    test.socket = bjoern.listen(test.handler, "127.0.0.1", port)
+    test.host, test.port = test.socket.getsockname()
+
+    bjoern.run()
+
+
+class MockReceivedRequests:
+    def get(self, key, default=None):
+        url = "http://127.0.0.1:8888/received_requests.json"
+        r = urlopen(url)
+        data: dict = json.loads(r.read().decode(r.info().get_param("charset") or "utf-8"))
+        return data.get(key, default)
+
+    def __getitem__(self, item):
+        url = "http://127.0.0.1:8888/received_requests.json"
+        r = urlopen(url)
+        data = json.loads(r.read().decode(r.info().get_param("charset") or "utf-8"))
+        return data[item]
 
 
 def setup_mock_web_api_server(test: TestCase):
-    test.server_started = threading.Event()
-    test.thread = MockServerThread(test)
+    test.thread = Process(target=start_fake_server_thread, args=(test, 8888))
     test.thread.start()
-    test.server_started.wait()
+    test.thread.pid
+    test.mock_received_requests = MockReceivedRequests()
+    wait_for_socket_mode_server(8888, 5)
+
+
+def wait_for_socket_mode_server(port: int, timeout: int):
+    start_time = time.time()
+    while (time.time() - start_time) < timeout:
+        try:
+            urlopen(f"http://127.0.0.1:{port}/health")
+            return
+        except URLError:
+            time.sleep(0.01)
 
 
 def cleanup_mock_web_api_server(test: TestCase):
-    test.thread.stop()
-    test.thread = None
+    test.thread.kill()
 
 
 def assert_auth_test_count(test: TestCase, expected_count: int):
@@ -271,7 +524,8 @@ def assert_auth_test_count(test: TestCase, expected_count: int):
     error = None
     while retry_count < 3:
         try:
-            test.mock_received_requests.get("/auth.test", 0) == expected_count
+            received_requests = MockReceivedRequests()
+            received_requests["/auth.test"] == expected_count
             break
         except Exception as e:
             error = e
@@ -289,7 +543,8 @@ async def assert_auth_test_count_async(test: TestCase, expected_count: int):
     error = None
     while retry_count < 3:
         try:
-            test.mock_received_requests.get("/auth.test", 0) == expected_count
+            received_requests = MockReceivedRequests()
+            received_requests["/auth.test"] == expected_count
             break
         except Exception as e:
             error = e

--- a/tests/scenario_tests/test_app_actor_user_token.py
+++ b/tests/scenario_tests/test_app_actor_user_token.py
@@ -177,7 +177,7 @@ class TestApp:
         response = app.dispatch(self.build_request())
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_authorize_result_no_user_token(self):
@@ -215,5 +215,5 @@ class TestApp:
         response = app.dispatch(self.build_request(team_id="T111111"))
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1

--- a/tests/scenario_tests/test_app_bot_only.py
+++ b/tests/scenario_tests/test_app_bot_only.py
@@ -173,7 +173,7 @@ class TestApp:
         response = app.dispatch(self.build_app_mention_request())
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_installation_store_bot_only_false(self):
@@ -189,7 +189,7 @@ class TestApp:
         response = app.dispatch(self.build_app_mention_request())
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_installation_store_bot_only(self):
@@ -204,7 +204,7 @@ class TestApp:
         response = app.dispatch(self.build_app_mention_request())
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_installation_store_bot_only_oauth_settings(self):
@@ -218,7 +218,7 @@ class TestApp:
         response = app.dispatch(self.build_app_mention_request())
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_installation_store_bot_only_oauth_settings_conflicts(self):
@@ -233,7 +233,7 @@ class TestApp:
         response = app.dispatch(self.build_app_mention_request())
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_installation_store_bot_only_oauth_flow(self):
@@ -247,7 +247,7 @@ class TestApp:
         response = app.dispatch(self.build_app_mention_request())
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_installation_store_bot_only_oauth_flow_conflicts(self):
@@ -262,5 +262,5 @@ class TestApp:
         response = app.dispatch(self.build_app_mention_request())
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1

--- a/tests/scenario_tests/test_app_custom_authorize.py
+++ b/tests/scenario_tests/test_app_custom_authorize.py
@@ -210,7 +210,7 @@ class TestApp:
         response = app.dispatch(self.build_app_mention_request())
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_installation_store_and_authorize(self):
@@ -231,7 +231,7 @@ class TestApp:
         response = app.dispatch(self.build_app_mention_request())
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_installation_store_and_func_authorize(self):

--- a/tests/scenario_tests/test_app_installation_store.py
+++ b/tests/scenario_tests/test_app_installation_store.py
@@ -154,5 +154,5 @@ class TestApp:
         response = app.dispatch(self.build_app_mention_request())
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1

--- a/tests/scenario_tests/test_app_using_methods_in_class.py
+++ b/tests/scenario_tests/test_app_using_methods_in_class.py
@@ -115,7 +115,7 @@ class TestAppUsingMethodsInClass:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(0.5)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_class_methods(self):

--- a/tests/scenario_tests/test_events.py
+++ b/tests/scenario_tests/test_events.py
@@ -87,7 +87,7 @@ class TestEvents:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_middleware_skip(self):
@@ -143,7 +143,7 @@ class TestEvents:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_stable_auto_ack(self):
@@ -221,7 +221,7 @@ class TestEvents:
         response = app.dispatch(request)
         assert response.status == 200
 
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 2
 
     def test_member_join_left_events(self):
@@ -283,7 +283,7 @@ class TestEvents:
         response = app.dispatch(request)
         assert response.status == 200
 
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         # the listeners should not be executed
         assert self.mock_received_requests["/chat.postMessage"] == 2
 
@@ -335,7 +335,7 @@ class TestEvents:
         assert response.status == 200
 
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 2
 
     message_file_share_body = {
@@ -564,7 +564,7 @@ class TestEvents:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_additional_decorators_2(self):
@@ -583,7 +583,7 @@ class TestEvents:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
 

--- a/tests/scenario_tests/test_events_ignore_self.py
+++ b/tests/scenario_tests/test_events_ignore_self.py
@@ -38,7 +38,7 @@ class TestEventsIgnoreSelf:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         # The listener should not be executed
         assert self.mock_received_requests.get("/chat.postMessage") is None
 
@@ -53,7 +53,7 @@ class TestEventsIgnoreSelf:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         # The listener should not be executed
         assert self.mock_received_requests.get("/chat.postMessage") is None
 
@@ -68,7 +68,7 @@ class TestEventsIgnoreSelf:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests.get("/chat.postMessage") == 1
 
     def test_self_events_disabled(self):
@@ -85,7 +85,7 @@ class TestEventsIgnoreSelf:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         # The listener should be executed as the ignoring logic is disabled
         assert self.mock_received_requests.get("/chat.postMessage") == 1
 

--- a/tests/scenario_tests/test_events_org_apps.py
+++ b/tests/scenario_tests/test_events_org_apps.py
@@ -107,7 +107,7 @@ class TestEventsOrgApps:
         assert response.status == 200
         # auth.test API call must be skipped
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert result.called is True
 
     def test_team_access_revoked(self):
@@ -144,7 +144,7 @@ class TestEventsOrgApps:
         assert response.status == 200
         # auth.test API call must be skipped
         assert self.mock_received_requests.get("/auth.test") is None
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert result.called is True
 
     def test_app_home_opened(self):
@@ -194,7 +194,7 @@ class TestEventsOrgApps:
         assert response.status == 200
         # auth.test API call must be skipped
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert result.called is True
 
     def test_message(self):
@@ -250,5 +250,5 @@ class TestEventsOrgApps:
         assert response.status == 200
         # auth.test API call must be skipped
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert result.called is True

--- a/tests/scenario_tests/test_events_request_verification.py
+++ b/tests/scenario_tests/test_events_request_verification.py
@@ -57,7 +57,7 @@ class TestEventsRequestVerification:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests.get("/chat.postMessage") == 1
 
     def test_disabled(self):
@@ -78,7 +78,7 @@ class TestEventsRequestVerification:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests.get("/chat.postMessage") == 1
 
 

--- a/tests/scenario_tests/test_events_shared_channels.py
+++ b/tests/scenario_tests/test_events_shared_channels.py
@@ -108,7 +108,7 @@ class TestEventsSharedChannels:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_middleware_skip(self):
@@ -180,7 +180,7 @@ class TestEventsSharedChannels:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_stable_auto_ack(self):
@@ -250,7 +250,7 @@ class TestEventsSharedChannels:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         # The listener should not be executed
         assert self.mock_received_requests.get("/chat.postMessage") is None
 
@@ -333,7 +333,7 @@ class TestEventsSharedChannels:
         response = app.dispatch(request)
         assert response.status == 200
 
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 2
 
     def test_member_join_left_events(self):
@@ -415,7 +415,7 @@ class TestEventsSharedChannels:
         response = app.dispatch(request)
         assert response.status == 200
 
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         # the listeners should not be executed
         assert self.mock_received_requests["/chat.postMessage"] == 2
 
@@ -490,5 +490,5 @@ class TestEventsSharedChannels:
 
         # this should not be called when we have authorize
         assert self.mock_received_requests.get("/auth.test") is None
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 2

--- a/tests/scenario_tests/test_events_socket_mode.py
+++ b/tests/scenario_tests/test_events_socket_mode.py
@@ -72,7 +72,7 @@ class TestEventsSocketMode:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_middleware_skip(self):
@@ -126,7 +126,7 @@ class TestEventsSocketMode:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_stable_auto_ack(self):
@@ -175,7 +175,7 @@ class TestEventsSocketMode:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         # The listener should not be executed
         assert self.mock_received_requests.get("/chat.postMessage") is None
 
@@ -236,7 +236,7 @@ class TestEventsSocketMode:
         response = app.dispatch(request)
         assert response.status == 200
 
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 2
 
     def test_member_join_left_events(self):
@@ -296,7 +296,7 @@ class TestEventsSocketMode:
         response = app.dispatch(request)
         assert response.status == 200
 
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         # the listeners should not be executed
         assert self.mock_received_requests["/chat.postMessage"] == 2
 
@@ -346,5 +346,5 @@ class TestEventsSocketMode:
         assert response.status == 200
 
         assert_auth_test_count(self, 1)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 2

--- a/tests/scenario_tests/test_events_token_revocations.py
+++ b/tests/scenario_tests/test_events_token_revocations.py
@@ -40,7 +40,7 @@ class MyInstallationStore(InstallationStore):
         enterprise_id: Optional[str],
         team_id: Optional[str],
         user_id: Optional[str] = None,
-        is_enterprise_install: Optional[bool] = False,
+        is_enterprise_install: Optional[bool] = False
     ) -> Optional[Installation]:
         assert enterprise_id == "E111"
         assert team_id is None

--- a/tests/scenario_tests/test_events_token_revocations.py
+++ b/tests/scenario_tests/test_events_token_revocations.py
@@ -40,7 +40,7 @@ class MyInstallationStore(InstallationStore):
         enterprise_id: Optional[str],
         team_id: Optional[str],
         user_id: Optional[str] = None,
-        is_enterprise_install: Optional[bool] = False
+        is_enterprise_install: Optional[bool] = False,
     ) -> Optional[Installation]:
         assert enterprise_id == "E111"
         assert team_id is None
@@ -132,7 +132,7 @@ class TestEventsTokenRevocations:
 
         # auth.test API call must be skipped
         assert_auth_test_count(self, 0)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert app.installation_store.delete_bot_called is True
         assert app.installation_store.delete_installation_called is True
         assert app.installation_store.delete_all_called is False
@@ -165,7 +165,7 @@ class TestEventsTokenRevocations:
         assert response.status == 200
         # auth.test API call must be skipped
         assert_auth_test_count(self, 0)
-        sleep(1)  # wait a bit after auto ack()
+        sleep(0.2)  # wait a bit after auto ack()
         assert app.installation_store.delete_bot_called is True
         assert app.installation_store.delete_installation_called is True
         assert app.installation_store.delete_all_called is True

--- a/tests/scenario_tests/test_events_token_revocations.py
+++ b/tests/scenario_tests/test_events_token_revocations.py
@@ -40,7 +40,7 @@ class MyInstallationStore(InstallationStore):
         enterprise_id: Optional[str],
         team_id: Optional[str],
         user_id: Optional[str] = None,
-        is_enterprise_install: Optional[bool] = False
+        is_enterprise_install: Optional[bool] = False,
     ) -> Optional[Installation]:
         assert enterprise_id == "E111"
         assert team_id is None

--- a/tests/scenario_tests/test_lazy.py
+++ b/tests/scenario_tests/test_lazy.py
@@ -106,7 +106,7 @@ class TestErrorHandler:
         request = self.build_valid_request()
         response = app.dispatch(request)
         assert response.status == 200
-        time.sleep(1)  # wait a bit
+        time.sleep(0.9)  # wait a bit
         assert self.mock_received_requests["/chat.postMessage"] == 2
 
     def test_lazy_class(self):
@@ -134,7 +134,7 @@ class TestErrorHandler:
         request = self.build_valid_request()
         response = app.dispatch(request)
         assert response.status == 200
-        time.sleep(1)  # wait a bit
+        time.sleep(0.9)  # wait a bit
         assert self.mock_received_requests["/chat.postMessage"] == 2
 
     def test_issue_545_context_copy_failure(self):
@@ -204,5 +204,5 @@ class TestErrorHandler:
         request = self.build_valid_request()
         response = app.dispatch(request)
         assert response.status == 200
-        time.sleep(1)  # wait a bit
+        time.sleep(0.9)  # wait a bit
         assert self.mock_received_requests["/chat.postMessage"] == 2

--- a/tests/scenario_tests/test_message.py
+++ b/tests/scenario_tests/test_message.py
@@ -71,7 +71,7 @@ class TestMessage:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        time.sleep(1)  # wait a bit after auto ack()
+        time.sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_all_message_matching_1(self):
@@ -88,7 +88,7 @@ class TestMessage:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        time.sleep(1)  # wait a bit after auto ack()
+        time.sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_all_message_matching_2(self):
@@ -105,7 +105,7 @@ class TestMessage:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        time.sleep(1)  # wait a bit after auto ack()
+        time.sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_string_keyword_capturing(self):
@@ -119,7 +119,7 @@ class TestMessage:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        time.sleep(1)  # wait a bit after auto ack()
+        time.sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_string_keyword_capturing2(self):
@@ -133,7 +133,7 @@ class TestMessage:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        time.sleep(1)  # wait a bit after auto ack()
+        time.sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_string_keyword_capturing_multi_capture(self):
@@ -147,7 +147,7 @@ class TestMessage:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        time.sleep(1)  # wait a bit after auto ack()
+        time.sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_string_keyword_unmatched(self):
@@ -173,7 +173,7 @@ class TestMessage:
         response = app.dispatch(request)
         assert response.status == 200
         assert_auth_test_count(self, 1)
-        time.sleep(1)  # wait a bit after auto ack()
+        time.sleep(0.2)  # wait a bit after auto ack()
         assert self.mock_received_requests["/chat.postMessage"] == 1
 
     def test_regexp_keyword_unmatched(self):

--- a/tests/scenario_tests/test_message_bot.py
+++ b/tests/scenario_tests/test_message_bot.py
@@ -76,7 +76,7 @@ class TestBotMessage:
         assert response.status == 200
 
         assert_auth_test_count(self, 1)
-        time.sleep(1)  # wait a bit after auto ack()
+        time.sleep(0.2)  # wait a bit after auto ack()
         assert result["call_count"] == 3
 
 

--- a/tests/scenario_tests/test_message_file_share.py
+++ b/tests/scenario_tests/test_message_file_share.py
@@ -71,7 +71,7 @@ class TestMessageFileShare:
         assert response.status == 200
 
         assert_auth_test_count(self, 1)
-        time.sleep(1)  # wait a bit after auto ack()
+        time.sleep(0.2)  # wait a bit after auto ack()
         assert result["call_count"] == 2
 
 

--- a/tests/scenario_tests/test_message_thread_broadcast.py
+++ b/tests/scenario_tests/test_message_thread_broadcast.py
@@ -71,7 +71,7 @@ class TestMessageThreadBroadcast:
         assert response.status == 200
 
         assert_auth_test_count(self, 1)
-        time.sleep(1)  # wait a bit after auto ack()
+        time.sleep(0.2)  # wait a bit after auto ack()
         assert result["call_count"] == 2
 
 


### PR DESCRIPTION
This daft PR aims to improve the reliability of tests by replacing the `HTTPServer` and `SimpleHTTPRequestHandler` with [bjoern](https://github.com/jonashaag/bjoern) (a light weight C based WSGI web server) and a minimal implementation of a WSGI receiver

The goal is to reduce errors cause by `HTTPServer` not being fast enough to handle tests and ultimately speed up our unit tests.

This does come with some drawbacks, notably bjoern requires the C dependency [libev](https://github.com/jonashaag/bjoern/wiki/Installation) in order to run.

#### Feedback

- Is this something we want to add to this project?
- Are there other avenues we may want to look into?

NOTE: this is a prototype and some work is still required

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
