### PR TITLE
Fix #1099 by locking pytype version

### DIFF
--- a/scripts/install_all_and_run_tests.sh
+++ b/scripts/install_all_and_run_tests.sh
@@ -36,6 +36,6 @@ else
     pip install -U pip click && \
     black slack_bolt/ tests/ && \
     pytest && \
-    pip install -U pytype && \
+    pip install "pytype==2022.12.15" && \
     pytype slack_bolt/
 fi


### PR DESCRIPTION
This pull request resolves #1099 -- pytype outputs can be different in newer versions, therefore we should lock its version for stable execution.

Thanks @srtaalej for reporting it!

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
