### PR TITLE
feat: Add deprecation warnings to Steps from Apps components and Docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -43,7 +43,7 @@ t:
     start: Bolt 入門ガイド
     contribute: 貢献
     beta: BETA
-    deprecated: 使用されていない
+    deprecated: 非推奨
 
 # Metadata
 repo_name: bolt-python

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,7 +35,7 @@ t:
     start: Getting started
     contribute: Contributing
     beta: BETA
-    legacy: LEGACY
+    deprecated: Deprecated
   ja-jp:
     basic: 基本的な概念
     steps: ワークフローステップ
@@ -43,7 +43,7 @@ t:
     start: Bolt 入門ガイド
     contribute: 貢献
     beta: BETA
-    legacy: LEGACY
+    deprecated: 使用されていない
 
 # Metadata
 repo_name: bolt-python

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -56,8 +56,8 @@
   <ul class="sidebar-section">
     <a href="{{ site.url | append: site.baseurl | append: localized_base_url }}/concepts#steps">
       <li class="title">
-        {{ site.t[page.lang].steps }} 
-        <!-- UNCOMMENT AFTER GA <span class="label-legacy">{{ site.t[page.lang].legacy }}</span> -->
+        {{ site.t[page.lang].steps }}
+        <span class="label-deprecated">{{ site.t[page.lang].deprecated }}</span>
       </li>
     </a>
     {% assign workflow_steps = site.steps | sort: "order" | where: "lang", page.lang %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -49,8 +49,8 @@ sidebar_style: main
         workflow_steps %}
         <div class="section-wrapper">
           <h3 id="{{section.slug}}">
-            {{ section.title }} 
-            <!-- UNCOMMENT AFTER GA <span class="label-legacy">{{ site.t[page.lang].legacy }}</span> -->
+            {{ section.title }}
+            <span class="label-deprecated">{{ site.t[page.lang].deprecated }}</span>
           </h3>
           {{ section.content | markdownify }}
           <hr />

--- a/docs/_steps/workflow_steps_overview.md
+++ b/docs/_steps/workflow_steps_overview.md
@@ -6,9 +6,12 @@ order: 1
 ---
 
 <div class="section-content">
