### PR TITLE
chore: align README pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
-# Bolt ![Bolt logo](docs/assets/bolt-logo.svg) for Python
+<h1 align="center">Bolt <img src="https://raw.githubusercontent.com/slackapi/bolt-python/main/docs/assets/bolt-logo.svg" alt="Bolt logo"/> for Python</h1>
 
-[![Python Version][python-version]][pypi-url]
-[![pypi package][pypi-image]][pypi-url]
-[![Codecov][codecov-image]][codecov-url]
+<p align="center">
+    <a href="https://pypi.org/project/slack-bolt/">
+        <img alt="PyPI - Version" src="https://img.shields.io/pypi/v/slack-bolt"></a>
+    <a href="https://codecov.io/gh/slackapi/bolt-python">
+        <img alt="Codecov" src="https://img.shields.io/codecov/c/gh/slackapi/bolt-python"></a>
+    <a href="https://pepy.tech/project/slack-bolt">
+        <img alt="Pepy Total Downloads" src="https://img.shields.io/pepy/dt/slack-bolt"></a>
+    <br>
+    <a href="https://pypi.org/project/slack-bolt/">
+        <img alt="Python Versions" src="https://img.shields.io/pypi/pyversions/slack-bolt.svg"></a>
+    <a href="https://slack.dev/bolt-python/">
+        <img alt="Documentation" src="https://img.shields.io/badge/dev-docs-yellow"></a>
+</p>
 
 A Python framework to build Slack apps in a flash with the latest platform features. Read the [getting started guide](https://slack.dev/bolt-python/tutorial/getting-started) and look at our [code examples](https://github.com/slackapi/bolt-python/tree/main/examples) to learn how to build apps using Bolt. The Python module documents are available [here](https://slack.dev/bolt-python/api-docs/slack_bolt/).
 


### PR DESCRIPTION
This PR updates the readme to follow the same pattern found in `bolt`, the `sdk` and the `hooks` projects

[Preview](https://github.com/WilliamBergamin/bolt-python/blob/update-readme/README.md)

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
