### PR TITLE
Add bot|user_scopes to context.authorize_result set by SingleTeamAuthorization

### DIFF
--- a/slack_bolt/middleware/authorization/internals.py
+++ b/slack_bolt/middleware/authorization/internals.py
@@ -76,4 +76,6 @@ def _to_authorize_result(  # type: ignore
         bot_token=token if _is_bot_token(token) else None,
         user_id=request_user_id or (user_id if not _is_bot_token(token) else None),
         user_token=token if not _is_bot_token(token) else None,
+        bot_scopes=auth_test_result.headers.get("x-oauth-scopes", []) if _is_bot_token(token) else None,
+        user_scopes=None if _is_bot_token(token) else auth_test_result.headers.get("x-oauth-scopes", []),
     )

--- a/slack_bolt/middleware/authorization/internals.py
+++ b/slack_bolt/middleware/authorization/internals.py
@@ -68,6 +68,7 @@ def _to_authorize_result(  # type: ignore
     request_user_id: Optional[str],
 ) -> AuthorizeResult:
     user_id = auth_test_result.get("user_id")
+    oauth_scopes: Optional[str] = auth_test_result.headers.get("x-oauth-scopes")
     return AuthorizeResult(
         enterprise_id=auth_test_result.get("enterprise_id"),
         team_id=auth_test_result.get("team_id"),
@@ -76,6 +77,6 @@ def _to_authorize_result(  # type: ignore
         bot_token=token if _is_bot_token(token) else None,
         user_id=request_user_id or (user_id if not _is_bot_token(token) else None),
         user_token=token if not _is_bot_token(token) else None,
-        bot_scopes=auth_test_result.headers.get("x-oauth-scopes", []) if _is_bot_token(token) else None,
-        user_scopes=None if _is_bot_token(token) else auth_test_result.headers.get("x-oauth-scopes", []),
+        bot_scopes=oauth_scopes if _is_bot_token(token) else None,
+        user_scopes=None if _is_bot_token(token) else oauth_scopes,
     )

--- a/tests/mock_web_api_server.py
+++ b/tests/mock_web_api_server.py
@@ -149,6 +149,7 @@ class MockHandler(SimpleHTTPRequestHandler):
             if self.is_valid_user_token():
                 if path == "/auth.test":
                     self.send_response(200)
+                    self.send_header("x-oauth-scopes", "chat:write,search:read")
                     self.set_common_headers(len(USER_AUTH_TEST_RESPONSE))
                     self.wfile.write(USER_AUTH_TEST_RESPONSE.encode("utf-8"))
                     return
@@ -156,6 +157,7 @@ class MockHandler(SimpleHTTPRequestHandler):
             if self.is_valid_token():
                 if path == "/auth.test":
                     self.send_response(200)
+                    self.send_header("x-oauth-scopes", "chat:write,commands")
                     self.set_common_headers(len(BOT_AUTH_TEST_RESPONSE))
                     self.wfile.write(BOT_AUTH_TEST_RESPONSE.encode("utf-8"))
                     return

--- a/tests/slack_bolt_async/middleware/authorization/test_single_team_authorization.py
+++ b/tests/slack_bolt_async/middleware/authorization/test_single_team_authorization.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+from slack.web.async_slack_response import AsyncSlackResponse
 from slack_sdk.web.async_client import AsyncWebClient
 
 from slack_bolt.middleware.authorization.async_single_team_authorization import (
@@ -46,6 +47,21 @@ class TestSingleTeamAuthorization:
 
         assert resp.status == 200
         assert resp.body == ""
+
+    @pytest.mark.asyncio
+    async def test_success_pattern_with_bot_scopes(self):
+        client = AsyncWebClient(base_url=self.mock_api_server_base_url, token="xoxb-valid")
+        authorization = AsyncSingleTeamAuthorization()
+        req = AsyncBoltRequest(body="payload={}", headers={})
+        req.context["client"] = client
+        resp = BoltResponse(status=404)
+
+        resp = await authorization.async_process(req=req, resp=resp, next=next)
+
+        assert resp.status == 200
+        assert resp.body == ""
+        assert req.context.authorize_result.bot_scopes == ["chat:write", "commands"]
+        assert req.context.authorize_result.user_scopes is None
 
     @pytest.mark.asyncio
     async def test_failure_pattern(self):


### PR DESCRIPTION
This pull request improves the built-in SingleTeamAuthorization middleware to attach bot|user_scopes to Request#Context#AuthorizeResult as MultiTeamsAuthorization does. 

Why does this matter? This property is useful specifically when you want to know the issued OAuth token, which is associated with an incoming Slack event request, has sufficient scopes for newly added feature in a Slack app. Here is an example: https://github.com/seratch/ChatGPT-in-Slack/blob/341f50ad00f853009f3c50ff6c3133d6fd0b3dd7/app/bolt_listeners.py#L1053-L1065

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