+
+Steps from Apps for legacy workflows are now deprecated. Use new [custom steps](https://api.slack.com/automation/functions/custom-bol).
+
 Workflow Steps from apps allow your app to create and process custom workflow steps that users can add using [Workflow Builder](https://api.slack.com/workflows).
 
-A workflow step is made up of three distinct user events: 
+A workflow step is made up of three distinct user events:
 
 - Adding or editing the step in a Workflow
 - Saving or updating the step's configuration

--- a/docs/_steps/workflow_steps_overview.md
+++ b/docs/_steps/workflow_steps_overview.md
@@ -7,7 +7,7 @@ order: 1
 
 <div class="section-content">
 
-Steps from Apps for legacy workflows are now deprecated. Use new [custom steps](https://api.slack.com/automation/functions/custom-bol).
+Steps from Apps for legacy workflows are now deprecated. Use new [custom steps](https://api.slack.com/automation/functions/custom-bolt).
 
 Workflow Steps from apps allow your app to create and process custom workflow steps that users can add using [Workflow Builder](https://api.slack.com/workflows).
 

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -117,7 +117,7 @@ span.beta {
   font-weight: 600;
 }
 
-.panel .sidebar-content ul.sidebar-section .label-legacy {
+.panel .sidebar-content ul.sidebar-section .label-deprecated {
   line-height: 1em;
   vertical-align: middle;
   color: var(--white);
@@ -321,7 +321,7 @@ td.rouge-gutter {
   width: 100%;
 }
 
-.content .section-wrapper .label-legacy {
+.content .section-wrapper .label-deprecated {
   line-height: 1em;
   vertical-align: middle;
   color: var(--white);

--- a/examples/workflow_steps/async_steps_from_apps.py
+++ b/examples/workflow_steps/async_steps_from_apps.py
@@ -9,6 +9,11 @@ from slack_bolt.workflows.step.async_step import (
     AsyncFail,
 )
 
+################################################################################
+# Steps from Apps for legacy workflows are now deprecated.                     #
+# Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
+################################################################################
+
 logging.basicConfig(level=logging.DEBUG)
 
 # export SLACK_SIGNING_SECRET=***

--- a/examples/workflow_steps/async_steps_from_apps_decorator.py
+++ b/examples/workflow_steps/async_steps_from_apps_decorator.py
@@ -11,6 +11,11 @@ from slack_bolt.workflows.step.async_step import (
     AsyncWorkflowStep,
 )
 
+################################################################################
+# Steps from Apps for legacy workflows are now deprecated.                     #
+# Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
+################################################################################
+
 logging.basicConfig(level=logging.DEBUG)
 
 # export SLACK_SIGNING_SECRET=***

--- a/examples/workflow_steps/async_steps_from_apps_primitive.py
+++ b/examples/workflow_steps/async_steps_from_apps_primitive.py
@@ -3,6 +3,11 @@ import logging
 from slack_sdk.web.async_client import AsyncSlackResponse, AsyncWebClient
 from slack_bolt.async_app import AsyncApp, AsyncAck
 
+################################################################################
+# Steps from Apps for legacy workflows are now deprecated.                     #
+# Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
+################################################################################
+
 logging.basicConfig(level=logging.DEBUG)
 
 # export SLACK_SIGNING_SECRET=***

--- a/examples/workflow_steps/steps_from_apps.py
+++ b/examples/workflow_steps/steps_from_apps.py
@@ -6,6 +6,11 @@ from slack_sdk.web import SlackResponse
 from slack_bolt import App, Ack
 from slack_bolt.workflows.step import Configure, Update, Complete, Fail
 
+################################################################################
+# Steps from Apps for legacy workflows are now deprecated.                     #
+# Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
+################################################################################
+
 logging.basicConfig(level=logging.DEBUG)
 
 # export SLACK_SIGNING_SECRET=***

--- a/examples/workflow_steps/steps_from_apps_decorator.py
+++ b/examples/workflow_steps/steps_from_apps_decorator.py
@@ -7,6 +7,11 @@ from slack_sdk.web import SlackResponse
 from slack_bolt import App, Ack
 from slack_bolt.workflows.step import Configure, Update, Complete, Fail, WorkflowStep
 
+################################################################################
+# Steps from Apps for legacy workflows are now deprecated.                     #
+# Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
+################################################################################
+
 logging.basicConfig(level=logging.DEBUG)
 
 # export SLACK_SIGNING_SECRET=***

--- a/examples/workflow_steps/steps_from_apps_primitive.py
+++ b/examples/workflow_steps/steps_from_apps_primitive.py
@@ -5,6 +5,11 @@ from slack_sdk.web import SlackResponse
 
 from slack_bolt import App, Ack
 
+################################################################################
+# Steps from Apps for legacy workflows are now deprecated.                     #
+# Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
+################################################################################
+
 logging.basicConfig(level=logging.DEBUG)
 
 # export SLACK_SIGNING_SECRET=***

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import time
+import warnings
 from concurrent.futures import Executor
 from concurrent.futures.thread import ThreadPoolExecutor
 from http.server import SimpleHTTPRequestHandler, HTTPServer
@@ -659,7 +660,13 @@ class App:
         save: Optional[Union[Callable[..., Optional[BoltResponse]], Listener, Sequence[Callable]]] = None,
         execute: Optional[Union[Callable[..., Optional[BoltResponse]], Listener, Sequence[Callable]]] = None,
     ):
-        """Registers a new Workflow Step listener.
+        """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+
+        Registers a new Workflow Step listener.
+
         Unlike others, this method doesn't behave as a decorator.
         If you want to register a workflow step by a decorator, use `WorkflowStepBuilder`'s methods.
 
@@ -688,6 +695,11 @@ class App:
             save: The function for handling configuration in the Workflow Builder
             execute: The function for handling the step execution
         """
+        warnings.warn(
+            ("Steps from Apps for legacy workflows are now deprecated. "
+             "Use new custom steps: https://api.slack.com/automation/functions/custom-bolt"),
+            category=DeprecationWarning,
+        )
         step = callback_id
         if isinstance(callback_id, (str, Pattern)):
             step = WorkflowStep(

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -696,8 +696,10 @@ class App:
             execute: The function for handling the step execution
         """
         warnings.warn(
-            ("Steps from Apps for legacy workflows are now deprecated. "
-             "Use new custom steps: https://api.slack.com/automation/functions/custom-bolt"),
+            (
+                "Steps from Apps for legacy workflows are now deprecated. "
+                "Use new custom steps: https://api.slack.com/automation/functions/custom-bolt"
+            ),
             category=DeprecationWarning,
         )
         step = callback_id

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -724,8 +724,10 @@ class AsyncApp:
             execute: The function for handling the step execution
         """
         warnings.warn(
-            ("Steps from Apps for legacy workflows are now deprecated. "
-             "Use new custom steps: https://api.slack.com/automation/functions/custom-bolt"),
+            (
+                "Steps from Apps for legacy workflows are now deprecated. "
+                "Use new custom steps: https://api.slack.com/automation/functions/custom-bolt"
+            ),
             category=DeprecationWarning,
         )
         step = callback_id

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -3,6 +3,7 @@ import logging
 import os
 import time
 from typing import Optional, List, Union, Callable, Pattern, Dict, Awaitable, Sequence, Any
+import warnings
 
 from aiohttp import web
 
@@ -689,7 +690,12 @@ class AsyncApp:
         execute: Optional[Union[Callable[..., Optional[BoltResponse]], AsyncListener, Sequence[Callable]]] = None,
     ):
         """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+
         Registers a new Workflow Step listener.
+
         Unlike others, this method doesn't behave as a decorator.
         If you want to register a workflow step by a decorator, use `AsyncWorkflowStepBuilder`'s methods.
 
@@ -717,6 +723,11 @@ class AsyncApp:
             save: The function for handling configuration in the Workflow Builder
             execute: The function for handling the step execution
         """
+        warnings.warn(
+            ("Steps from Apps for legacy workflows are now deprecated. "
+             "Use new custom steps: https://api.slack.com/automation/functions/custom-bolt"),
+            category=DeprecationWarning,
+        )
         step = callback_id
         if isinstance(callback_id, (str, Pattern)):
             step = AsyncWorkflowStep(

--- a/slack_bolt/workflows/step/async_step.py
+++ b/slack_bolt/workflows/step/async_step.py
@@ -43,7 +43,12 @@ class AsyncWorkflowStepBuilder:
         app_name: Optional[str] = None,
         base_logger: Optional[Logger] = None,
     ):
-        """This builder is supposed to be used as decorator.
+        """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+
+        This builder is supposed to be used as decorator.
 
             my_step = AsyncWorkflowStep.builder("my_step")
             @my_step.edit
@@ -80,7 +85,13 @@ class AsyncWorkflowStepBuilder:
         middleware: Optional[Union[Callable, AsyncMiddleware]] = None,
         lazy: Optional[List[Callable[..., Awaitable[None]]]] = None,
     ):
-        """Registers a new edit listener with details.
+        """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+
+        Registers a new edit listener with details.
+
         You can use this method as decorator as well.
 
             @my_step.edit
@@ -127,7 +138,13 @@ class AsyncWorkflowStepBuilder:
         middleware: Optional[Union[Callable, AsyncMiddleware]] = None,
         lazy: Optional[List[Callable[..., Awaitable[None]]]] = None,
     ):
-        """Registers a new save listener with details.
+        """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+
+        Registers a new save listener with details.
+
         You can use this method as decorator as well.
 
             @my_step.save
@@ -174,7 +191,13 @@ class AsyncWorkflowStepBuilder:
         middleware: Optional[Union[Callable, AsyncMiddleware]] = None,
         lazy: Optional[List[Callable[..., Awaitable[None]]]] = None,
     ):
-        """Registers a new execute listener with details.
+        """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+
+        Registers a new execute listener with details.
+
         You can use this method as decorator as well.
 
             @my_step.execute
@@ -215,7 +238,12 @@ class AsyncWorkflowStepBuilder:
         return _inner
 
     def build(self, base_logger: Optional[Logger] = None) -> "AsyncWorkflowStep":
-        """Constructs a WorkflowStep object. This method may raise an exception
+        """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+
+        Constructs a WorkflowStep object. This method may raise an exception
         if the builder doesn't have enough configurations to build the object.
 
         Returns:
@@ -309,6 +337,10 @@ class AsyncWorkflowStep:
         base_logger: Optional[Logger] = None,
     ):
         """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+
         Args:
             callback_id: The callback_id for this workflow step
             edit: Either a single function or a list of functions for opening a modal in the builder UI
@@ -350,6 +382,11 @@ class AsyncWorkflowStep:
         callback_id: Union[str, Pattern],
         base_logger: Optional[Logger] = None,
     ) -> AsyncWorkflowStepBuilder:
+        """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        """
         return AsyncWorkflowStepBuilder(callback_id, base_logger=base_logger)
 
     @classmethod

--- a/slack_bolt/workflows/step/step.py
+++ b/slack_bolt/workflows/step/step.py
@@ -38,7 +38,12 @@ class WorkflowStepBuilder:
         app_name: Optional[str] = None,
         base_logger: Optional[Logger] = None,
     ):
-        """This builder is supposed to be used as decorator.
+        """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+
+        This builder is supposed to be used as decorator.
 
             my_step = WorkflowStep.builder("my_step")
             @my_step.edit
@@ -75,7 +80,13 @@ class WorkflowStepBuilder:
         middleware: Optional[Union[Callable, Middleware]] = None,
         lazy: Optional[List[Callable[..., None]]] = None,
     ):
-        """Registers a new edit listener with details.
+        """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+
+        Registers a new edit listener with details.
+
         You can use this method as decorator as well.
 
             @my_step.edit
@@ -123,7 +134,13 @@ class WorkflowStepBuilder:
         middleware: Optional[Union[Callable, Middleware]] = None,
         lazy: Optional[List[Callable[..., None]]] = None,
     ):
-        """Registers a new save listener with details.
+        """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+
+        Registers a new save listener with details.
+
         You can use this method as decorator as well.
 
             @my_step.save
@@ -170,7 +187,13 @@ class WorkflowStepBuilder:
         middleware: Optional[Union[Callable, Middleware]] = None,
         lazy: Optional[List[Callable[..., None]]] = None,
     ):
-        """Registers a new execute listener with details.
+        """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+
+        Registers a new execute listener with details.
+
         You can use this method as decorator as well.
 
             @my_step.execute
@@ -211,7 +234,12 @@ class WorkflowStepBuilder:
         return _inner
 
     def build(self, base_logger: Optional[Logger] = None) -> "WorkflowStep":
-        """Constructs a WorkflowStep object. This method may raise an exception
+        """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+
+        Constructs a WorkflowStep object. This method may raise an exception
         if the builder doesn't have enough configurations to build the object.
 
         Returns:
@@ -320,6 +348,10 @@ class WorkflowStep:
         base_logger: Optional[Logger] = None,
     ):
         """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+
         Args:
             callback_id: The callback_id for this workflow step
             edit: Either a single function or a list of functions for opening a modal in the builder UI
@@ -357,6 +389,11 @@ class WorkflowStep:
 
     @classmethod
     def builder(cls, callback_id: Union[str, Pattern], base_logger: Optional[Logger] = None) -> WorkflowStepBuilder:
+        """
+        Deprecated:
+            Steps from Apps for legacy workflows are now deprecated.
+            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        """
         return WorkflowStepBuilder(
             callback_id,
             base_logger=base_logger,


### PR DESCRIPTION
This PR aims to inform developers that steps from apps are deprecated
- Add a deprecation notice in the `docstring` of steps from apps components 
- Adds a runtime deprecation warning displayed whenever the step handler is invoked
- Adds deprecation notice in the `examples`
- Adds a deprecation notice to the `slack.dev`

| Before | After |
|---|---|
| <img width="2560" alt="Screenshot 2024-06-06 at 12 51 36 PM" src="https://github.com/slackapi/bolt-python/assets/25348381/e766427b-a131-4eab-848c-f0d0624f891c"> | <img width="2558" alt="Screenshot 2024-06-06 at 12 51 04 PM" src="https://github.com/slackapi/bolt-python/assets/25348381/78d3d0df-6daf-4065-8ef8-bd648781ad7a"> |

### Category

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
