### PR TITLE
Docs: docusaurus migration nits

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,5 +1,3 @@
-<!-- <img src="./img/bolt-py-logo.svg" alt="logo" width="128"/> -->
-
 # Bolt for Python
 
 Bolt for Python is a Python framework to build Slack apps with the latest Slack platform features. Read the [Getting Started Guide](/getting-started) to set up and run your first Bolt app.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,7 +8,7 @@ import { themes as prismThemes } from "prism-react-renderer";
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: "Slack Developer Tools",
+  title: "Bolt for Python",
   tagline: "Official frameworks, libraries, and SDKs for Slack developers",
   favicon: "img/favicon.ico",
 


### PR DESCRIPTION
A comment on the index page is messing with the title. Removed comment. Also made title of site "Bolt for Python" for page unfurl clarity

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [X] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
