### PR TITLE
Docs: sidebar reference link needs to be full URL

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -87,7 +87,7 @@ const sidebars = {
     {
       type: 'link',
       label: 'Reference',
-      href: '/api-docs/slack_bolt',
+      href: '/api-docs/slack_bolt/',
     },
     {type: 'html', value: '<hr>'},
     {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -87,7 +87,7 @@ const sidebars = {
     {
       type: 'link',
       label: 'Reference',
-      href: '/api-docs/slack_bolt/',
+      href: 'https://slack.dev/bolt-python/api-docs/slack_bolt/',
     },
     {type: 'html', value: '<hr>'},
     {


### PR DESCRIPTION
The link works - try refreshing the page and it'll load - but it's not liking the relative link initially for some reason

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [X] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
