### PR TITLE
chore: purge the "workflow step" terminology

### DIFF
--- a/docs/content/steps/adding-editing-steps.md
+++ b/docs/content/steps/adding-editing-steps.md
@@ -1,14 +1,14 @@
 ---
-title: Adding or editing workflow steps
+title: Adding or editing steps from apps
 lang: en
 slug: /concepts/adding-editing-steps
 ---
 
 :::danger
 
-Workflow Steps from Apps are a deprecated feature.
+Steps from apps are a deprecated feature.
 
-Workflow Steps from Apps are different than, and not interchangable with, Slack automation workflows. We encourage those who are currently publishing Workflow Steps from Apps to consider the new [Slack automation features](https://api.slack.com/automation), such as custom functions for Bolt.
+Steps from apps are different than, and not interchangeable with, Slack automation workflows. We encourage those who are currently publishing steps from apps to consider the new [Slack automation features](https://api.slack.com/automation), such as custom steps for Bolt.
 
 Please [read the Slack API changelog entry](https://api.slack.com/changelog/2023-08-workflow-steps-from-apps-step-back) for more information.
 
@@ -16,7 +16,7 @@ Please [read the Slack API changelog entry](https://api.slack.com/changelog/2023
 
 When a builder adds (or later edits) your step in their workflow, your app will receive a [`workflow_step_edit` event](https://api.slack.com/reference/workflows/workflow_step_edit). The `edit` callback in your `WorkflowStep` configuration will be run when this event is received.
 
-Whether a builder is adding or editing a step, you need to send them a [workflow step configuration modal](https://api.slack.com/reference/workflows/configuration-view). This modal is where step-specific settings are chosen, and it has more restrictions than typical modals—most notably, it cannot include `title`, `submit`, or `close` properties. By default, the configuration modal's `callback_id` will be the same as the workflow step.
+Whether a builder is adding or editing a step, you need to send them a [step from app configuration modal](https://api.slack.com/reference/workflows/configuration-view). This modal is where step-specific settings are chosen, and it has more restrictions than typical modals—most notably, it cannot include `title`, `submit`, or `close` properties. By default, the configuration modal's `callback_id` will be the same as the step from app.
 
 Within the `edit` callback, the `configure()` utility can be used to easily open your step's configuration modal by passing in the view's blocks with the corresponding `blocks` argument. To disable saving the configuration before certain conditions are met, you can also pass in `submit_disabled` with a value of `True`.
 

--- a/docs/content/steps/creating-steps.md
+++ b/docs/content/steps/creating-steps.md
@@ -1,28 +1,28 @@
 ---
-title: Creating workflow steps
+title: Creating steps from apps
 lang: en
 slug: /concepts/creating-steps
 ---
 
 :::danger
 
-Workflow Steps from Apps are a deprecated feature.
+Steps from apps are a deprecated feature.
 
-Workflow Steps from Apps are different than, and not interchangable with, Slack automation workflows. We encourage those who are currently publishing Workflow Steps from Apps to consider the new [Slack automation features](https://api.slack.com/automation), such as custom functions for Bolt.
+Steps from apps are different than, and not interchangeable with, Slack automation workflows. We encourage those who are currently publishing steps from apps to consider the new [Slack automation features](https://api.slack.com/automation), such as custom steps for Bolt.
 
 Please [read the Slack API changelog entry](https://api.slack.com/changelog/2023-08-workflow-steps-from-apps-step-back) for more information.
 
 :::
 
-To create a workflow step, Bolt provides the `WorkflowStep` class.
+To create a step from app, Bolt provides the `WorkflowStep` class.
 
 When instantiating a new `WorkflowStep`, pass in the step's `callback_id` and a configuration object.
 
-The configuration object contains three keys: `edit`, `save`, and `execute`. Each of these keys must be a single callback or a list of callbacks. All callbacks have access to a `step` object that contains information about the workflow step event.
+The configuration object contains three keys: `edit`, `save`, and `execute`. Each of these keys must be a single callback or a list of callbacks. All callbacks have access to a `step` object that contains information about the step from app event.
 
-After instantiating a `WorkflowStep`, you can pass it into `app.step()`. Behind the scenes, your app will listen and respond to the workflow step’s events using the callbacks provided in the configuration object.
+After instantiating a `WorkflowStep`, you can pass it into `app.step()`. Behind the scenes, your app will listen and respond to the step’s events using the callbacks provided in the configuration object.
 
-Alternatively, workflow steps can also be created using the `WorkflowStepBuilder` class alongside a decorator pattern. For more information, including an example of this approach, [refer to the documentation](https://slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/step.html#slack_bolt.workflows.step.step.WorkflowStepBuilder).
+Alternatively, steps from apps can also be created using the `WorkflowStepBuilder` class alongside a decorator pattern. For more information, including an example of this approach, [refer to the documentation](https://slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/step.html#slack_bolt.workflows.step.step.WorkflowStepBuilder).
 
 Refer to the module documents (<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">common</a> / <a href="https://slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">step-specific</a>) to learn the available arguments.
 

--- a/docs/content/steps/executing-steps.md
+++ b/docs/content/steps/executing-steps.md
@@ -1,22 +1,22 @@
 ---
-title: Executing workflow steps
+title: Executing steps from apps
 lang: en
 slug: /concepts/executing-steps
 ---
 
 :::danger
 
-Workflow Steps from Apps are a deprecated feature.
+Steps from apps are a deprecated feature.
 
-Workflow Steps from Apps are different than, and not interchangable with, Slack automation workflows. We encourage those who are currently publishing Workflow Steps from Apps to consider the new [Slack automation features](https://api.slack.com/automation), such as custom functions for Bolt.
+Steps from apps are different than, and not interchangeable with, Slack automation workflows. We encourage those who are currently publishing steps from apps to consider the new [Slack automation features](https://api.slack.com/automation), such as custom steps for Bolt.
 
 Please [read the Slack API changelog entry](https://api.slack.com/changelog/2023-08-workflow-steps-from-apps-step-back) for more information.
 
 :::
 
-When your workflow step is executed by an end user, your app will receive a [`workflow_step_execute` event](https://api.slack.com/events/workflow_step_execute). The `execute` callback in your `WorkflowStep` configuration will be run when this event is received.
+When your step from app is executed by an end user, your app will receive a [`workflow_step_execute` event](https://api.slack.com/events/workflow_step_execute). The `execute` callback in your `WorkflowStep` configuration will be run when this event is received.
 
-Using the `inputs` from the `save` callback, this is where you can make third-party API calls, save information to a database, update the user's Home tab, or decide the outputs that will be available to subsequent workflow steps by mapping values to the `outputs` object.
+Using the `inputs` from the `save` callback, this is where you can make third-party API calls, save information to a database, update the user's Home tab, or decide the outputs that will be available to subsequent steps from apps by mapping values to the `outputs` object.
 
 Within the `execute` callback, your app must either call `complete()` to indicate that the step's execution was successful, or `fail()` to indicate that the step's execution failed.
 

--- a/docs/content/steps/saving-steps.md
+++ b/docs/content/steps/saving-steps.md
@@ -6,9 +6,9 @@ slug: /concepts/saving-steps
 
 :::danger
 
-Workflow Steps from Apps are a deprecated feature.
+Steps from apps are a deprecated feature.
 
-Workflow Steps from Apps are different than, and not interchangable with, Slack automation workflows. We encourage those who are currently publishing Workflow Steps from Apps to consider the new [Slack automation features](https://api.slack.com/automation), such as custom functions for Bolt.
+Steps from apps are different than, and not interchangeable with, Slack automation workflows. We encourage those who are currently publishing steps from apps to consider the new [Slack automation features](https://api.slack.com/automation), such as custom steps for Bolt.
 
 Please [read the Slack API changelog entry](https://api.slack.com/changelog/2023-08-workflow-steps-from-apps-step-back) for more information.
 
@@ -18,8 +18,8 @@ After the configuration modal is opened, your app will listen for the `view_subm
 
 Within the `save` callback, the `update()` method can be used to save the builder's step configuration by passing in the following arguments:
 
-- `inputs` is a dictionary representing the data your app expects to receive from the user upon workflow step execution.
-- `outputs` is a list of objects containing data that your app will provide upon the workflow step's completion. Outputs can then be used in subsequent steps of the workflow.
+- `inputs` is a dictionary representing the data your app expects to receive from the user upon step execution.
+- `outputs` is a list of objects containing data that your app will provide upon the step's completion. Outputs can then be used in subsequent steps of the workflow.
 - `step_name` overrides the default Step name
 - `step_image_url` overrides the default Step image
 

--- a/docs/content/steps/steps.md
+++ b/docs/content/steps/steps.md
@@ -1,29 +1,29 @@
 ---
-title: Overview of Workflow Steps for apps
+title: Overview of steps form apps
 lang: en
 slug: /concepts/steps
 ---
 
 :::danger
 
-Workflow Steps from Apps are a deprecated feature.
+Steps from apps are a deprecated feature.
 
-Workflow Steps from Apps are different than, and not interchangable with, Slack automation workflows. We encourage those who are currently publishing Workflow Steps from Apps to consider the new [Slack automation features](https://api.slack.com/automation), such as custom functions for Bolt.
+Steps from apps are different than, and not interchangeable with, Slack automation workflows. We encourage those who are currently publishing steps from apps to consider the new [Slack automation features](https://api.slack.com/automation), such as custom steps for Bolt.
 
 Please [read the Slack API changelog entry](https://api.slack.com/changelog/2023-08-workflow-steps-from-apps-step-back) for more information.
 
 :::
 
-Steps from Apps for legacy workflows are now deprecated. Use new [custom steps](https://api.slack.com/automation/functions/custom-bolt).
+Steps from apps for legacy workflows are now deprecated. Use new [custom steps](https://api.slack.com/automation/functions/custom-bolt).
 
-Workflow Steps from apps allow your app to create and process custom workflow steps that users can add using [Workflow Builder](https://api.slack.com/workflows).
+Steps from apps allow your app to create and process steps that users can add using [Workflow Builder](https://api.slack.com/workflows).
 
-A workflow step is made up of three distinct user events:
+A step from apps is made up of three distinct user events:
 
 - Adding or editing the step in a Workflow
 - Saving or updating the step's configuration
 - The end user's execution of the step
 
-All three events must be handled for a workflow step to function.
+All three events must be handled for a step from app to function.
 
-Read more about workflow steps from apps in the [API documentation](https://api.slack.com/workflows/steps).
+Read more about step from apps in the [API documentation](https://api.slack.com/workflows/steps).

--- a/docs/content/steps/steps.md
+++ b/docs/content/steps/steps.md
@@ -1,5 +1,5 @@
 ---
-title: Overview of steps form apps
+title: Overview of steps from apps
 lang: en
 slug: /concepts/steps
 ---

--- a/docs/content/steps/steps.md
+++ b/docs/content/steps/steps.md
@@ -18,7 +18,7 @@ Steps from apps for legacy workflows are now deprecated. Use new [custom steps](
 
 Steps from apps allow your app to create and process steps that users can add using [Workflow Builder](https://api.slack.com/workflows).
 
-A step from apps is made up of three distinct user events:
+Steps from apps are made up of three distinct user events:
 
 - Adding or editing the step in a Workflow
 - Saving or updating the step's configuration
@@ -26,4 +26,4 @@ A step from apps is made up of three distinct user events:
 
 All three events must be handled for a step from app to function.
 
-Read more about step from apps in the [API documentation](https://api.slack.com/workflows/steps).
+Read more about steps from apps in the [API documentation](https://api.slack.com/workflows/steps).

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current.json
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current.json
@@ -11,9 +11,9 @@
     "message": "応用コンセプト",
     "description": "The label for category Advanced concepts in sidebar sidebarBoltPy"
   },
-  "sidebar.sidebarBoltPy.category.Workflow steps (Deprecated)": {
+  "sidebar.sidebarBoltPy.category.steps from apps (Deprecated)": {
     "message": "ワークフローステップ 非推奨",
-    "description": "The label for category Workflow steps (Deprecated) in sidebar sidebarBoltPy"
+    "description": "The label for category steps from apps (Deprecated) in sidebar sidebarBoltPy"
   },
   "sidebar.sidebarBoltPy.category.Tutorials": {
     "message": "チュートリアル",

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -62,11 +62,11 @@ const sidebars = {
         'advanced/global-middleware',
         'advanced/context',
         'advanced/lazy-listeners',
-        ],
+      ],
     },
     {
       type: 'category',
-      label: 'Workflow steps (Deprecated)',
+      label: 'Steps from apps (Deprecated)',
       items: [
         'steps/steps',
         'steps/executing-steps',
@@ -75,7 +75,7 @@ const sidebars = {
         'steps/saving-steps',
       ],
     },
-    {type: 'html', value: '<hr>'},
+    { type: 'html', value: '<hr>' },
     {
       type: 'category',
       label: 'Tutorials',
@@ -83,13 +83,13 @@ const sidebars = {
         'tutorial/getting-started-http'
       ],
     },
-    {type: 'html', value: '<hr>'},
+    { type: 'html', value: '<hr>' },
     {
       type: 'link',
       label: 'Reference',
       href: 'https://slack.dev/bolt-python/api-docs/slack_bolt/',
     },
-    {type: 'html', value: '<hr>'},
+    { type: 'html', value: '<hr>' },
     {
       type: 'link',
       label: 'Release notes',

--- a/examples/workflow_steps/async_steps_from_apps.py
+++ b/examples/workflow_steps/async_steps_from_apps.py
@@ -10,7 +10,7 @@ from slack_bolt.workflows.step.async_step import (
 )
 
 ################################################################################
-# Steps from Apps for legacy workflows are now deprecated.                     #
+# Steps from apps for legacy workflows are now deprecated.                     #
 # Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
 ################################################################################
 

--- a/examples/workflow_steps/async_steps_from_apps_decorator.py
+++ b/examples/workflow_steps/async_steps_from_apps_decorator.py
@@ -12,7 +12,7 @@ from slack_bolt.workflows.step.async_step import (
 )
 
 ################################################################################
-# Steps from Apps for legacy workflows are now deprecated.                     #
+# Steps from apps for legacy workflows are now deprecated.                     #
 # Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
 ################################################################################
 

--- a/examples/workflow_steps/async_steps_from_apps_primitive.py
+++ b/examples/workflow_steps/async_steps_from_apps_primitive.py
@@ -4,7 +4,7 @@ from slack_sdk.web.async_client import AsyncSlackResponse, AsyncWebClient
 from slack_bolt.async_app import AsyncApp, AsyncAck
 
 ################################################################################
-# Steps from Apps for legacy workflows are now deprecated.                     #
+# Steps from apps for legacy workflows are now deprecated.                     #
 # Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
 ################################################################################
 

--- a/examples/workflow_steps/steps_from_apps.py
+++ b/examples/workflow_steps/steps_from_apps.py
@@ -7,7 +7,7 @@ from slack_bolt import App, Ack
 from slack_bolt.workflows.step import Configure, Update, Complete, Fail
 
 ################################################################################
-# Steps from Apps for legacy workflows are now deprecated.                     #
+# Steps from apps for legacy workflows are now deprecated.                     #
 # Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
 ################################################################################
 

--- a/examples/workflow_steps/steps_from_apps_decorator.py
+++ b/examples/workflow_steps/steps_from_apps_decorator.py
@@ -8,7 +8,7 @@ from slack_bolt import App, Ack
 from slack_bolt.workflows.step import Configure, Update, Complete, Fail, WorkflowStep
 
 ################################################################################
-# Steps from Apps for legacy workflows are now deprecated.                     #
+# Steps from apps for legacy workflows are now deprecated.                     #
 # Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
 ################################################################################
 

--- a/examples/workflow_steps/steps_from_apps_primitive.py
+++ b/examples/workflow_steps/steps_from_apps_primitive.py
@@ -6,7 +6,7 @@ from slack_sdk.web import SlackResponse
 from slack_bolt import App, Ack
 
 ################################################################################
-# Steps from Apps for legacy workflows are now deprecated.                     #
+# Steps from apps for legacy workflows are now deprecated.                     #
 # Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
 ################################################################################
 

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -651,7 +651,7 @@ class App:
         return None
 
     # -------------------------
-    # Workflows: Steps from Apps
+    # Workflows: Steps from apps
 
     def step(
         self,
@@ -662,13 +662,13 @@ class App:
     ):
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
 
-        Registers a new Workflow Step listener.
+        Registers a new step from app listener.
 
         Unlike others, this method doesn't behave as a decorator.
-        If you want to register a workflow step by a decorator, use `WorkflowStepBuilder`'s methods.
+        If you want to register a step from app by a decorator, use `WorkflowStepBuilder`'s methods.
 
             # Create a new WorkflowStep instance
             from slack_bolt.workflows.step import WorkflowStep
@@ -681,7 +681,7 @@ class App:
             # Pass Step to set up listeners
             app.step(ws)
 
-        Refer to https://api.slack.com/workflows/steps for details of Steps from Apps.
+        Refer to https://api.slack.com/workflows/steps for details of steps from apps.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`'s API document.
 
@@ -690,14 +690,14 @@ class App:
         refer to `slack_bolt.workflows.step.utilities` API documents.
 
         Args:
-            callback_id: The Callback ID for this workflow step
+            callback_id: The Callback ID for this step from app
             edit: The function for displaying a modal in the Workflow Builder
             save: The function for handling configuration in the Workflow Builder
             execute: The function for handling the step execution
         """
         warnings.warn(
             (
-                "Steps from Apps for legacy workflows are now deprecated. "
+                "Steps from apps for legacy workflows are now deprecated. "
                 "Use new custom steps: https://api.slack.com/automation/functions/custom-bolt"
             ),
             category=DeprecationWarning,

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -680,7 +680,7 @@ class AsyncApp:
         return None
 
     # -------------------------
-    # Workflows: Steps from Apps
+    # Workflows: Steps from apps
 
     def step(
         self,
@@ -691,13 +691,13 @@ class AsyncApp:
     ):
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
 
-        Registers a new Workflow Step listener.
+        Registers a new step from app listener.
 
         Unlike others, this method doesn't behave as a decorator.
-        If you want to register a workflow step by a decorator, use `AsyncWorkflowStepBuilder`'s methods.
+        If you want to register a step from app by a decorator, use `AsyncWorkflowStepBuilder`'s methods.
 
             # Create a new WorkflowStep instance
             from slack_bolt.workflows.async_step import AsyncWorkflowStep
@@ -710,7 +710,7 @@ class AsyncApp:
             # Pass Step to set up listeners
             app.step(ws)
 
-        Refer to https://api.slack.com/workflows/steps for details of Steps from Apps.
+        Refer to https://api.slack.com/workflows/steps for details of steps from apps.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`'s API document.
         For further information about AsyncWorkflowStep specific function arguments
@@ -718,14 +718,14 @@ class AsyncApp:
         refer to the `async` prefixed ones in `slack_bolt.workflows.step.utilities` API documents.
 
         Args:
-            callback_id: The Callback ID for this workflow step
+            callback_id: The Callback ID for this step from app
             edit: The function for displaying a modal in the Workflow Builder
             save: The function for handling configuration in the Workflow Builder
             execute: The function for handling the step execution
         """
         warnings.warn(
             (
-                "Steps from Apps for legacy workflows are now deprecated. "
+                "Steps from apps for legacy workflows are now deprecated. "
                 "Use new custom steps: https://api.slack.com/automation/functions/custom-bolt"
             ),
             category=DeprecationWarning,

--- a/slack_bolt/kwargs_injection/__init__.py
+++ b/slack_bolt/kwargs_injection/__init__.py
@@ -1,7 +1,7 @@
 """For middleware/listener arguments, Bolt does flexible data injection in accordance with their names.
 
 To learn the available arguments, check `slack_bolt.kwargs_injection.args`'s API document.
-For Workflow steps, checking `slack_bolt.workflows.step.utilities` as well should be helpful.
+For steps from apps, checking `slack_bolt.workflows.step.utilities` as well should be helpful.
 """
 
 # Don't add async module imports here

--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -147,7 +147,7 @@ def _build_filtered_body(body: Optional[Dict[str, Any]]) -> dict:
         filtered_body["command"] = body.get("command")
 
     if payload_type in ["workflow_step_edit", "shortcut", "message_action"]:
-        # Workflow Steps, Global Shortcuts, Message Shortcuts
+        # Step from apps, Global Shortcuts, Message Shortcuts
         filtered_body["callback_id"] = body.get("callback_id")
 
     if payload_type == "interactive_message":

--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -147,7 +147,7 @@ def _build_filtered_body(body: Optional[Dict[str, Any]]) -> dict:
         filtered_body["command"] = body.get("command")
 
     if payload_type in ["workflow_step_edit", "shortcut", "message_action"]:
-        # Step from apps, Global Shortcuts, Message Shortcuts
+        # Steps from apps, Global Shortcuts, Message Shortcuts
         filtered_body["callback_id"] = body.get("callback_id")
 
     if payload_type == "interactive_message":

--- a/slack_bolt/request/payload_utils.py
+++ b/slack_bolt/request/payload_utils.py
@@ -161,7 +161,7 @@ def is_workflow_step_save(body: Dict[str, Any]) -> bool:
 
 
 # -------------------
-# Workflow Steps
+# Steps From Apps
 # -------------------
 
 

--- a/slack_bolt/workflows/__init__.py
+++ b/slack_bolt/workflows/__init__.py
@@ -1,4 +1,4 @@
-"""Workflow Steps from Apps enables developers to build their own custom workflow steps.
+"""Steps from apps enables developers to build their own steps.
 
 Check the following API documents first:
 

--- a/slack_bolt/workflows/step/async_step.py
+++ b/slack_bolt/workflows/step/async_step.py
@@ -27,7 +27,7 @@ from ...middleware.async_middleware import AsyncMiddleware
 
 
 class AsyncWorkflowStepBuilder:
-    """Steps from Apps
+    """Steps from apps
     Refer to https://api.slack.com/workflows/steps for details.
     """
 
@@ -45,7 +45,7 @@ class AsyncWorkflowStepBuilder:
     ):
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
 
         This builder is supposed to be used as decorator.
@@ -87,7 +87,7 @@ class AsyncWorkflowStepBuilder:
     ):
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
 
         Registers a new edit listener with details.
@@ -140,7 +140,7 @@ class AsyncWorkflowStepBuilder:
     ):
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
 
         Registers a new save listener with details.
@@ -193,7 +193,7 @@ class AsyncWorkflowStepBuilder:
     ):
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
 
         Registers a new execute listener with details.
@@ -240,7 +240,7 @@ class AsyncWorkflowStepBuilder:
     def build(self, base_logger: Optional[Logger] = None) -> "AsyncWorkflowStep":
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
 
         Constructs a WorkflowStep object. This method may raise an exception
@@ -318,13 +318,13 @@ class AsyncWorkflowStepBuilder:
 
 class AsyncWorkflowStep:
     callback_id: Union[str, Pattern]
-    """The Callback ID of the workflow step"""
+    """The Callback ID of the step from app"""
     edit: AsyncListener
     """`edit` listener, which displays a modal in Workflow Builder"""
     save: AsyncListener
     """`save` listener, which accepts workflow creator's data submission in Workflow Builder"""
     execute: AsyncListener
-    """`execute` listener, which processes workflow step execution"""
+    """`execute` listener, which processes the step from app execution"""
 
     def __init__(
         self,
@@ -338,16 +338,16 @@ class AsyncWorkflowStep:
     ):
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
 
         Args:
-            callback_id: The callback_id for this workflow step
+            callback_id: The callback_id for this step from app
             edit: Either a single function or a list of functions for opening a modal in the builder UI
                 When it's a list, the first one is responsible for ack() while the rest are lazy listeners.
             save: Either a single function or a list of functions for handling modal interactions in the builder UI
                 When it's a list, the first one is responsible for ack() while the rest are lazy listeners.
-            execute: Either a single function or a list of functions for handling workflow step executions
+            execute: Either a single function or a list of functions for handling step from apps executions
                 When it's a list, the first one is responsible for ack() while the rest are lazy listeners.
             app_name: The app name that can be mainly used for logging
             base_logger: The logger instance that can be used as a template when creating this step's logger
@@ -384,7 +384,7 @@ class AsyncWorkflowStep:
     ) -> AsyncWorkflowStepBuilder:
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
         """
         return AsyncWorkflowStepBuilder(callback_id, base_logger=base_logger)

--- a/slack_bolt/workflows/step/async_step.py
+++ b/slack_bolt/workflows/step/async_step.py
@@ -347,7 +347,7 @@ class AsyncWorkflowStep:
                 When it's a list, the first one is responsible for ack() while the rest are lazy listeners.
             save: Either a single function or a list of functions for handling modal interactions in the builder UI
                 When it's a list, the first one is responsible for ack() while the rest are lazy listeners.
-            execute: Either a single function or a list of functions for handling step from apps executions
+            execute: Either a single function or a list of functions for handling steps from apps executions
                 When it's a list, the first one is responsible for ack() while the rest are lazy listeners.
             app_name: The app name that can be mainly used for logging
             base_logger: The logger instance that can be used as a template when creating this step's logger

--- a/slack_bolt/workflows/step/async_step_middleware.py
+++ b/slack_bolt/workflows/step/async_step_middleware.py
@@ -10,7 +10,7 @@ from slack_bolt.workflows.step.async_step import AsyncWorkflowStep
 
 
 class AsyncWorkflowStepMiddleware(AsyncMiddleware):  # type:ignore
-    """Base middleware for workflow step specific ones"""
+    """Base middleware for step from app specific ones"""
 
     def __init__(self, step: AsyncWorkflowStep, listener_runner: AsyncioListenerRunner):
         self.step = step

--- a/slack_bolt/workflows/step/step.py
+++ b/slack_bolt/workflows/step/step.py
@@ -22,7 +22,7 @@ from slack_sdk.web import WebClient
 
 
 class WorkflowStepBuilder:
-    """Steps from Apps
+    """Steps from apps
     Refer to https://api.slack.com/workflows/steps for details.
     """
 
@@ -40,7 +40,7 @@ class WorkflowStepBuilder:
     ):
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
 
         This builder is supposed to be used as decorator.
@@ -82,7 +82,7 @@ class WorkflowStepBuilder:
     ):
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
 
         Registers a new edit listener with details.
@@ -136,7 +136,7 @@ class WorkflowStepBuilder:
     ):
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
 
         Registers a new save listener with details.
@@ -189,7 +189,7 @@ class WorkflowStepBuilder:
     ):
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
 
         Registers a new execute listener with details.
@@ -236,7 +236,7 @@ class WorkflowStepBuilder:
     def build(self, base_logger: Optional[Logger] = None) -> "WorkflowStep":
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
 
         Constructs a WorkflowStep object. This method may raise an exception
@@ -329,13 +329,13 @@ class WorkflowStepBuilder:
 
 class WorkflowStep:
     callback_id: Union[str, Pattern]
-    """The Callback ID of the workflow step"""
+    """The Callback ID of the step from app"""
     edit: Listener
     """`edit` listener, which displays a modal in Workflow Builder"""
     save: Listener
     """`save` listener, which accepts workflow creator's data submission in Workflow Builder"""
     execute: Listener
-    """`execute` listener, which processes workflow step execution"""
+    """`execute` listener, which processes step from app execution"""
 
     def __init__(
         self,
@@ -349,16 +349,16 @@ class WorkflowStep:
     ):
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
 
         Args:
-            callback_id: The callback_id for this workflow step
+            callback_id: The callback_id for this step from app
             edit: Either a single function or a list of functions for opening a modal in the builder UI
                 When it's a list, the first one is responsible for ack() while the rest are lazy listeners.
             save: Either a single function or a list of functions for handling modal interactions in the builder UI
                 When it's a list, the first one is responsible for ack() while the rest are lazy listeners.
-            execute: Either a single function or a list of functions for handling workflow step executions
+            execute: Either a single function or a list of functions for handling step from app executions
                 When it's a list, the first one is responsible for ack() while the rest are lazy listeners.
             app_name: The app name that can be mainly used for logging
             base_logger: The logger instance that can be used as a template when creating this step's logger
@@ -391,7 +391,7 @@ class WorkflowStep:
     def builder(cls, callback_id: Union[str, Pattern], base_logger: Optional[Logger] = None) -> WorkflowStepBuilder:
         """
         Deprecated:
-            Steps from Apps for legacy workflows are now deprecated.
+            Steps from apps for legacy workflows are now deprecated.
             Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
         """
         return WorkflowStepBuilder(

--- a/slack_bolt/workflows/step/step_middleware.py
+++ b/slack_bolt/workflows/step/step_middleware.py
@@ -10,7 +10,7 @@ from slack_bolt.workflows.step.step import WorkflowStep
 
 
 class WorkflowStepMiddleware(Middleware):  # type:ignore
-    """Base middleware for workflow step specific ones"""
+    """Base middleware for step from app specific ones"""
 
     def __init__(self, step: WorkflowStep, listener_runner: ThreadListenerRunner):
         self.step = step

--- a/slack_bolt/workflows/step/utilities/__init__.py
+++ b/slack_bolt/workflows/step/utilities/__init__.py
@@ -1,6 +1,6 @@
-"""Utilities specific to workflow steps from apps.
+"""Utilities specific to steps from apps.
 
-In workflow step listeners, you can use a few specific listener/middleware arguments.
+In step from apps listeners, you can use a few specific listener/middleware arguments.
 
 ### `edit` listener
 

--- a/slack_bolt/workflows/step/utilities/__init__.py
+++ b/slack_bolt/workflows/step/utilities/__init__.py
@@ -1,6 +1,6 @@
 """Utilities specific to steps from apps.
 
-In step from apps listeners, you can use a few specific listener/middleware arguments.
+In steps from apps listeners, you can use a few specific listener/middleware arguments.
 
 ### `edit` listener
 

--- a/slack_bolt/workflows/step/utilities/async_complete.py
+++ b/slack_bolt/workflows/step/utilities/async_complete.py
@@ -2,7 +2,7 @@ from slack_sdk.web.async_client import AsyncWebClient
 
 
 class AsyncComplete:
-    """`complete()` utility to tell Slack the completion of a workflow step execution.
+    """`complete()` utility to tell Slack the completion of a step from app execution.
 
         async def execute(step, complete, fail):
             inputs = step["inputs"]

--- a/slack_bolt/workflows/step/utilities/async_fail.py
+++ b/slack_bolt/workflows/step/utilities/async_fail.py
@@ -2,7 +2,7 @@ from slack_sdk.web.async_client import AsyncWebClient
 
 
 class AsyncFail:
-    """`fail()` utility to tell Slack the execution failure of a workflow step.
+    """`fail()` utility to tell Slack the execution failure of a step from app.
 
         async def execute(step, complete, fail):
             inputs = step["inputs"]

--- a/slack_bolt/workflows/step/utilities/complete.py
+++ b/slack_bolt/workflows/step/utilities/complete.py
@@ -2,7 +2,7 @@ from slack_sdk.web import WebClient
 
 
 class Complete:
-    """`complete()` utility to tell Slack the completion of a workflow step execution.
+    """`complete()` utility to tell Slack the completion of a step from app execution.
 
         def execute(step, complete, fail):
             inputs = step["inputs"]

--- a/slack_bolt/workflows/step/utilities/fail.py
+++ b/slack_bolt/workflows/step/utilities/fail.py
@@ -2,7 +2,7 @@ from slack_sdk.web import WebClient
 
 
 class Fail:
-    """`fail()` utility to tell Slack the execution failure of a workflow step.
+    """`fail()` utility to tell Slack the execution failure of a step from app.
 
         def execute(step, complete, fail):
             inputs = step["inputs"]


### PR DESCRIPTION
This PR aims to purge the `workflow step` terminology in favor to the new one `steps from apps`

### Category 

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements 

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
