### PR TITLE
Fix #1074 Customize user-facing message sent when an installation is not managed by bolt-python app

### DIFF
--- a/scripts/install_all_and_run_tests.sh
+++ b/scripts/install_all_and_run_tests.sh
@@ -14,24 +14,24 @@ python_version=`python --version | awk '{print $2}'`
 
 if [ ${python_version:0:3} == "3.6" ]
 then
-  pip install -r requirements.txt
+  pip install -U -r requirements.txt
 else
   pip install -e .
 fi
 
 if [[ $test_target != "" ]]
 then
-    pip install -r requirements/testing.txt && \
-    pip install -r requirements/adapter.txt && \
-    pip install -r requirements/adapter_testing.txt && \
+    pip install -U -r requirements/testing.txt && \
+    pip install -U -r requirements/adapter.txt && \
+    pip install -U -r requirements/adapter_testing.txt && \
     # To avoid errors due to the old versions of click forced by Chalice
     pip install -U pip click && \
     black slack_bolt/ tests/ && \
     pytest $1
 else
-    pip install -r requirements/testing.txt && \
-    pip install -r requirements/adapter.txt && \
-    pip install -r requirements/adapter_testing.txt && \
+    pip install -U -r requirements/testing.txt && \
+    pip install -U -r requirements/adapter.txt && \
+    pip install -U -r requirements/adapter_testing.txt && \
     # To avoid errors due to the old versions of click forced by Chalice
     pip install -U pip click && \
     black slack_bolt/ tests/ && \

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -114,6 +114,7 @@ class AsyncApp:
         # for multi-workspace apps
         before_authorize: Optional[Union[AsyncMiddleware, Callable[..., Awaitable[Any]]]] = None,
         authorize: Optional[Callable[..., Awaitable[AuthorizeResult]]] = None,
+        user_facing_authorize_error_message: Optional[str] = None,
         installation_store: Optional[AsyncInstallationStore] = None,
         # for either only bot scope usage or v1.0.x compatibility
         installation_store_bot_only: Optional[bool] = None,
@@ -167,6 +168,8 @@ class AsyncApp:
             before_authorize: A global middleware that can be executed right before authorize function
             authorize: The function to authorize an incoming request from Slack
                 by checking if there is a team/user in the installation data.
+            user_facing_authorize_error_message: The user-facing error message to display
+                when the app is installed but the installation is not managed by this app's installation store
             installation_store: The module offering save/find operations of installation data
             installation_store_bot_only: Use `AsyncInstallationStore#async_find_bot()` if True (Default: False)
             request_verification_enabled: False if you would like to disable the built-in middleware (Default: True).
@@ -354,6 +357,7 @@ class AsyncApp:
             ignoring_self_events_enabled=ignoring_self_events_enabled,
             ssl_check_enabled=ssl_check_enabled,
             url_verification_enabled=url_verification_enabled,
+            user_facing_authorize_error_message=user_facing_authorize_error_message,
         )
 
         self._server: Optional[AsyncSlackAppServer] = None
@@ -364,6 +368,7 @@ class AsyncApp:
         ignoring_self_events_enabled: bool = True,
         ssl_check_enabled: bool = True,
         url_verification_enabled: bool = True,
+        user_facing_authorize_error_message: Optional[str] = None,
     ):
         if self._init_middleware_list_done:
             return
@@ -383,10 +388,19 @@ class AsyncApp:
         # As authorize is required for making a Bolt app function, we don't offer the flag to disable this
         if self._async_oauth_flow is None:
             if self._token:
-                self._async_middleware_list.append(AsyncSingleTeamAuthorization(base_logger=self._base_logger))
+                self._async_middleware_list.append(
+                    AsyncSingleTeamAuthorization(
+                        base_logger=self._base_logger,
+                        user_facing_authorize_error_message=user_facing_authorize_error_message,
+                    )
+                )
             elif self._async_authorize is not None:
                 self._async_middleware_list.append(
-                    AsyncMultiTeamsAuthorization(authorize=self._async_authorize, base_logger=self._base_logger)
+                    AsyncMultiTeamsAuthorization(
+                        authorize=self._async_authorize,
+                        base_logger=self._base_logger,
+                        user_facing_authorize_error_message=user_facing_authorize_error_message,
+                    )
                 )
             else:
                 raise BoltError(error_token_required())
@@ -396,6 +410,7 @@ class AsyncApp:
                     authorize=self._async_authorize,
                     base_logger=self._base_logger,
                     user_token_resolution=self._async_oauth_flow.settings.user_token_resolution,
+                    user_facing_authorize_error_message=user_facing_authorize_error_message,
                 )
             )
 

--- a/slack_bolt/middleware/authorization/async_internals.py
+++ b/slack_bolt/middleware/authorization/async_internals.py
@@ -1,4 +1,3 @@
-from slack_bolt.middleware.authorization.internals import _build_error_text
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 
@@ -15,9 +14,9 @@ def _is_no_auth_required(req: AsyncBoltRequest) -> bool:
     return _is_url_verification(req) or _is_ssl_check(req)
 
 
-def _build_error_response() -> BoltResponse:
+def _build_user_facing_error_response(message: str) -> BoltResponse:
     # show an ephemeral message to the end-user
     return BoltResponse(
         status=200,
-        body=_build_error_text(),
+        body=message,
     )

--- a/slack_bolt/middleware/authorization/internals.py
+++ b/slack_bolt/middleware/authorization/internals.py
@@ -43,18 +43,18 @@ def _is_no_auth_test_call_required(req: Union[BoltRequest, "AsyncBoltRequest"]) 
     return _is_no_auth_test_events(req)
 
 
-def _build_error_text() -> str:
+def _build_user_facing_authorize_error_message() -> str:
     return (
         ":warning: We apologize, but for some unknown reason, your installation with this app is no longer available. "
         "Please reinstall this app into your workspace :bow:"
     )
 
 
-def _build_error_response() -> BoltResponse:
+def _build_user_facing_error_response(message: str) -> BoltResponse:
     # show an ephemeral message to the end-user
     return BoltResponse(
         status=200,
-        body=_build_error_text(),
+        body=message,
     )
 
 

--- a/tests/slack_bolt/middleware/authorization/test_single_team_authorization.py
+++ b/tests/slack_bolt/middleware/authorization/test_single_team_authorization.py
@@ -1,7 +1,7 @@
 from slack_sdk import WebClient
 
 from slack_bolt.middleware import SingleTeamAuthorization
-from slack_bolt.middleware.authorization.internals import _build_error_text
+from slack_bolt.middleware.authorization.internals import _build_user_facing_authorize_error_message
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 from tests.mock_web_api_server import (
@@ -43,4 +43,15 @@ class TestSingleTeamAuthorization:
         resp = authorization.process(req=req, resp=resp, next=next)
 
         assert resp.status == 200
-        assert resp.body == _build_error_text()
+        assert resp.body == _build_user_facing_authorize_error_message()
+
+    def test_failure_pattern_custom_message(self):
+        authorization = SingleTeamAuthorization(auth_test_result={}, user_facing_authorize_error_message="foo")
+        req = BoltRequest(body="payload={}", headers={})
+        req.context["client"] = WebClient(base_url=self.mock_api_server_base_url, token="dummy")
+        resp = BoltResponse(status=404)
+
+        resp = authorization.process(req=req, resp=resp, next=next)
+
+        assert resp.status == 200
+        assert resp.body == "foo"


### PR DESCRIPTION
This pull request resolves #1074 

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
