### PR TITLE
health: move to mypy

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,4 +1,4 @@
-name: Run pytype validation
+name: Run mypy validation
 
 on:
   push:
@@ -11,13 +11,13 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Run pytype verification
+      - name: Run mypy verification
         run: |
-          ./scripts/run_pytype.sh
+          ./scripts/run_mypy.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,8 @@ filterwarnings = [
 	"ignore:The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.:DeprecationWarning",
 ]
 asyncio_mode = "auto"
+
+[tool.mypy]
+files = "slack_bolt/"
+force_union_syntax = true
+warn_unused_ignores = true

--- a/requirements/testing_without_asyncio.txt
+++ b/requirements/testing_without_asyncio.txt
@@ -1,4 +1,3 @@
 # pip install -r requirements/testing_without_asyncio.txt
 pytest>=6.2.5,<8.4        # https://github.com/tornadoweb/tornado/issues/3375
 pytest-cov>=3,<6
-black==22.8.0             # Until we drop Python 3.6 support, we have to stay with this version

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -1,0 +1,3 @@
+mypy==1.11.1
+flake8==6.0.0
+black==22.8.0             # Until we drop Python 3.6 support, we have to stay with this version

--- a/scripts/install_all_and_run_tests.sh
+++ b/scripts/install_all_and_run_tests.sh
@@ -42,5 +42,5 @@ else
     black slack_bolt/ tests/ && \
     flake8 slack_bolt/ && flake8 examples/
     pytest && \
-    mypy slack_bolt/
+    mypy --config-file pyproject.toml
 fi

--- a/scripts/install_all_and_run_tests.sh
+++ b/scripts/install_all_and_run_tests.sh
@@ -32,10 +32,11 @@ else
     pip install -U -r requirements/testing.txt && \
     pip install -U -r requirements/adapter.txt && \
     pip install -U -r requirements/adapter_testing.txt && \
+    pip install -r requirements/tools.txt && \
     # To avoid errors due to the old versions of click forced by Chalice
     pip install -U pip click && \
     black slack_bolt/ tests/ && \
+    flake8 slack_bolt/ && flake8 examples/
     pytest && \
-    pip install "pytype==2022.12.15" && \
-    pytype slack_bolt/
+    mypy slack_bolt/
 fi

--- a/scripts/install_all_and_run_tests.sh
+++ b/scripts/install_all_and_run_tests.sh
@@ -6,6 +6,10 @@
 script_dir=`dirname $0`
 cd ${script_dir}/..
 rm -rf ./slack_bolt.egg-info
+
+# Update pip to prevent warnings
+pip install -U pip
+
 # The package causes a conflict with moto
 pip uninstall python-lambda
 

--- a/scripts/run_flake8.sh
+++ b/scripts/run_flake8.sh
@@ -3,5 +3,5 @@
 
 script_dir=$(dirname $0)
 cd ${script_dir}/.. && \
-  pip install "flake8==6.0.0" && \
+  pip install -r requirements/tools.txt && \
   flake8 slack_bolt/ && flake8 examples/

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -7,4 +7,4 @@ cd ${script_dir}/.. && \
   pip install -r requirements/async.txt && \
   pip install -r requirements/adapter.txt && \
   pip install -r requirements/tools.txt && \
-  mypy slack_bolt/
+  mypy --config-file pyproject.toml

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# ./scripts/run_pytype.sh
+# ./scripts/run_mypy.sh
 
 script_dir=$(dirname $0)
 cd ${script_dir}/.. && \
   pip install .
   pip install -r requirements/async.txt && \
   pip install -r requirements/adapter.txt && \
-  pip install "pytype==2022.12.15" && \
-  pytype slack_bolt/
+  pip install -r requirements/tools.txt && \
+  mypy slack_bolt/

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -14,17 +14,6 @@ then
   black slack_bolt/ tests/ && \
     pytest -vv $1
 else
-  if [ ${python_version:0:3} == "3.8" ]
-  then
-    # pytype's behavior can be different in older Python versions
-    black slack_bolt/ tests/ \
-      && pytest -vv \
-      && pip install -r requirements/adapter.txt \
-      && pip install -r requirements/adapter_testing.txt \
-      && pip install -U pip setuptools wheel \
-      && pip install -U pytype \
-      && pytype slack_bolt/
-  else
     black slack_bolt/ tests/ && pytest
   fi
 fi

--- a/slack_bolt/adapter/aiohttp/__init__.py
+++ b/slack_bolt/adapter/aiohttp/__init__.py
@@ -10,7 +10,7 @@ async def to_bolt_request(request: web.Request) -> AsyncBoltRequest:
     return AsyncBoltRequest(
         body=await request.text(),
         query=request.query_string,
-        headers=request.headers,
+        headers=request.headers,  # type: ignore[arg-type]
     )
 
 
@@ -33,7 +33,7 @@ async def to_aiohttp_response(bolt_resp: BoltResponse) -> web.Response:
                 value=c.value,
                 max_age=c.get("max-age"),
                 expires=c.get("expires"),
-                path=c.get("path"),
+                path=c.get("path"),  # type: ignore[arg-type]
                 domain=c.get("domain"),
                 secure=True,
                 httponly=True,

--- a/slack_bolt/adapter/asgi/aiohttp/__init__.py
+++ b/slack_bolt/adapter/asgi/aiohttp/__init__.py
@@ -1,5 +1,3 @@
-from slack_bolt.oauth.async_oauth_flow import AsyncOAuthFlow
-
 from slack_bolt.adapter.asgi.http_request import AsgiHttpRequest
 from slack_bolt.adapter.asgi.builtin import SlackRequestHandler
 
@@ -41,13 +39,11 @@ class AsyncSlackRequestHandler(SlackRequestHandler):
         )
 
     async def handle_installation(self, request: AsgiHttpRequest) -> BoltResponse:
-        oauth_flow: AsyncOAuthFlow = self.app.oauth_flow
-        return await oauth_flow.handle_installation(
+        return await self.app.oauth_flow.handle_installation(  # type: ignore[union-attr]
             AsyncBoltRequest(body=await request.get_raw_body(), query=request.query_string, headers=request.get_headers())
         )
 
     async def handle_callback(self, request: AsgiHttpRequest) -> BoltResponse:
-        oauth_flow: AsyncOAuthFlow = self.app.oauth_flow
-        return await oauth_flow.handle_callback(
+        return await self.app.oauth_flow.handle_callback(  # type: ignore[union-attr]
             AsyncBoltRequest(body=await request.get_raw_body(), query=request.query_string, headers=request.get_headers())
         )

--- a/slack_bolt/adapter/asgi/builtin/__init__.py
+++ b/slack_bolt/adapter/asgi/builtin/__init__.py
@@ -9,7 +9,7 @@ from slack_bolt.adapter.asgi.base_handler import BaseSlackRequestHandler
 
 
 class SlackRequestHandler(BaseSlackRequestHandler):
-    def __init__(self, app: App, path: str = "/slack/events"):  # type: ignore
+    def __init__(self, app: App, path: str = "/slack/events"):
         """Setup Bolt as an ASGI web framework, this will make your application compatible with ASGI web servers.
         This can be used for production deployment.
 

--- a/slack_bolt/adapter/asgi/builtin/__init__.py
+++ b/slack_bolt/adapter/asgi/builtin/__init__.py
@@ -1,4 +1,3 @@
-from slack_bolt.oauth.oauth_flow import OAuthFlow
 from slack_bolt.adapter.asgi.http_request import AsgiHttpRequest
 
 from slack_bolt import App
@@ -39,13 +38,11 @@ class SlackRequestHandler(BaseSlackRequestHandler):
         )
 
     async def handle_installation(self, request: AsgiHttpRequest) -> BoltResponse:
-        oauth_flow: OAuthFlow = self.app.oauth_flow
-        return oauth_flow.handle_installation(
+        return self.app.oauth_flow.handle_installation(  # type: ignore[union-attr]
             BoltRequest(body=await request.get_raw_body(), query=request.query_string, headers=request.get_headers())
         )
 
     async def handle_callback(self, request: AsgiHttpRequest) -> BoltResponse:
-        oauth_flow: OAuthFlow = self.app.oauth_flow
-        return oauth_flow.handle_callback(
+        return self.app.oauth_flow.handle_callback(  # type: ignore[union-attr]
             BoltRequest(body=await request.get_raw_body(), query=request.query_string, headers=request.get_headers())
         )

--- a/slack_bolt/adapter/asgi/http_request.py
+++ b/slack_bolt/adapter/asgi/http_request.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Union
+from typing import Callable, Dict, Iterable, Sequence, Tuple, Union
 
 from .utils import scope_type, ENCODING
 
@@ -8,10 +8,10 @@ class AsgiHttpRequest:
 
     def __init__(self, scope: scope_type, receive: Callable):
         self.receive = receive
-        self.query_string = str(scope["query_string"], ENCODING)
-        self.raw_headers = scope["headers"]
+        self.query_string = str(scope["query_string"], ENCODING)  # type: ignore[arg-type]
+        self.raw_headers: Iterable[Tuple[bytes, bytes]] = scope["headers"]  # type: ignore[assignment]
 
-    def get_headers(self) -> Dict[str, str]:
+    def get_headers(self) -> Dict[str, Union[str, Sequence[str]]]:
         return {str(header[0], ENCODING): str(header[1], (ENCODING)) for header in self.raw_headers}
 
     async def get_raw_body(self) -> str:
@@ -22,7 +22,7 @@ class AsgiHttpRequest:
             if chunk["type"] != "http.request":
                 raise Exception("Body chunks could not be received from asgi server")
 
-            chunks.extend(chunk.get("body", b""))
+            chunks.extend(chunk.get("body", b""))  # type: ignore[arg-type]
             if not chunk.get("more_body", False):
                 break
         return bytes(chunks).decode(ENCODING)

--- a/slack_bolt/adapter/aws_lambda/chalice_handler.py
+++ b/slack_bolt/adapter/aws_lambda/chalice_handler.py
@@ -2,7 +2,7 @@ import logging
 from os import getenv
 from typing import Optional
 
-from botocore.client import BaseClient
+from botocore.client import BaseClient  # type: ignore[import-untyped]
 
 from chalice.app import Request, Response, Chalice
 
@@ -29,7 +29,7 @@ class ChaliceSlackRequestHandler:
                     LocalLambdaClient,
                 )
 
-                lambda_client = LocalLambdaClient(self.chalice, None)
+                lambda_client = LocalLambdaClient(self.chalice, None)  # type: ignore[arg-type]
             except ImportError:
                 logging.info("Failed to load LocalLambdaClient for CLI mode.")
                 pass
@@ -50,7 +50,7 @@ class ChaliceSlackRequestHandler:
                 root.removeHandler(handler)
 
     def handle(self, request: Request):
-        body: str = request.raw_body.decode("utf-8") if request.raw_body else ""
+        body: str = request.raw_body.decode("utf-8") if request.raw_body else ""  # type: ignore[union-attr]
         self.logger.debug(f"Incoming request: {request.to_dict()}, body: {body}")
 
         method = request.method
@@ -72,7 +72,7 @@ class ChaliceSlackRequestHandler:
                     bolt_resp = oauth_flow.handle_installation(bolt_req)
                     return to_chalice_response(bolt_resp)
         elif method == "POST":
-            bolt_req: BoltRequest = to_bolt_request(request, body)
+            bolt_req = to_bolt_request(request, body)
             # https://docs.aws.amazon.com/lambda/latest/dg/python-context.html
             aws_lambda_function_name = self.chalice.lambda_context.function_name
             bolt_req.context["aws_lambda_function_name"] = aws_lambda_function_name
@@ -81,7 +81,7 @@ class ChaliceSlackRequestHandler:
             aws_response = to_chalice_response(bolt_resp)
             return aws_response
         elif method == "NONE":
-            bolt_req: BoltRequest = to_bolt_request(request, body)
+            bolt_req = to_bolt_request(request, body)
             bolt_resp = self.app.dispatch(bolt_req)
             aws_response = to_chalice_response(bolt_resp)
             return aws_response
@@ -92,8 +92,8 @@ class ChaliceSlackRequestHandler:
 def to_bolt_request(request: Request, body: str) -> BoltRequest:
     return BoltRequest(
         body=body,
-        query=request.query_params,
-        headers=request.headers,
+        query=request.query_params,  # type: ignore[arg-type]
+        headers=request.headers,  # type: ignore[arg-type]
     )
 
 
@@ -101,7 +101,7 @@ def to_chalice_response(resp: BoltResponse) -> Response:
     return Response(
         status_code=resp.status,
         body=resp.body,
-        headers=resp.first_headers(),
+        headers=resp.first_headers(),  # type: ignore[arg-type]
     )
 
 

--- a/slack_bolt/adapter/aws_lambda/chalice_handler.py
+++ b/slack_bolt/adapter/aws_lambda/chalice_handler.py
@@ -18,7 +18,7 @@ from slack_bolt.response import BoltResponse
 
 
 class ChaliceSlackRequestHandler:
-    def __init__(self, app: App, chalice: Chalice, lambda_client: Optional[BaseClient] = None):  # type: ignore
+    def __init__(self, app: App, chalice: Chalice, lambda_client: Optional[BaseClient] = None):
         self.app = app
         self.chalice = chalice
         self.logger = get_bolt_app_logger(app.name, ChaliceSlackRequestHandler, app.logger)

--- a/slack_bolt/adapter/aws_lambda/chalice_lazy_listener_runner.py
+++ b/slack_bolt/adapter/aws_lambda/chalice_lazy_listener_runner.py
@@ -2,8 +2,8 @@ import json
 from logging import Logger
 from typing import Callable, Optional
 
-import boto3
-from botocore.client import BaseClient
+import boto3  # type: ignore[import-untyped]
+from botocore.client import BaseClient  # type: ignore[import-untyped]
 
 from slack_bolt import BoltRequest
 from slack_bolt.lazy_listener import LazyListenerRunner
@@ -20,7 +20,7 @@ class ChaliceLazyListenerRunner(LazyListenerRunner):
 
         chalice_request: dict = request.context["chalice_request"]
         request.headers["x-slack-bolt-lazy-only"] = ["1"]
-        request.headers["x-slack-bolt-lazy-function-name"] = [request.lazy_function_name]
+        request.headers["x-slack-bolt-lazy-function-name"] = [request.lazy_function_name]  # type: ignore[list-item]
         payload = {
             "method": "NONE",
             "headers": {k: v[0] for k, v in request.headers.items()},

--- a/slack_bolt/adapter/aws_lambda/handler.py
+++ b/slack_bolt/adapter/aws_lambda/handler.py
@@ -12,7 +12,7 @@ from slack_bolt.response import BoltResponse
 
 
 class SlackRequestHandler:
-    def __init__(self, app: App):  # type: ignore
+    def __init__(self, app: App):
         self.app = app
         self.logger = get_bolt_app_logger(app.name, SlackRequestHandler, app.logger)
         self.app.listener_runner.lazy_listener_runner = LambdaLazyListenerRunner(self.logger)

--- a/slack_bolt/adapter/aws_lambda/lambda_s3_oauth_flow.py
+++ b/slack_bolt/adapter/aws_lambda/lambda_s3_oauth_flow.py
@@ -3,7 +3,7 @@ import os
 from logging import Logger
 from typing import Optional
 
-import boto3
+import boto3  # type: ignore[import-untyped]
 
 from slack_bolt.authorization.authorize import InstallationStoreAuthorize
 from slack_bolt.oauth import OAuthFlow

--- a/slack_bolt/adapter/aws_lambda/lazy_listener_runner.py
+++ b/slack_bolt/adapter/aws_lambda/lazy_listener_runner.py
@@ -2,7 +2,7 @@ import json
 from logging import Logger
 from typing import Callable, Optional, Any
 
-import boto3
+import boto3  # type: ignore[import-untyped]
 
 from slack_bolt import BoltRequest
 from slack_bolt.lazy_listener import LazyListenerRunner

--- a/slack_bolt/adapter/bottle/handler.py
+++ b/slack_bolt/adapter/bottle/handler.py
@@ -1,4 +1,4 @@
-from bottle import Request, Response
+from bottle import Request, Response  # type: ignore[import-untyped]
 
 from slack_bolt.app import App
 from slack_bolt.oauth import OAuthFlow
@@ -25,7 +25,7 @@ def set_response(bolt_resp: BoltResponse, resp: Response) -> None:
 
 
 class SlackRequestHandler:
-    def __init__(self, app: App):  # type: ignore
+    def __init__(self, app: App):
         self.app = app
 
     def handle(self, req: Request, resp: Response) -> str:
@@ -41,7 +41,7 @@ class SlackRequestHandler:
                     set_response(bolt_resp, resp)
                     return bolt_resp.body or ""
         elif req.method == "POST":
-            bolt_resp: BoltResponse = self.app.dispatch(to_bolt_request(req))
+            bolt_resp = self.app.dispatch(to_bolt_request(req))
             set_response(bolt_resp, resp)
             return bolt_resp.body or ""
 

--- a/slack_bolt/adapter/cherrypy/handler.py
+++ b/slack_bolt/adapter/cherrypy/handler.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-import cherrypy
+import cherrypy  # type: ignore[import-untyped]
 
 from slack_bolt.app import App
 from slack_bolt.oauth import OAuthFlow
@@ -55,7 +55,7 @@ def slack_in():
 
 
 class SlackRequestHandler:
-    def __init__(self, app: App):  # type: ignore
+    def __init__(self, app: App):
         self.app = app
 
     def handle(self) -> bytes:
@@ -73,7 +73,7 @@ class SlackRequestHandler:
                     set_response_status_and_headers(bolt_resp)
                     return (bolt_resp.body or "").encode("utf-8")
         elif req.method == "POST":
-            bolt_resp: BoltResponse = self.app.dispatch(build_bolt_request())
+            bolt_resp = self.app.dispatch(build_bolt_request())
             set_response_status_and_headers(bolt_resp)
             return (bolt_resp.body or "").encode("utf-8")
 

--- a/slack_bolt/adapter/django/handler.py
+++ b/slack_bolt/adapter/django/handler.py
@@ -3,7 +3,7 @@ from logging import Logger
 from threading import current_thread, Thread
 from typing import Optional, Callable
 
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse  # type: ignore[import-untyped]
 
 from slack_bolt.app import App
 from slack_bolt.error import BoltError
@@ -58,7 +58,7 @@ def to_django_response(bolt_resp: BoltResponse) -> HttpResponse:
     return resp
 
 
-from django.db import close_old_connections
+from django.db import close_old_connections  # type: ignore[import-untyped]
 
 
 def release_thread_local_connections(logger: Logger, execution_timing: str):
@@ -110,7 +110,7 @@ class DjangoThreadLazyListenerRunner(ThreadLazyListenerRunner):
 
 
 class SlackRequestHandler:
-    def __init__(self, app: App):  # type: ignore
+    def __init__(self, app: App):
         self.app = app
         listener_runner = self.app.listener_runner
         # This runner closes all thread-local connections in the thread when an execution completes
@@ -173,7 +173,7 @@ class SlackRequestHandler:
                     bolt_resp = oauth_flow.handle_callback(to_bolt_request(req))
                     return to_django_response(bolt_resp)
         elif req.method == "POST":
-            bolt_resp: BoltResponse = self.app.dispatch(to_bolt_request(req))
+            bolt_resp = self.app.dispatch(to_bolt_request(req))
             return to_django_response(bolt_resp)
 
         return HttpResponse(status=404, content=b"Not Found")

--- a/slack_bolt/adapter/falcon/async_resource.py
+++ b/slack_bolt/adapter/falcon/async_resource.py
@@ -1,8 +1,8 @@
-from datetime import datetime  # type: ignore
+from datetime import datetime
 from http import HTTPStatus
 
-from falcon import version as falcon_version
-from falcon.asgi import Request, Response
+from falcon import version as falcon_version  # type: ignore[import-untyped]
+from falcon.asgi import Request, Response  # type: ignore[import-untyped]
 from slack_bolt import BoltResponse
 from slack_bolt.async_app import AsyncApp
 from slack_bolt.error import BoltError
@@ -22,7 +22,7 @@ class AsyncSlackAppResource:
     app.add_route("/slack/events", AsyncSlackAppResource(app))
     """
 
-    def __init__(self, app: AsyncApp):  # type: ignore
+    def __init__(self, app: AsyncApp):
         if falcon_version.__version__.startswith("2."):
             raise BoltError("This ASGI compatible adapter requires Falcon version >= 3.0")
 

--- a/slack_bolt/adapter/falcon/resource.py
+++ b/slack_bolt/adapter/falcon/resource.py
@@ -1,7 +1,7 @@
-from datetime import datetime  # type: ignore
+from datetime import datetime
 from http import HTTPStatus
 
-from falcon import Request, Response, version as falcon_version
+from falcon import Request, Response, version as falcon_version  # type: ignore[import-untyped]
 
 from slack_bolt import BoltResponse
 from slack_bolt.app import App
@@ -19,7 +19,7 @@ class SlackAppResource:
     api.add_route("/slack/events", SlackAppResource(app))
     """
 
-    def __init__(self, app: App):  # type: ignore
+    def __init__(self, app: App):
         self.app = app
 
     def on_get(self, req: Request, resp: Response):

--- a/slack_bolt/adapter/flask/handler.py
+++ b/slack_bolt/adapter/flask/handler.py
@@ -7,11 +7,11 @@ from slack_bolt.response import BoltResponse
 
 
 def to_bolt_request(req: Request) -> BoltRequest:
-    return BoltRequest(  # type: ignore
+    return BoltRequest(
         body=req.get_data(as_text=True),
         query=req.query_string.decode("utf-8"),
-        headers=req.headers,  # type: ignore
-    )  # type: ignore
+        headers=req.headers,  # type: ignore[arg-type]
+    )
 
 
 def to_flask_response(bolt_resp: BoltResponse) -> Response:
@@ -26,7 +26,7 @@ def to_flask_response(bolt_resp: BoltResponse) -> Response:
 
 
 class SlackRequestHandler:
-    def __init__(self, app: App):  # type: ignore
+    def __init__(self, app: App):
         self.app = app
 
     def handle(self, req: Request) -> Response:
@@ -40,7 +40,7 @@ class SlackRequestHandler:
                     bolt_resp = oauth_flow.handle_callback(to_bolt_request(req))
                     return to_flask_response(bolt_resp)
         elif req.method == "POST":
-            bolt_resp: BoltResponse = self.app.dispatch(to_bolt_request(req))
+            bolt_resp = self.app.dispatch(to_bolt_request(req))
             return to_flask_response(bolt_resp)
 
         return make_response("Not Found", 404)

--- a/slack_bolt/adapter/google_cloud_functions/handler.py
+++ b/slack_bolt/adapter/google_cloud_functions/handler.py
@@ -7,7 +7,6 @@ from slack_bolt.app import App
 from slack_bolt.error import BoltError
 from slack_bolt.lazy_listener import LazyListenerRunner
 from slack_bolt.request import BoltRequest
-from slack_bolt.response import BoltResponse
 
 
 class NoopLazyListenerRunner(LazyListenerRunner):
@@ -20,7 +19,7 @@ class NoopLazyListenerRunner(LazyListenerRunner):
 
 
 class SlackRequestHandler:
-    def __init__(self, app: App):  # type: ignore
+    def __init__(self, app: App):
         self.app = app
         # Note that lazy listener is not supported
         self.app.listener_runner.lazy_listener_runner = NoopLazyListenerRunner()
@@ -37,7 +36,7 @@ class SlackRequestHandler:
                 bolt_resp = self.app.oauth_flow.handle_installation(bolt_req)
                 return to_flask_response(bolt_resp)
         elif req.method == "POST":
-            bolt_resp: BoltResponse = self.app.dispatch(to_bolt_request(req))
+            bolt_resp = self.app.dispatch(to_bolt_request(req))
             return to_flask_response(bolt_resp)
 
         return make_response("Not Found", 404)

--- a/slack_bolt/adapter/pyramid/handler.py
+++ b/slack_bolt/adapter/pyramid/handler.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple
 
-from pyramid.request import Request
-from pyramid.response import Response
+from pyramid.request import Request  # type: ignore[import-untyped]
+from pyramid.response import Response  # type: ignore[import-untyped]
 
 from slack_bolt import App, BoltRequest, BoltResponse
 from slack_bolt.oauth import OAuthFlow
@@ -37,7 +37,7 @@ def to_pyramid_response(bolt_resp: BoltResponse) -> Response:
 
 
 class SlackRequestHandler:
-    def __init__(self, app: App):  # type: ignore
+    def __init__(self, app: App):
         self.app = app
 
     def handle(self, request: Request) -> Response:

--- a/slack_bolt/adapter/sanic/async_handler.py
+++ b/slack_bolt/adapter/sanic/async_handler.py
@@ -1,4 +1,4 @@
-from datetime import datetime  # type: ignore
+from datetime import datetime
 
 from sanic.request import Request
 from sanic.response import HTTPResponse
@@ -12,7 +12,7 @@ def to_async_bolt_request(req: Request) -> AsyncBoltRequest:
     return AsyncBoltRequest(
         body=req.body.decode("utf-8"),
         query=req.query_string,
-        headers=req.headers,
+        headers=req.headers,  # type: ignore[arg-type]
     )
 
 
@@ -31,15 +31,15 @@ def to_sanic_response(bolt_resp: BoltResponse) -> HTTPResponse:
                 resp.cookies[name]["expires"] = expire
             resp.cookies[name]["path"] = c.get("path")
             resp.cookies[name]["domain"] = c.get("domain")
-            if c.get("max-age") is not None and len(c.get("max-age")) > 0:
-                resp.cookies[name]["max-age"] = int(c.get("max-age"))
+            if c.get("max-age") is not None and len(c.get("max-age")) > 0:  # type: ignore[arg-type]
+                resp.cookies[name]["max-age"] = int(c.get("max-age"))  # type: ignore[arg-type]
             resp.cookies[name]["secure"] = True
             resp.cookies[name]["httponly"] = True
     return resp
 
 
 class AsyncSlackRequestHandler:
-    def __init__(self, app: AsyncApp):  # type: ignore
+    def __init__(self, app: AsyncApp):
         self.app = app
 
     async def handle(self, req: Request) -> HTTPResponse:

--- a/slack_bolt/adapter/socket_mode/aiohttp/__init__.py
+++ b/slack_bolt/adapter/socket_mode/aiohttp/__init__.py
@@ -1,4 +1,5 @@
 """[`aiohttp`](https://pypi.org/project/aiohttp/) based implementation / asyncio compatible"""
+
 import os
 from logging import Logger
 from time import time
@@ -20,13 +21,13 @@ from slack_bolt.response import BoltResponse
 
 
 class SocketModeHandler(AsyncBaseSocketModeHandler):
-    app: App  # type: ignore
+    app: App
     app_token: str
     client: SocketModeClient
 
-    def __init__(  # type: ignore
+    def __init__(
         self,
-        app: App,  # type: ignore
+        app: App,
         app_token: Optional[str] = None,
         logger: Optional[Logger] = None,
         web_client: Optional[AsyncWebClient] = None,
@@ -48,26 +49,26 @@ class SocketModeHandler(AsyncBaseSocketModeHandler):
         self.client = SocketModeClient(
             app_token=self.app_token,
             logger=logger if logger is not None else app.logger,
-            web_client=web_client if web_client is not None else app.client,
+            web_client=web_client if web_client is not None else app.client,  # type: ignore[arg-type]
             proxy=proxy,
             ping_interval=ping_interval,
         )
-        self.client.socket_mode_request_listeners.append(self.handle)
+        self.client.socket_mode_request_listeners.append(self.handle)  # type: ignore[arg-type]
 
-    async def handle(self, client: SocketModeClient, req: SocketModeRequest) -> None:
+    async def handle(self, client: SocketModeClient, req: SocketModeRequest) -> None:  # type: ignore[override]
         start = time()
         bolt_resp: BoltResponse = run_bolt_app(self.app, req)
         await send_async_response(client, req, bolt_resp, start)
 
 
 class AsyncSocketModeHandler(AsyncBaseSocketModeHandler):
-    app: AsyncApp  # type: ignore
+    app: AsyncApp
     app_token: str
     client: SocketModeClient
 
-    def __init__(  # type: ignore
+    def __init__(
         self,
-        app: AsyncApp,  # type: ignore
+        app: AsyncApp,
         app_token: Optional[str] = None,
         logger: Optional[Logger] = None,
         web_client: Optional[AsyncWebClient] = None,
@@ -83,9 +84,9 @@ class AsyncSocketModeHandler(AsyncBaseSocketModeHandler):
             proxy=proxy,
             ping_interval=ping_interval,
         )
-        self.client.socket_mode_request_listeners.append(self.handle)
+        self.client.socket_mode_request_listeners.append(self.handle)  # type: ignore[arg-type]
 
-    async def handle(self, client: SocketModeClient, req: SocketModeRequest) -> None:
+    async def handle(self, client: SocketModeClient, req: SocketModeRequest) -> None:  # type: ignore[override]
         start = time()
         bolt_resp: BoltResponse = await run_async_bolt_app(self.app, req)
         await send_async_response(client, req, bolt_resp, start)

--- a/slack_bolt/adapter/socket_mode/async_base_handler.py
+++ b/slack_bolt/adapter/socket_mode/async_base_handler.py
@@ -1,4 +1,5 @@
 """The base class of asyncio-based Socket Mode client implementation"""
+
 import asyncio
 import logging
 from typing import Union
@@ -12,7 +13,7 @@ from slack_bolt.util.utils import get_boot_message
 
 
 class AsyncBaseSocketModeHandler:
-    app: Union[App, AsyncApp]  # type: ignore
+    app: Union[App, AsyncApp]
     client: AsyncBaseSocketModeClient
 
     async def handle(self, client: AsyncBaseSocketModeClient, req: SocketModeRequest) -> None:

--- a/slack_bolt/adapter/socket_mode/async_internals.py
+++ b/slack_bolt/adapter/socket_mode/async_internals.py
@@ -1,4 +1,5 @@
 """Internal functions"""
+
 import json
 import logging
 from time import time
@@ -12,7 +13,7 @@ from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 
 
-async def run_async_bolt_app(app: AsyncApp, req: SocketModeRequest):  # type: ignore
+async def run_async_bolt_app(app: AsyncApp, req: SocketModeRequest):
     bolt_req: AsyncBoltRequest = AsyncBoltRequest(mode="socket_mode", body=req.payload)
     bolt_resp: BoltResponse = await app.async_dispatch(bolt_req)
     return bolt_resp

--- a/slack_bolt/adapter/socket_mode/base_handler.py
+++ b/slack_bolt/adapter/socket_mode/base_handler.py
@@ -1,6 +1,7 @@
 """The base class of Socket Mode client implementation.
 If you want to build asyncio-based ones, use `AsyncBaseSocketModeHandler` instead.
 """
+
 import logging
 import signal
 import sys
@@ -14,7 +15,7 @@ from slack_bolt.util.utils import get_boot_message
 
 
 class BaseSocketModeHandler:
-    app: App  # type: ignore
+    app: App
     client: BaseSocketModeClient
 
     def handle(self, client: BaseSocketModeClient, req: SocketModeRequest) -> None:

--- a/slack_bolt/adapter/socket_mode/builtin/__init__.py
+++ b/slack_bolt/adapter/socket_mode/builtin/__init__.py
@@ -1,4 +1,5 @@
 """The built-in implementation, which does not have any external dependencies"""
+
 import os
 from logging import Logger
 from time import time
@@ -15,13 +16,13 @@ from slack_bolt.response import BoltResponse
 
 
 class SocketModeHandler(BaseSocketModeHandler):
-    app: App  # type: ignore
+    app: App
     app_token: str
     client: SocketModeClient
 
-    def __init__(  # type: ignore
+    def __init__(
         self,
-        app: App,  # type: ignore
+        app: App,
         app_token: Optional[str] = None,
         logger: Optional[Logger] = None,
         web_client: Optional[WebClient] = None,
@@ -68,9 +69,9 @@ class SocketModeHandler(BaseSocketModeHandler):
             receive_buffer_size=receive_buffer_size,
             concurrency=concurrency,
         )
-        self.client.socket_mode_request_listeners.append(self.handle)
+        self.client.socket_mode_request_listeners.append(self.handle)  # type: ignore[arg-type]
 
-    def handle(self, client: SocketModeClient, req: SocketModeRequest) -> None:
+    def handle(self, client: SocketModeClient, req: SocketModeRequest) -> None:  # type: ignore[override]
         start = time()
         bolt_resp: BoltResponse = run_bolt_app(self.app, req)
         send_response(client, req, bolt_resp, start)

--- a/slack_bolt/adapter/socket_mode/internals.py
+++ b/slack_bolt/adapter/socket_mode/internals.py
@@ -1,4 +1,5 @@
 """Internal functions"""
+
 import json
 import logging
 from time import time
@@ -12,7 +13,7 @@ from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 
 
-def run_bolt_app(app: App, req: SocketModeRequest):  # type: ignore
+def run_bolt_app(app: App, req: SocketModeRequest):
     bolt_req: BoltRequest = BoltRequest(mode="socket_mode", body=req.payload)
     bolt_resp: BoltResponse = app.dispatch(bolt_req)
     return bolt_resp

--- a/slack_bolt/adapter/socket_mode/websocket_client/__init__.py
+++ b/slack_bolt/adapter/socket_mode/websocket_client/__init__.py
@@ -1,4 +1,5 @@
 """[`websocket-client`](https://pypi.org/project/websocket-client/) based implementation"""
+
 import os
 from logging import Logger
 from time import time
@@ -15,13 +16,13 @@ from slack_bolt.response import BoltResponse
 
 
 class SocketModeHandler(BaseSocketModeHandler):
-    app: App  # type: ignore
+    app: App
     app_token: str
     client: SocketModeClient
 
-    def __init__(  # type: ignore
+    def __init__(
         self,
-        app: App,  # type: ignore
+        app: App,
         app_token: Optional[str] = None,
         logger: Optional[Logger] = None,
         web_client: Optional[WebClient] = None,
@@ -62,9 +63,9 @@ class SocketModeHandler(BaseSocketModeHandler):
             proxy_type=proxy_type,
             trace_enabled=trace_enabled,
         )
-        self.client.socket_mode_request_listeners.append(self.handle)
+        self.client.socket_mode_request_listeners.append(self.handle)  # type: ignore[arg-type]
 
-    def handle(self, client: SocketModeClient, req: SocketModeRequest) -> None:
+    def handle(self, client: SocketModeClient, req: SocketModeRequest) -> None:  # type: ignore[override]
         start = time()
         bolt_resp: BoltResponse = run_bolt_app(self.app, req)
         send_response(client, req, bolt_resp, start)

--- a/slack_bolt/adapter/socket_mode/websockets/__init__.py
+++ b/slack_bolt/adapter/socket_mode/websockets/__init__.py
@@ -1,4 +1,5 @@
 """[`websockets`](https://pypi.org/project/websockets/) based implementation  / asyncio compatible"""
+
 import os
 from logging import Logger
 from time import time
@@ -20,13 +21,13 @@ from slack_bolt.response import BoltResponse
 
 
 class SocketModeHandler(AsyncBaseSocketModeHandler):
-    app: App  # type: ignore
+    app: App
     app_token: str
     client: SocketModeClient
 
-    def __init__(  # type: ignore
+    def __init__(
         self,
-        app: App,  # type: ignore
+        app: App,
         app_token: Optional[str] = None,
         logger: Optional[Logger] = None,
         web_client: Optional[AsyncWebClient] = None,
@@ -50,25 +51,25 @@ class SocketModeHandler(AsyncBaseSocketModeHandler):
         self.client = SocketModeClient(
             app_token=self.app_token,
             logger=logger if logger is not None else app.logger,
-            web_client=web_client if web_client is not None else app.client,
+            web_client=web_client if web_client is not None else app.client,  # type: ignore[arg-type]
             ping_interval=ping_interval,
         )
-        self.client.socket_mode_request_listeners.append(self.handle)
+        self.client.socket_mode_request_listeners.append(self.handle)  # type: ignore[arg-type]
 
-    async def handle(self, client: SocketModeClient, req: SocketModeRequest) -> None:
+    async def handle(self, client: SocketModeClient, req: SocketModeRequest) -> None:  # type: ignore[override]
         start = time()
         bolt_resp: BoltResponse = run_bolt_app(self.app, req)
         await send_async_response(client, req, bolt_resp, start)
 
 
 class AsyncSocketModeHandler(AsyncBaseSocketModeHandler):
-    app: AsyncApp  # type: ignore
+    app: AsyncApp
     app_token: str
     client: SocketModeClient
 
-    def __init__(  # type: ignore
+    def __init__(
         self,
-        app: AsyncApp,  # type: ignore
+        app: AsyncApp,
         app_token: Optional[str] = None,
         logger: Optional[Logger] = None,
         web_client: Optional[AsyncWebClient] = None,
@@ -82,9 +83,9 @@ class AsyncSocketModeHandler(AsyncBaseSocketModeHandler):
             web_client=web_client if web_client is not None else app.client,
             ping_interval=ping_interval,
         )
-        self.client.socket_mode_request_listeners.append(self.handle)
+        self.client.socket_mode_request_listeners.append(self.handle)  # type: ignore[arg-type]
 
-    async def handle(self, client: SocketModeClient, req: SocketModeRequest) -> None:
+    async def handle(self, client: SocketModeClient, req: SocketModeRequest) -> None:  # type: ignore[override]
         start = time()
         bolt_resp: BoltResponse = await run_async_bolt_app(self.app, req)
         await send_async_response(client, req, bolt_resp, start)

--- a/slack_bolt/adapter/starlette/async_handler.py
+++ b/slack_bolt/adapter/starlette/async_handler.py
@@ -15,8 +15,8 @@ def to_async_bolt_request(
 ) -> AsyncBoltRequest:
     request = AsyncBoltRequest(
         body=body.decode("utf-8"),
-        query=req.query_params,
-        headers=req.headers,
+        query=req.query_params,  # type: ignore[arg-type]
+        headers=req.headers,  # type: ignore[arg-type]
     )
     if addition_context_properties is not None:
         for k, v in addition_context_properties.items():
@@ -37,7 +37,7 @@ def to_starlette_response(bolt_resp: BoltResponse) -> Response:
                 value=c.value,
                 max_age=c.get("max-age"),
                 expires=c.get("expires"),
-                path=c.get("path"),
+                path=c.get("path"),  # type: ignore[arg-type]
                 domain=c.get("domain"),
                 secure=True,
                 httponly=True,
@@ -46,7 +46,7 @@ def to_starlette_response(bolt_resp: BoltResponse) -> Response:
 
 
 class AsyncSlackRequestHandler:
-    def __init__(self, app: AsyncApp):  # type: ignore
+    def __init__(self, app: AsyncApp):
         self.app = app
 
     async def handle(self, req: Request, addition_context_properties: Optional[Dict[str, Any]] = None) -> Response:

--- a/slack_bolt/adapter/starlette/async_handler.py
+++ b/slack_bolt/adapter/starlette/async_handler.py
@@ -37,7 +37,7 @@ def to_starlette_response(bolt_resp: BoltResponse) -> Response:
                 value=c.value,
                 max_age=c.get("max-age"),
                 expires=c.get("expires"),
-                path=c.get("path"),  # type: ignore[arg-type]
+                path=c.get("path"),
                 domain=c.get("domain"),
                 secure=True,
                 httponly=True,

--- a/slack_bolt/adapter/starlette/handler.py
+++ b/slack_bolt/adapter/starlette/handler.py
@@ -14,8 +14,8 @@ def to_bolt_request(
 ) -> BoltRequest:
     request = BoltRequest(
         body=body.decode("utf-8"),
-        query=req.query_params,
-        headers=req.headers,
+        query=req.query_params,  # type: ignore[arg-type]
+        headers=req.headers,  # type: ignore[arg-type]
     )
     if addition_context_properties is not None:
         for k, v in addition_context_properties.items():
@@ -36,7 +36,7 @@ def to_starlette_response(bolt_resp: BoltResponse) -> Response:
                 value=c.value,
                 max_age=c.get("max-age"),
                 expires=c.get("expires"),
-                path=c.get("path"),
+                path=c.get("path"),  # type: ignore[arg-type]
                 domain=c.get("domain"),
                 secure=True,
                 httponly=True,
@@ -45,7 +45,7 @@ def to_starlette_response(bolt_resp: BoltResponse) -> Response:
 
 
 class SlackRequestHandler:
-    def __init__(self, app: App):  # type: ignore
+    def __init__(self, app: App):
         self.app = app
 
     async def handle(self, req: Request, addition_context_properties: Optional[Dict[str, Any]] = None) -> Response:

--- a/slack_bolt/adapter/starlette/handler.py
+++ b/slack_bolt/adapter/starlette/handler.py
@@ -36,7 +36,7 @@ def to_starlette_response(bolt_resp: BoltResponse) -> Response:
                 value=c.value,
                 max_age=c.get("max-age"),
                 expires=c.get("expires"),
-                path=c.get("path"),  # type: ignore[arg-type]
+                path=c.get("path"),
                 domain=c.get("domain"),
                 secure=True,
                 httponly=True,

--- a/slack_bolt/adapter/tornado/async_handler.py
+++ b/slack_bolt/adapter/tornado/async_handler.py
@@ -9,7 +9,7 @@ from .handler import set_response
 
 
 class AsyncSlackEventsHandler(RequestHandler):
-    def initialize(self, app: AsyncApp):  # type: ignore
+    def initialize(self, app: AsyncApp):
         self.app = app
 
     async def post(self):
@@ -19,12 +19,12 @@ class AsyncSlackEventsHandler(RequestHandler):
 
 
 class AsyncSlackOAuthHandler(RequestHandler):
-    def initialize(self, app: AsyncApp):  # type: ignore
+    def initialize(self, app: AsyncApp):
         self.app = app
 
     async def get(self):
-        if self.app.oauth_flow is not None:  # type: ignore
-            oauth_flow: AsyncOAuthFlow = self.app.oauth_flow  # type: ignore
+        if self.app.oauth_flow is not None:
+            oauth_flow: AsyncOAuthFlow = self.app.oauth_flow
             if self.request.path == oauth_flow.install_path:
                 bolt_resp = await oauth_flow.handle_installation(to_async_bolt_request(self.request))
                 set_response(self, bolt_resp)
@@ -40,5 +40,5 @@ def to_async_bolt_request(req: HTTPServerRequest) -> AsyncBoltRequest:
     return AsyncBoltRequest(
         body=req.body.decode("utf-8") if req.body else "",
         query=req.query,
-        headers=req.headers,
+        headers=req.headers,  # type: ignore[arg-type]
     )

--- a/slack_bolt/adapter/tornado/handler.py
+++ b/slack_bolt/adapter/tornado/handler.py
@@ -1,4 +1,4 @@
-from datetime import datetime  # type: ignore
+from datetime import datetime
 
 from tornado.httputil import HTTPServerRequest
 from tornado.web import RequestHandler
@@ -10,7 +10,7 @@ from slack_bolt.response import BoltResponse
 
 
 class SlackEventsHandler(RequestHandler):
-    def initialize(self, app: App):  # type: ignore
+    def initialize(self, app: App):
         self.app = app
 
     def post(self):
@@ -20,12 +20,12 @@ class SlackEventsHandler(RequestHandler):
 
 
 class SlackOAuthHandler(RequestHandler):
-    def initialize(self, app: App):  # type: ignore
+    def initialize(self, app: App):
         self.app = app
 
     def get(self):
-        if self.app.oauth_flow is not None:  # type: ignore
-            oauth_flow: OAuthFlow = self.app.oauth_flow  # type: ignore
+        if self.app.oauth_flow is not None:
+            oauth_flow: OAuthFlow = self.app.oauth_flow
             if self.request.path == oauth_flow.install_path:
                 bolt_resp = oauth_flow.handle_installation(to_bolt_request(self.request))
                 set_response(self, bolt_resp)
@@ -41,7 +41,7 @@ def to_bolt_request(req: HTTPServerRequest) -> BoltRequest:
     return BoltRequest(
         body=req.body.decode("utf-8") if req.body else "",
         query=req.query,
-        headers=req.headers,
+        headers=req.headers,  # type: ignore[arg-type]
     )
 
 

--- a/slack_bolt/adapter/wsgi/handler.py
+++ b/slack_bolt/adapter/wsgi/handler.py
@@ -3,7 +3,6 @@ from typing import Any, Callable, Dict, Iterable, List, Tuple
 from slack_bolt import App
 from slack_bolt.adapter.wsgi.http_request import WsgiHttpRequest
 from slack_bolt.adapter.wsgi.http_response import WsgiHttpResponse
-from slack_bolt.oauth.oauth_flow import OAuthFlow
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 
@@ -41,14 +40,12 @@ class SlackRequestHandler:
         )
 
     def handle_installation(self, request: WsgiHttpRequest) -> BoltResponse:
-        oauth_flow: OAuthFlow = self.app.oauth_flow
-        return oauth_flow.handle_installation(
+        return self.app.oauth_flow.handle_installation(  # type: ignore[union-attr]
             BoltRequest(body=request.get_body(), query=request.query_string, headers=request.get_headers())
         )
 
     def handle_callback(self, request: WsgiHttpRequest) -> BoltResponse:
-        oauth_flow: OAuthFlow = self.app.oauth_flow
-        return oauth_flow.handle_callback(
+        return self.app.oauth_flow.handle_callback(  # type: ignore[union-attr]
             BoltRequest(body=request.get_body(), query=request.query_string, headers=request.get_headers())
         )
 
@@ -56,17 +53,17 @@ class SlackRequestHandler:
         if request.method == "GET":
             if self.app.oauth_flow is not None:
                 if request.path == self.app.oauth_flow.install_path:
-                    bolt_response: BoltResponse = self.handle_installation(request)
+                    bolt_response = self.handle_installation(request)
                     return WsgiHttpResponse(
                         status=bolt_response.status, headers=bolt_response.headers, body=bolt_response.body
                     )
-                if request.path == self.app.oauth_flow.redirect_uri_path:
-                    bolt_response: BoltResponse = self.handle_callback(request)
+                elif request.path == self.app.oauth_flow.redirect_uri_path:
+                    bolt_response = self.handle_callback(request)
                     return WsgiHttpResponse(
                         status=bolt_response.status, headers=bolt_response.headers, body=bolt_response.body
                     )
         if request.method == "POST" and request.path == self.path:
-            bolt_response: BoltResponse = self.dispatch(request)
+            bolt_response = self.dispatch(request)
             return WsgiHttpResponse(status=bolt_response.status, headers=bolt_response.headers, body=bolt_response.body)
         return WsgiHttpResponse(status=404, headers={"content-type": ["text/plain;charset=utf-8"]}, body="Not Found")
 

--- a/slack_bolt/adapter/wsgi/http_request.py
+++ b/slack_bolt/adapter/wsgi/http_request.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Sequence, Union
 
 from .internals import ENCODING
 
@@ -19,7 +19,7 @@ class WsgiHttpRequest:
         self.protocol: str = environ.get("SERVER_PROTOCOL", "")
         self.environ = environ
 
-    def get_headers(self) -> Dict[str, str]:
+    def get_headers(self) -> Dict[str, Union[str, Sequence[str]]]:
         headers = {}
         for key, value in self.environ.items():
             if key in {"CONTENT_LENGTH", "CONTENT_TYPE"}:

--- a/slack_bolt/app/__init__.py
+++ b/slack_bolt/app/__init__.py
@@ -7,7 +7,7 @@ you can use `slack_bolt.app.async_app` for building async apps.\
 """
 
 # Don't add async module imports here
-from .app import App  # type: ignore
+from .app import App
 
 __all__ = [
     "App",

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -38,6 +38,7 @@ from slack_bolt.listener_matcher import builtins as builtin_matchers
 from slack_bolt.listener_matcher.listener_matcher import ListenerMatcher
 from slack_bolt.logger import get_bolt_app_logger, get_bolt_logger
 from slack_bolt.logger.messages import (
+    error_oauth_flow_or_authorize_required,
     warning_client_prioritized_and_token_skipped,
     warning_token_skipped,
     error_auth_test_failure,
@@ -427,7 +428,7 @@ class App:
                 )
             )
         else:
-            raise BoltError("OAuthFlow or Authorize must be configured to make a Bolt app")
+            raise BoltError(error_oauth_flow_or_authorize_required())
 
         if ignoring_self_events_enabled is True:
             self._middleware_list.append(IgnoringSelfEvents(base_logger=self._base_logger))

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -109,7 +109,7 @@ class App:
         user_facing_authorize_error_message: Optional[str] = None,
         installation_store: Optional[InstallationStore] = None,
         # for either only bot scope usage or v1.0.x compatibility
-        installation_store_bot_only: bool = False,
+        installation_store_bot_only: Optional[bool] = None,
         # for customizing the built-in middleware
         request_verification_enabled: bool = True,
         ignoring_self_events_enabled: bool = True,
@@ -260,7 +260,7 @@ class App:
                 client_id=settings.client_id if settings is not None else None,
                 client_secret=settings.client_secret if settings is not None else None,
                 logger=self._framework_logger,
-                bot_only=installation_store_bot_only,
+                bot_only=installation_store_bot_only or False,
                 client=self._client,  # for proxy use cases etc.
                 user_token_resolution=(settings.user_token_resolution if settings is not None else "authed_user"),
             )
@@ -315,7 +315,7 @@ class App:
             self._framework_logger.warning(warning_token_skipped())
 
         # after setting bot_only here, __init__ cannot replace authorize function
-        if installation_store_bot_only is not False and self._oauth_flow is not None:
+        if installation_store_bot_only is not None and self._oauth_flow is not None:
             app_bot_only = installation_store_bot_only or False
             oauth_flow_bot_only = self._oauth_flow.settings.installation_store_bot_only
             if app_bot_only != oauth_flow_bot_only:

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -426,6 +426,9 @@ class App:
                     user_facing_authorize_error_message=user_facing_authorize_error_message,
                 )
             )
+        else:
+            raise BoltError("OAuthFlow or Authorize must be configured to make a Bolt app")
+
         if ignoring_self_events_enabled is True:
             self._middleware_list.append(IgnoringSelfEvents(base_logger=self._base_logger))
         if url_verification_enabled is True:

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -44,6 +44,7 @@ from slack_bolt.authorization.async_authorize import (
 )
 from slack_bolt.error import BoltError, BoltUnhandledRequestError
 from slack_bolt.logger.messages import (
+    error_oauth_flow_or_authorize_required,
     warning_client_prioritized_and_token_skipped,
     warning_token_skipped,
     error_token_required,
@@ -426,7 +427,7 @@ class AsyncApp:
                 )
             )
         else:
-            raise BoltError("OAuthFlow or Authorize must be configured to make a Bolt app")
+            raise BoltError(error_oauth_flow_or_authorize_required())
 
         if ignoring_self_events_enabled is True:
             self._async_middleware_list.append(AsyncIgnoringSelfEvents(base_logger=self._base_logger))

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -120,7 +120,7 @@ class AsyncApp:
         user_facing_authorize_error_message: Optional[str] = None,
         installation_store: Optional[AsyncInstallationStore] = None,
         # for either only bot scope usage or v1.0.x compatibility
-        installation_store_bot_only: bool = False,
+        installation_store_bot_only: Optional[bool] = None,
         # for customizing the built-in middleware
         request_verification_enabled: bool = True,
         ignoring_self_events_enabled: bool = True,
@@ -265,7 +265,7 @@ class AsyncApp:
                 client_id=settings.client_id if settings is not None else None,
                 client_secret=settings.client_secret if settings is not None else None,
                 logger=self._framework_logger,
-                bot_only=installation_store_bot_only,
+                bot_only=installation_store_bot_only or False,
                 client=self._async_client,  # for proxy use cases etc.
                 user_token_resolution=(settings.user_token_resolution if settings is not None else "authed_user"),
             )
@@ -327,7 +327,7 @@ class AsyncApp:
             self._framework_logger.warning(warning_token_skipped())
 
         # after setting bot_only here, __init__ cannot replace authorize function
-        if installation_store_bot_only is not False and self._async_oauth_flow is not None:
+        if installation_store_bot_only is not None and self._async_oauth_flow is not None:
             app_bot_only = installation_store_bot_only or False
             oauth_flow_bot_only = self._async_oauth_flow.settings.installation_store_bot_only
             if app_bot_only != oauth_flow_bot_only:

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -425,6 +425,8 @@ class AsyncApp:
                     user_facing_authorize_error_message=user_facing_authorize_error_message,
                 )
             )
+        else:
+            raise BoltError("OAuthFlow or Authorize must be configured to make a Bolt app")
 
         if ignoring_self_events_enabled is True:
             self._async_middleware_list.append(AsyncIgnoringSelfEvents(base_logger=self._base_logger))

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -589,10 +589,7 @@ class AsyncApp:
                 self._framework_logger.debug(debug_checking_listener(listener_name))
                 if await listener.async_matches(req=req, resp=resp):  # type: ignore[arg-type]
                     # run all the middleware attached to this listener first
-                    (
-                        middleware_resp,
-                        next_was_not_called,
-                    ) = await listener.run_async_middleware(
+                    (middleware_resp, next_was_not_called) = await listener.run_async_middleware(
                         req=req, resp=resp  # type: ignore[arg-type]
                     )
                     if next_was_not_called:

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -19,6 +19,7 @@ from slack_bolt.listener.asyncio_runner import AsyncioListenerRunner  # type: ig
 from slack_bolt.middleware.async_middleware_error_handler import (
     AsyncCustomMiddlewareErrorHandler,
     AsyncDefaultMiddlewareErrorHandler,
+    AsyncMiddlewareErrorHandler,
 )
 from slack_bolt.middleware.message_listener_matches.async_message_listener_matches import (
     AsyncMessageListenerMatches,
@@ -119,7 +120,7 @@ class AsyncApp:
         user_facing_authorize_error_message: Optional[str] = None,
         installation_store: Optional[AsyncInstallationStore] = None,
         # for either only bot scope usage or v1.0.x compatibility
-        installation_store_bot_only: Optional[bool] = None,
+        installation_store_bot_only: bool = False,
         # for customizing the built-in middleware
         request_verification_enabled: bool = True,
         ignoring_self_events_enabled: bool = True,
@@ -197,7 +198,8 @@ class AsyncApp:
             oauth_flow: Instantiated `slack_bolt.oauth.AsyncOAuthFlow`. This is always prioritized over oauth_settings.
             verification_token: Deprecated verification mechanism. This can used only for ssl_check requests.
         """
-        signing_secret = signing_secret or os.environ.get("SLACK_SIGNING_SECRET", "")
+        if signing_secret is None:
+            signing_secret = os.environ.get("SLACK_SIGNING_SECRET", "")
         token = token or os.environ.get("SLACK_BOT_TOKEN")
 
         self._name: str = name or inspect.stack()[1].filename.split(os.path.sep)[-1]
@@ -233,7 +235,7 @@ class AsyncApp:
 
         self._async_before_authorize: Optional[AsyncMiddleware] = None
         if before_authorize is not None:
-            if isinstance(before_authorize, Callable):
+            if callable(before_authorize):
                 self._async_before_authorize = AsyncCustomMiddleware(
                     app_name=self._name,
                     func=before_authorize,
@@ -294,7 +296,8 @@ class AsyncApp:
                 logger=self._framework_logger,
             )
             self._async_installation_store = installation_store
-            self._async_oauth_flow.settings.installation_store = installation_store
+            if installation_store is not None:
+                self._async_oauth_flow.settings.installation_store = installation_store
 
             if self._async_oauth_flow._async_client is None:
                 self._async_oauth_flow._async_client = self._async_client
@@ -311,25 +314,26 @@ class AsyncApp:
                 logger=self._framework_logger,
             )
             self._async_installation_store = installation_store
-            oauth_settings.installation_store = installation_store
+            if installation_store is not None:
+                oauth_settings.installation_store = installation_store
 
             self._async_oauth_flow = AsyncOAuthFlow(client=self._async_client, logger=self.logger, settings=oauth_settings)
             if self._async_authorize is None:
                 self._async_authorize = self._async_oauth_flow.settings.authorize
-            self._async_authorize.token_rotation_expiration_minutes = oauth_settings.token_rotation_expiration_minutes
+            self._async_authorize.token_rotation_expiration_minutes = oauth_settings.token_rotation_expiration_minutes  # type: ignore[attr-defined] # noqa: E501
 
         if (self._async_installation_store is not None or self._async_authorize is not None) and self._token is not None:
             self._token = None
             self._framework_logger.warning(warning_token_skipped())
 
         # after setting bot_only here, __init__ cannot replace authorize function
-        if installation_store_bot_only is not None and self._async_oauth_flow is not None:
+        if installation_store_bot_only is not False and self._async_oauth_flow is not None:
             app_bot_only = installation_store_bot_only or False
             oauth_flow_bot_only = self._async_oauth_flow.settings.installation_store_bot_only
             if app_bot_only != oauth_flow_bot_only:
                 self.logger.warning(warning_bot_only_conflicts())
                 self._async_oauth_flow.settings.installation_store_bot_only = app_bot_only
-                self._async_authorize.bot_only = app_bot_only
+                self._async_authorize.bot_only = app_bot_only  # type: ignore[union-attr]
 
         self._async_tokens_revocation_listeners: Optional[AsyncTokenRevocationListeners] = None
         if self._async_installation_store is not None:
@@ -353,7 +357,7 @@ class AsyncApp:
                 logger=self._framework_logger,
             ),
         )
-        self._async_middleware_error_handler = AsyncDefaultMiddlewareErrorHandler(
+        self._async_middleware_error_handler: AsyncMiddlewareErrorHandler = AsyncDefaultMiddlewareErrorHandler(
             logger=self._framework_logger,
         )
 
@@ -412,7 +416,7 @@ class AsyncApp:
                 )
             else:
                 raise BoltError(error_token_required())
-        else:
+        elif self._async_authorize is not None:
             self._async_middleware_list.append(
                 AsyncMultiTeamsAuthorization(
                     authorize=self._async_authorize,
@@ -554,7 +558,9 @@ class AsyncApp:
                 middleware_state["next_called"] = False
                 if self._framework_logger.level <= logging.DEBUG:
                     self._framework_logger.debug(f"Applying {middleware.name}")
-                resp = await middleware.async_process(req=req, resp=resp, next=async_middleware_next)
+                resp = await middleware.async_process(
+                    req=req, resp=resp, next=async_middleware_next  # type: ignore[arg-type]
+                )
                 if not middleware_state["next_called"]:
                     if resp is None:
                         # next() method was not called without providing the response to return to Slack
@@ -581,12 +587,14 @@ class AsyncApp:
             for listener in self._async_listeners:
                 listener_name = get_name_for_callable(listener.ack_function)
                 self._framework_logger.debug(debug_checking_listener(listener_name))
-                if await listener.async_matches(req=req, resp=resp):
+                if await listener.async_matches(req=req, resp=resp):  # type: ignore[arg-type]
                     # run all the middleware attached to this listener first
                     (
                         middleware_resp,
                         next_was_not_called,
-                    ) = await listener.run_async_middleware(req=req, resp=resp)
+                    ) = await listener.run_async_middleware(
+                        req=req, resp=resp  # type: ignore[arg-type]
+                    )
                     if next_was_not_called:
                         if middleware_resp is not None:
                             if self._framework_logger.level <= logging.DEBUG:
@@ -608,7 +616,7 @@ class AsyncApp:
                     self._framework_logger.debug(debug_running_listener(listener_name))
                     listener_response: Optional[BoltResponse] = await self._async_listener_runner.run(
                         request=req,
-                        response=resp,
+                        response=resp,  # type: ignore[arg-type]
                         listener_name=listener_name,
                         listener=listener,
                     )
@@ -675,7 +683,7 @@ class AsyncApp:
             if isinstance(middleware_or_callable, AsyncMiddleware):
                 middleware: AsyncMiddleware = middleware_or_callable
                 self._async_middleware_list.append(middleware)
-            elif isinstance(middleware_or_callable, Callable):
+            elif callable(middleware_or_callable):
                 self._async_middleware_list.append(
                     AsyncCustomMiddleware(
                         app_name=self.name,
@@ -743,9 +751,9 @@ class AsyncApp:
         if isinstance(callback_id, (str, Pattern)):
             step = AsyncWorkflowStep(
                 callback_id=callback_id,
-                edit=edit,
-                save=save,
-                execute=execute,
+                edit=edit,  # type: ignore[arg-type]
+                save=save,  # type: ignore[arg-type]
+                execute=execute,  # type: ignore[arg-type]
                 base_logger=self._base_logger,
             )
         elif isinstance(step, AsyncWorkflowStepBuilder):
@@ -1376,9 +1384,9 @@ class AsyncApp:
             trust_env_in_session=self._async_client.trust_env_in_session,
             headers=self._async_client.headers,
             team_id=req.context.team_id,
-            retry_handlers=self._async_client.retry_handlers.copy()
-            if self._async_client.retry_handlers is not None
-            else None,
+            retry_handlers=(
+                self._async_client.retry_handlers.copy() if self._async_client.retry_handlers is not None else None
+            ),
         )
         req.context["client"] = client_per_request
 
@@ -1414,7 +1422,7 @@ class AsyncApp:
                 name = get_name_for_callable(func)
                 raise BoltError(error_listener_function_must_be_coro_func(name))
 
-        listener_matchers = [
+        listener_matchers: List[AsyncListenerMatcher] = [
             AsyncCustomListenerMatcher(app_name=self.name, func=f, base_logger=self._base_logger) for f in (matchers or [])
         ]
         listener_matchers.insert(0, primary_matcher)
@@ -1422,7 +1430,7 @@ class AsyncApp:
         for m in middleware or []:
             if isinstance(m, AsyncMiddleware):
                 listener_middleware.append(m)
-            elif isinstance(m, Callable) and inspect.iscoroutinefunction(m):
+            elif callable(m) and inspect.iscoroutinefunction(m):
                 listener_middleware.append(AsyncCustomMiddleware(app_name=self.name, func=m, base_logger=self._base_logger))
             else:
                 raise ValueError(error_unexpected_listener_middleware(type(m)))

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -15,7 +15,7 @@ from slack_bolt.listener.async_listener_start_handler import (
 from slack_bolt.listener.async_listener_completion_handler import (
     AsyncDefaultListenerCompletionHandler,
 )
-from slack_bolt.listener.asyncio_runner import AsyncioListenerRunner  # type: ignore
+from slack_bolt.listener.asyncio_runner import AsyncioListenerRunner
 from slack_bolt.middleware.async_middleware_error_handler import (
     AsyncCustomMiddlewareErrorHandler,
     AsyncDefaultMiddlewareErrorHandler,

--- a/slack_bolt/app/async_server.py
+++ b/slack_bolt/app/async_server.py
@@ -12,14 +12,14 @@ class AsyncSlackAppServer:
     port: int
     path: str
     host: str
-    bolt_app: "AsyncApp"  # type:ignore
+    bolt_app: "AsyncApp"  # type: ignore[name-defined]
     web_app: web.Application
 
-    def __init__(  # type:ignore
+    def __init__(
         self,
         port: int,
         path: str,
-        app: "AsyncApp",  # type:ignore
+        app: "AsyncApp",  # type: ignore[name-defined]
         host: Optional[str] = None,
     ):
         """Standalone AIOHTTP Web Server.
@@ -34,7 +34,7 @@ class AsyncSlackAppServer:
         self.port = port
         self.path = path
         self.host = host if host is not None else "0.0.0.0"
-        self.bolt_app: "AsyncApp" = app  # type: ignore
+        self.bolt_app: "AsyncApp" = app  # type: ignore[name-defined]
         self.web_app = web.Application()
         self._bolt_oauth_flow = self.bolt_app.oauth_flow
         if self._bolt_oauth_flow:

--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -1,5 +1,5 @@
 from logging import Logger
-from typing import Optional, Callable, Awaitable, Dict, Any, List
+from typing import Optional, Callable, Awaitable, Dict, Any, Sequence
 
 from slack_sdk.errors import SlackApiError, SlackTokenRotationError
 from slack_sdk.oauth.installation_store import Bot, Installation
@@ -82,9 +82,7 @@ class AsyncCallableAuthorize(AsyncAuthorize):
                 if k not in all_available_args:
                     all_available_args[k] = v
 
-            kwargs: Dict[str, Any] = {  # type: ignore
-                k: v for k, v in all_available_args.items() if k in self.arg_names  # type: ignore
-            }
+            kwargs: Dict[str, Any] = {k: v for k, v in all_available_args.items() if k in self.arg_names}
             found_arg_names = kwargs.keys()
             for name in self.arg_names:
                 if name not in found_arg_names:
@@ -176,8 +174,8 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
 
         bot_token: Optional[str] = None
         user_token: Optional[str] = None
-        bot_scopes: Optional[List[str]] = None
-        user_scopes: Optional[List[str]] = None
+        bot_scopes: Optional[Sequence[str]] = None
+        user_scopes: Optional[Sequence[str]] = None
         latest_bot_installation: Optional[Installation] = None
         this_user_installation: Optional[Installation] = None
 
@@ -303,14 +301,14 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
                         # Token rotation
                         if self.token_rotator is None:
                             raise BoltError(self._config_error_message)
-                        refreshed = await self.token_rotator.perform_bot_token_rotation(
+                        refreshed_bot = await self.token_rotator.perform_bot_token_rotation(
                             bot=bot,
                             minutes_before_expiration=self.token_rotation_expiration_minutes,
                         )
-                        if refreshed is not None:
-                            await self.installation_store.async_save_bot(refreshed)
-                            bot_token = refreshed.bot_token
-                            bot_scopes = refreshed.bot_scopes
+                        if refreshed_bot is not None:
+                            await self.installation_store.async_save_bot(refreshed_bot)
+                            bot_token = refreshed_bot.bot_token
+                            bot_scopes = refreshed_bot.bot_scopes
 
             except SlackTokenRotationError as rotation_error:
                 # When token rotation fails, it is usually unrecoverable
@@ -333,13 +331,13 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
             return self.authorize_result_cache[token]
 
         try:
-            auth_test_api_response = await context.client.auth_test(token=token)
+            auth_test_api_response = await context.client.auth_test(token=token)  # type: ignore[union-attr]
             user_auth_test_response = None
             if user_token is not None and token != user_token:
-                user_auth_test_response = await context.client.auth_test(token=user_token)
+                user_auth_test_response = await context.client.auth_test(token=user_token)  # type: ignore[union-attr]
             authorize_result = AuthorizeResult.from_auth_test_response(
-                auth_test_response=auth_test_api_response,
-                user_auth_test_response=user_auth_test_response,
+                auth_test_response=auth_test_api_response,  # type: ignore[arg-type]
+                user_auth_test_response=user_auth_test_response,  # type: ignore[arg-type]
                 bot_token=bot_token,
                 user_token=user_token,
                 bot_scopes=bot_scopes,

--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -336,8 +336,8 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
             if user_token is not None and token != user_token:
                 user_auth_test_response = await context.client.auth_test(token=user_token)  # type: ignore[union-attr]
             authorize_result = AuthorizeResult.from_auth_test_response(
-                auth_test_response=auth_test_api_response,  # type: ignore[arg-type]
-                user_auth_test_response=user_auth_test_response,  # type: ignore[arg-type]
+                auth_test_response=auth_test_api_response,
+                user_auth_test_response=user_auth_test_response,
                 bot_token=bot_token,
                 user_token=user_token,
                 bot_scopes=bot_scopes,

--- a/slack_bolt/authorization/async_authorize_args.py
+++ b/slack_bolt/authorization/async_authorize_args.py
@@ -32,7 +32,7 @@ class AsyncAuthorizeArgs:
         """
         self.context = context
         self.logger = context.logger
-        self.client = context.client
+        self.client = context.client  # type: ignore[assignment]
         self.enterprise_id = enterprise_id
         self.team_id = team_id
         self.user_id = user_id

--- a/slack_bolt/authorization/authorize_args.py
+++ b/slack_bolt/authorization/authorize_args.py
@@ -32,7 +32,7 @@ class AuthorizeArgs:
         """
         self.context = context
         self.logger = context.logger
-        self.client = context.client
+        self.client = context.client  # type: ignore[assignment]
         self.enterprise_id = enterprise_id
         self.team_id = team_id
         self.user_id = user_id

--- a/slack_bolt/authorization/authorize_result.py
+++ b/slack_bolt/authorization/authorize_result.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union
+from typing import Optional, Sequence, Union
 
 from slack_sdk.web import SlackResponse
 
@@ -14,12 +14,12 @@ class AuthorizeResult(dict):
     bot_id: Optional[str]
     bot_user_id: Optional[str]
     bot_token: Optional[str]
-    bot_scopes: Optional[List[str]]  # since v1.17
+    bot_scopes: Optional[Sequence[str]]  # since v1.17
 
     user_id: Optional[str]
     user: Optional[str]  # since v1.18
     user_token: Optional[str]
-    user_scopes: Optional[List[str]]  # since v1.17
+    user_scopes: Optional[Sequence[str]]  # since v1.17
 
     def __init__(
         self,
@@ -32,12 +32,12 @@ class AuthorizeResult(dict):
         bot_user_id: Optional[str] = None,
         bot_id: Optional[str] = None,
         bot_token: Optional[str] = None,
-        bot_scopes: Optional[Union[List[str], str]] = None,
+        bot_scopes: Optional[Union[Sequence[str], str]] = None,
         # user
         user_id: Optional[str] = None,
         user: Optional[str] = None,
         user_token: Optional[str] = None,
-        user_scopes: Optional[Union[List[str], str]] = None,
+        user_scopes: Optional[Union[Sequence[str], str]] = None,
     ):
         """
         Args:
@@ -64,14 +64,14 @@ class AuthorizeResult(dict):
         self["bot_token"] = self.bot_token = bot_token
         if bot_scopes is not None and isinstance(bot_scopes, str):
             bot_scopes = [scope.strip() for scope in bot_scopes.split(",")]
-        self["bot_scopes"] = self.bot_scopes = bot_scopes  # type: ignore
+        self["bot_scopes"] = self.bot_scopes = bot_scopes
         # user
         self["user_id"] = self.user_id = user_id
         self["user"] = self.user = user
         self["user_token"] = self.user_token = user_token
         if user_scopes is not None and isinstance(user_scopes, str):
             user_scopes = [scope.strip() for scope in user_scopes.split(",")]
-        self["user_scopes"] = self.user_scopes = user_scopes  # type: ignore
+        self["user_scopes"] = self.user_scopes = user_scopes
 
     @classmethod
     def from_auth_test_response(
@@ -79,21 +79,19 @@ class AuthorizeResult(dict):
         *,
         bot_token: Optional[str] = None,
         user_token: Optional[str] = None,
-        bot_scopes: Optional[Union[List[str], str]] = None,
-        user_scopes: Optional[Union[List[str], str]] = None,
-        auth_test_response: SlackResponse,
-        user_auth_test_response: Optional[SlackResponse] = None,
+        bot_scopes: Optional[Union[Sequence[str], str]] = None,
+        user_scopes: Optional[Union[Sequence[str], str]] = None,
+        auth_test_response: Union[SlackResponse, "AsyncSlackResponse"],  # type: ignore[name-defined]
+        user_auth_test_response: Optional[Union[SlackResponse, "AsyncSlackResponse"]] = None,  # type: ignore[name-defined]
     ) -> "AuthorizeResult":
-        bot_user_id: Optional[str] = (  # type:ignore
+        bot_user_id: Optional[str] = (
             auth_test_response.get("user_id") if auth_test_response.get("bot_id") is not None else None
         )
-        user_id: Optional[str] = (  # type:ignore
-            auth_test_response.get("user_id") if auth_test_response.get("bot_id") is None else None
-        )
-        user_name = auth_test_response.get("user")
+        user_id: Optional[str] = auth_test_response.get("user_id") if auth_test_response.get("bot_id") is None else None
+        user_name: Optional[str] = auth_test_response.get("user")
         if user_id is None and user_auth_test_response is not None:
-            user_id: Optional[str] = user_auth_test_response.get("user_id")  # type:ignore
-            user_name: Optional[str] = user_auth_test_response.get("user")  # type:ignore
+            user_id = user_auth_test_response.get("user_id")
+            user_name = user_auth_test_response.get("user")
 
         return AuthorizeResult(
             enterprise_id=auth_test_response.get("enterprise_id"),

--- a/slack_bolt/context/ack/internals.py
+++ b/slack_bolt/context/ack/internals.py
@@ -27,7 +27,7 @@ def _set_response(
 ) -> BoltResponse:
     if isinstance(text_or_whole_response, str):
         text: str = text_or_whole_response
-        body = {"text": text}
+        body: Dict[str, Any] = {"text": text}
         if response_type:
             body["response_type"] = response_type
         if unfurl_links is not None:
@@ -54,7 +54,7 @@ def _set_response(
                         status=200,
                         body={
                             "response_action": response_action,
-                            "errors": convert_to_dict(errors),
+                            "errors": convert_to_dict(errors),  # type: ignore[arg-type]
                         },
                     )
                 else:
@@ -66,7 +66,7 @@ def _set_response(
                 self.response = BoltResponse(status=200, body=body)
         elif errors:
             # dialogs: errors without response_action
-            body = {"errors": convert_to_dict_list(errors)}
+            body = {"errors": convert_to_dict_list(errors)}  # type: ignore[arg-type]
             self.response = BoltResponse(status=200, body=body)
         else:
             if len(body) == 1 and "text" in body:

--- a/slack_bolt/context/async_context.py
+++ b/slack_bolt/context/async_context.py
@@ -120,8 +120,8 @@ class AsyncBoltContext(BaseContext):
         if "respond" not in self:
             self["respond"] = AsyncRespond(
                 response_url=self.response_url,
-                proxy=self.client.proxy,
-                ssl=self.client.ssl,
+                proxy=self.client.proxy,  # type: ignore[union-attr]
+                ssl=self.client.ssl,  # type: ignore[union-attr]
             )
         return self["respond"]
 
@@ -146,7 +146,9 @@ class AsyncBoltContext(BaseContext):
             Callable `complete()` function
         """
         if "complete" not in self:
-            self["complete"] = AsyncComplete(client=self.client, function_execution_id=self.function_execution_id)
+            self["complete"] = AsyncComplete(
+                client=self.client, function_execution_id=self.function_execution_id  # type: ignore[arg-type]
+            )
         return self["complete"]
 
     @property
@@ -170,5 +172,7 @@ class AsyncBoltContext(BaseContext):
             Callable `fail()` function
         """
         if "fail" not in self:
-            self["fail"] = AsyncFail(client=self.client, function_execution_id=self.function_execution_id)
+            self["fail"] = AsyncFail(
+                client=self.client, function_execution_id=self.function_execution_id  # type: ignore[arg-type]
+            )
         return self["fail"]

--- a/slack_bolt/context/base_context.py
+++ b/slack_bolt/context/base_context.py
@@ -1,6 +1,3 @@
-# pytype: skip-file
-# Note: Since 2021.12.8, the pytype code analyzer does not properly work for this file
-
 from logging import Logger
 from typing import Any, Dict, Optional, Tuple
 

--- a/slack_bolt/context/context.py
+++ b/slack_bolt/context/context.py
@@ -1,4 +1,3 @@
-# pytype: skip-file
 from typing import Optional
 
 from slack_sdk import WebClient
@@ -122,8 +121,8 @@ class BoltContext(BaseContext):
         if "respond" not in self:
             self["respond"] = Respond(
                 response_url=self.response_url,
-                proxy=self.client.proxy,
-                ssl=self.client.ssl,
+                proxy=self.client.proxy,  # type: ignore[union-attr]
+                ssl=self.client.ssl,  # type: ignore[union-attr]
             )
         return self["respond"]
 
@@ -148,7 +147,9 @@ class BoltContext(BaseContext):
             Callable `complete()` function
         """
         if "complete" not in self:
-            self["complete"] = Complete(client=self.client, function_execution_id=self.function_execution_id)
+            self["complete"] = Complete(
+                client=self.client, function_execution_id=self.function_execution_id  # type: ignore[arg-type]
+            )
         return self["complete"]
 
     @property
@@ -172,5 +173,7 @@ class BoltContext(BaseContext):
             Callable `fail()` function
         """
         if "fail" not in self:
-            self["fail"] = Fail(client=self.client, function_execution_id=self.function_execution_id)
+            self["fail"] = Fail(
+                client=self.client, function_execution_id=self.function_execution_id  # type: ignore[arg-type]
+            )
         return self["fail"]

--- a/slack_bolt/context/respond/async_respond.py
+++ b/slack_bolt/context/respond/async_respond.py
@@ -46,7 +46,7 @@ class AsyncRespond:
             text_or_whole_response: Union[str, dict] = text
             if isinstance(text_or_whole_response, str):
                 message = _build_message(
-                    text=text,
+                    text=text,  # type: ignore[arg-type]
                     blocks=blocks,
                     attachments=attachments,
                     response_type=response_type,

--- a/slack_bolt/context/respond/internals.py
+++ b/slack_bolt/context/respond/internals.py
@@ -18,7 +18,7 @@ def _build_message(
     thread_ts: Optional[str] = None,
     metadata: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    message = {"text": text}
+    message: Dict[str, Any] = {"text": text}
     if blocks is not None and len(blocks) > 0:
         message["blocks"] = convert_to_dict_list(blocks)
     if attachments is not None and len(attachments) > 0:

--- a/slack_bolt/context/say/async_say.py
+++ b/slack_bolt/context/say/async_say.py
@@ -46,8 +46,8 @@ class AsyncSay:
             text_or_whole_response: Union[str, dict] = text
             if isinstance(text_or_whole_response, str):
                 text = text_or_whole_response
-                return await self.client.chat_postMessage(
-                    channel=channel or self.channel,
+                return await self.client.chat_postMessage(  # type: ignore[union-attr]
+                    channel=channel or self.channel,  # type: ignore[arg-type]
                     text=text,
                     blocks=blocks,
                     attachments=attachments,
@@ -69,7 +69,7 @@ class AsyncSay:
                 message: dict = create_copy(text_or_whole_response)
                 if "channel" not in message:
                     message["channel"] = channel or self.channel
-                return await self.client.chat_postMessage(**message)
+                return await self.client.chat_postMessage(**message)  # type: ignore[union-attr]
             else:
                 raise ValueError(f"The arg is unexpected type ({type(text_or_whole_response)})")
         else:

--- a/slack_bolt/context/say/say.py
+++ b/slack_bolt/context/say/say.py
@@ -46,8 +46,8 @@ class Say:
             text_or_whole_response: Union[str, dict] = text
             if isinstance(text_or_whole_response, str):
                 text = text_or_whole_response
-                return self.client.chat_postMessage(
-                    channel=channel or self.channel,
+                return self.client.chat_postMessage(  # type: ignore[union-attr]
+                    channel=channel or self.channel,  # type: ignore[arg-type]
                     text=text,
                     blocks=blocks,
                     attachments=attachments,
@@ -69,7 +69,7 @@ class Say:
                 message: dict = create_copy(text_or_whole_response)
                 if "channel" not in message:
                     message["channel"] = channel or self.channel
-                return self.client.chat_postMessage(**message)
+                return self.client.chat_postMessage(**message)  # type: ignore[union-attr]
             else:
                 raise ValueError(f"The arg is unexpected type ({type(text_or_whole_response)})")
         else:

--- a/slack_bolt/error/__init__.py
+++ b/slack_bolt/error/__init__.py
@@ -7,16 +7,16 @@ class BoltError(Exception):
 
 
 class BoltUnhandledRequestError(BoltError):
-    request: "BoltRequest"  # type: ignore
+    request: "BoltRequest"  # type: ignore[name-defined]
     body: dict
-    current_response: Optional["BoltResponse"]  # type: ignore
+    current_response: Optional["BoltResponse"]  # type: ignore[name-defined]
     last_global_middleware_name: Optional[str]
 
-    def __init__(  # type: ignore
+    def __init__(
         self,
         *,
-        request: Union["BoltRequest", "AsyncBoltRequest"],  # type: ignore
-        current_response: Optional["BoltResponse"],  # type: ignore
+        request: Union["BoltRequest", "AsyncBoltRequest"],  # type: ignore[name-defined]
+        current_response: Optional["BoltResponse"],  # type: ignore[name-defined]
         last_global_middleware_name: Optional[str] = None,
     ):
         self.request = request

--- a/slack_bolt/kwargs_injection/args.py
+++ b/slack_bolt/kwargs_injection/args.py
@@ -1,4 +1,3 @@
-# pytype: skip-file
 import logging
 from logging import Logger
 from typing import Callable, Dict, Any, Optional

--- a/slack_bolt/kwargs_injection/async_args.py
+++ b/slack_bolt/kwargs_injection/async_args.py
@@ -1,4 +1,3 @@
-# pytype: skip-file
 from logging import Logger
 from typing import Callable, Awaitable, Dict, Any, Optional
 

--- a/slack_bolt/kwargs_injection/async_utils.py
+++ b/slack_bolt/kwargs_injection/async_utils.py
@@ -1,7 +1,6 @@
-# pytype: skip-file
 import inspect
 import logging
-from typing import Callable, Dict, Optional, Any, Sequence
+from typing import Callable, Dict, MutableSequence, Optional, Any
 
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
@@ -22,10 +21,10 @@ from ..logger.messages import warning_skip_uncommon_arg_name
 def build_async_required_kwargs(
     *,
     logger: logging.Logger,
-    required_arg_names: Sequence[str],
+    required_arg_names: MutableSequence[str],
     request: AsyncBoltRequest,
     response: Optional[BoltResponse],
-    next_func: Callable[[], None] = None,
+    next_func: Optional[Callable[[], None]] = None,
     this_func: Optional[Callable] = None,
     error: Optional[Exception] = None,  # for error handlers
     next_keys_required: bool = True,  # False for listeners / middleware / error handlers
@@ -98,7 +97,7 @@ def build_async_required_kwargs(
     for name in required_arg_names:
         if name == "args":
             if isinstance(request, AsyncBoltRequest):
-                kwargs[name] = AsyncArgs(**all_available_args)
+                kwargs[name] = AsyncArgs(**all_available_args)  # type: ignore[arg-type]
             else:
                 logger.warning(f"Unknown Request object type detected ({type(request)})")
 

--- a/slack_bolt/kwargs_injection/utils.py
+++ b/slack_bolt/kwargs_injection/utils.py
@@ -1,7 +1,6 @@
-# pytype: skip-file
 import inspect
 import logging
-from typing import Callable, Dict, Optional, Any, Sequence
+from typing import Callable, Dict, MutableSequence, Optional, Any
 
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
@@ -22,10 +21,10 @@ from ..logger.messages import warning_skip_uncommon_arg_name
 def build_required_kwargs(
     *,
     logger: logging.Logger,
-    required_arg_names: Sequence[str],
+    required_arg_names: MutableSequence[str],
     request: BoltRequest,
     response: Optional[BoltResponse],
-    next_func: Callable[[], None] = None,
+    next_func: Optional[Callable[[], None]] = None,
     this_func: Optional[Callable] = None,
     error: Optional[Exception] = None,  # for error handlers
     next_keys_required: bool = True,  # False for listeners / middleware / error handlers
@@ -98,7 +97,7 @@ def build_required_kwargs(
     for name in required_arg_names:
         if name == "args":
             if isinstance(request, BoltRequest):
-                kwargs[name] = Args(**all_available_args)
+                kwargs[name] = Args(**all_available_args)  # type: ignore[arg-type]
             else:
                 logger.warning(f"Unknown Request object type detected ({type(request)})")
 

--- a/slack_bolt/lazy_listener/async_runner.py
+++ b/slack_bolt/lazy_listener/async_runner.py
@@ -31,4 +31,4 @@ class AsyncLazyListenerRunner(metaclass=ABCMeta):
             logger=self.logger,
             request=request,
         )
-        return await func()  # type: ignore
+        return await func()  # type: ignore[operator]

--- a/slack_bolt/listener/async_listener.py
+++ b/slack_bolt/listener/async_listener.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod, ABCMeta
-from typing import Callable, Awaitable, Tuple, Optional, Sequence
+from typing import Callable, Awaitable, MutableSequence, Tuple, Optional, Sequence
 
 from slack_bolt.listener_matcher.async_listener_matcher import AsyncListenerMatcher
 from slack_bolt.middleware.async_middleware import AsyncMiddleware
@@ -50,7 +50,7 @@ class AsyncListener(metaclass=ABCMeta):
             async def _next():
                 middleware_state["next_called"] = True
 
-            resp = await m.async_process(req=req, resp=resp, next=_next)
+            resp = await m.async_process(req=req, resp=resp, next=_next)  # type: ignore[assignment]
             if not middleware_state["next_called"]:
                 # next() was not called in this middleware
                 return (resp, True)
@@ -82,12 +82,12 @@ from slack_bolt.response import BoltResponse
 
 class AsyncCustomListener(AsyncListener):
     app_name: str
-    ack_function: Callable[..., Awaitable[Optional[BoltResponse]]]
+    ack_function: Callable[..., Awaitable[Optional[BoltResponse]]]  # type: ignore[assignment]
     lazy_functions: Sequence[Callable[..., Awaitable[None]]]
     matchers: Sequence[AsyncListenerMatcher]
     middleware: Sequence[AsyncMiddleware]
     auto_acknowledgement: bool
-    arg_names: Sequence[str]
+    arg_names: MutableSequence[str]
     logger: Logger
 
     def __init__(

--- a/slack_bolt/listener/async_listener_error_handler.py
+++ b/slack_bolt/listener/async_listener_error_handler.py
@@ -48,6 +48,7 @@ class AsyncCustomListenerErrorHandler(AsyncListenerErrorHandler):
         )
         returned_response = await self.func(**kwargs)
         if returned_response is not None and isinstance(returned_response, BoltResponse):
+            assert response is not None
             response.status = returned_response.status
             response.headers = returned_response.headers
             response.body = returned_response.body

--- a/slack_bolt/listener/async_listener_error_handler.py
+++ b/slack_bolt/listener/async_listener_error_handler.py
@@ -48,10 +48,9 @@ class AsyncCustomListenerErrorHandler(AsyncListenerErrorHandler):
         )
         returned_response = await self.func(**kwargs)
         if returned_response is not None and isinstance(returned_response, BoltResponse):
-            assert response is not None, "response should never be 'None' here"
-            response.status = returned_response.status
-            response.headers = returned_response.headers
-            response.body = returned_response.body
+            response.status = returned_response.status  # type: ignore[union-attr]
+            response.headers = returned_response.headers  # type: ignore[union-attr]
+            response.body = returned_response.body  # type: ignore[union-attr]
 
 
 class AsyncDefaultListenerErrorHandler(AsyncListenerErrorHandler):

--- a/slack_bolt/listener/async_listener_error_handler.py
+++ b/slack_bolt/listener/async_listener_error_handler.py
@@ -48,7 +48,7 @@ class AsyncCustomListenerErrorHandler(AsyncListenerErrorHandler):
         )
         returned_response = await self.func(**kwargs)
         if returned_response is not None and isinstance(returned_response, BoltResponse):
-            assert response is not None
+            assert response is not None, "response should never be 'None' here"
             response.status = returned_response.status
             response.headers = returned_response.headers
             response.body = returned_response.body

--- a/slack_bolt/listener/asyncio_runner.py
+++ b/slack_bolt/listener/asyncio_runner.py
@@ -123,7 +123,7 @@ class AsyncioListenerRunner:
                             response = BoltResponse(status=500)
                         response.status = 500
                         if ack.response is not None:  # already acknowledged
-                            response = None
+                            response = None  # type: ignore[assignment]
 
                         await self.listener_error_handler.handle(
                             error=e,

--- a/slack_bolt/listener/custom_listener.py
+++ b/slack_bolt/listener/custom_listener.py
@@ -1,5 +1,5 @@
 from logging import Logger
-from typing import Callable, Optional, Sequence
+from typing import Callable, MutableSequence, Optional, Sequence
 
 from slack_bolt.kwargs_injection import build_required_kwargs
 from slack_bolt.listener_matcher import ListenerMatcher
@@ -13,12 +13,12 @@ from ..util.utils import get_arg_names_of_callable
 
 class CustomListener(Listener):
     app_name: str
-    ack_function: Callable[..., Optional[BoltResponse]]
+    ack_function: Callable[..., Optional[BoltResponse]]  # type: ignore[assignment]
     lazy_functions: Sequence[Callable[..., None]]
     matchers: Sequence[ListenerMatcher]
-    middleware: Sequence[Middleware]  # type: ignore
+    middleware: Sequence[Middleware]
     auto_acknowledgement: bool
-    arg_names: Sequence[str]
+    arg_names: MutableSequence[str]
     logger: Logger
 
     def __init__(
@@ -28,7 +28,7 @@ class CustomListener(Listener):
         ack_function: Callable[..., Optional[BoltResponse]],
         lazy_functions: Sequence[Callable[..., None]],
         matchers: Sequence[ListenerMatcher],
-        middleware: Sequence[Middleware],  # type: ignore
+        middleware: Sequence[Middleware],
         auto_acknowledgement: bool = False,
         base_logger: Optional[Logger] = None,
     ):

--- a/slack_bolt/listener/listener.py
+++ b/slack_bolt/listener/listener.py
@@ -9,7 +9,7 @@ from slack_bolt.response import BoltResponse
 
 class Listener(metaclass=ABCMeta):
     matchers: Sequence[ListenerMatcher]
-    middleware: Sequence[Middleware]  # type: ignore
+    middleware: Sequence[Middleware]
     ack_function: Callable[..., BoltResponse]
     lazy_functions: Sequence[Callable[..., None]]
     auto_acknowledgement: bool
@@ -48,7 +48,7 @@ class Listener(metaclass=ABCMeta):
             def next_():
                 middleware_state["next_called"] = True
 
-            resp = m.process(req=req, resp=resp, next=next_)
+            resp = m.process(req=req, resp=resp, next=next_)  # type: ignore[assignment]
             if not middleware_state["next_called"]:
                 # next() was not called in this middleware
                 return (resp, True)

--- a/slack_bolt/listener/listener_error_handler.py
+++ b/slack_bolt/listener/listener_error_handler.py
@@ -48,6 +48,7 @@ class CustomListenerErrorHandler(ListenerErrorHandler):
         )
         returned_response = self.func(**kwargs)
         if returned_response is not None and isinstance(returned_response, BoltResponse):
+            assert response is not None
             response.status = returned_response.status
             response.headers = returned_response.headers
             response.body = returned_response.body

--- a/slack_bolt/listener/listener_error_handler.py
+++ b/slack_bolt/listener/listener_error_handler.py
@@ -48,10 +48,9 @@ class CustomListenerErrorHandler(ListenerErrorHandler):
         )
         returned_response = self.func(**kwargs)
         if returned_response is not None and isinstance(returned_response, BoltResponse):
-            assert response is not None, "response should never be 'None' here"
-            response.status = returned_response.status
-            response.headers = returned_response.headers
-            response.body = returned_response.body
+            response.status = returned_response.status  # type: ignore[union-attr]
+            response.headers = returned_response.headers  # type: ignore[union-attr]
+            response.body = returned_response.body  # type: ignore[union-attr]
 
 
 class DefaultListenerErrorHandler(ListenerErrorHandler):

--- a/slack_bolt/listener/listener_error_handler.py
+++ b/slack_bolt/listener/listener_error_handler.py
@@ -48,7 +48,7 @@ class CustomListenerErrorHandler(ListenerErrorHandler):
         )
         returned_response = self.func(**kwargs)
         if returned_response is not None and isinstance(returned_response, BoltResponse):
-            assert response is not None
+            assert response is not None, "response should never be 'None' here"
             response.status = returned_response.status
             response.headers = returned_response.headers
             response.body = returned_response.body

--- a/slack_bolt/listener/thread_runner.py
+++ b/slack_bolt/listener/thread_runner.py
@@ -45,7 +45,7 @@ class ThreadListenerRunner:
         self.listener_executor = listener_executor
         self.lazy_listener_runner = lazy_listener_runner
 
-    def run(  # type: ignore
+    def run(
         self,
         request: BoltRequest,
         response: BoltResponse,

--- a/slack_bolt/listener_matcher/async_builtins.py
+++ b/slack_bolt/listener_matcher/async_builtins.py
@@ -1,4 +1,3 @@
-# pytype: skip-file
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 from .async_listener_matcher import AsyncListenerMatcher
@@ -8,7 +7,7 @@ from ..kwargs_injection.async_utils import build_async_required_kwargs
 
 class AsyncBuiltinListenerMatcher(BuiltinListenerMatcher, AsyncListenerMatcher):
     async def async_matches(self, req: AsyncBoltRequest, resp: BoltResponse) -> bool:
-        return await self.func(
+        return await self.func(  # type: ignore[misc]
             **build_async_required_kwargs(
                 logger=self.logger,
                 required_arg_names=self.arg_names,

--- a/slack_bolt/listener_matcher/async_listener_matcher.py
+++ b/slack_bolt/listener_matcher/async_listener_matcher.py
@@ -45,7 +45,7 @@ class AsyncCustomListenerMatcher(AsyncListenerMatcher):
         return await self.func(
             **build_async_required_kwargs(
                 logger=self.logger,
-                required_arg_names=self.arg_names,
+                required_arg_names=self.arg_names,  # type: ignore[arg-type]
                 request=req,
                 response=resp,
                 this_func=self.func,

--- a/slack_bolt/listener_matcher/builtins.py
+++ b/slack_bolt/listener_matcher/builtins.py
@@ -1,4 +1,3 @@
-# pytype: skip-file
 import re
 import sys
 from logging import Logger
@@ -27,7 +26,7 @@ from ..logger.messages import error_message_event_type
 from ..util.utils import get_arg_names_of_callable
 
 if sys.version_info.major == 3 and sys.version_info.minor <= 6:
-    from re import _pattern_type as Pattern
+    from re import _pattern_type as Pattern  # type: ignore[attr-defined]
 else:
     from re import Pattern
 from typing import Callable, Awaitable, Any, Sequence, Optional, Union, Dict
@@ -52,7 +51,7 @@ class BuiltinListenerMatcher(ListenerMatcher):
         self.logger = get_bolt_logger(self.func, base_logger)
 
     def matches(self, req: BoltRequest, resp: BoltResponse) -> bool:
-        return self.func(
+        return self.func(  # type: ignore[return-value]
             **build_required_kwargs(
                 logger=self.logger,
                 required_arg_names=self.arg_names,
@@ -67,7 +66,7 @@ def build_listener_matcher(
     func: Callable[..., bool],
     asyncio: bool,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     if asyncio:
         from .async_builtins import AsyncBuiltinListenerMatcher
 
@@ -91,7 +90,7 @@ def event(
     ],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     if isinstance(constraints, (str, Pattern)):
         event_type: Union[str, Pattern] = constraints
         _verify_message_event_type(event_type)
@@ -102,7 +101,7 @@ def event(
         return build_listener_matcher(func, asyncio, base_logger)
 
     elif "type" in constraints:
-        _verify_message_event_type(constraints["type"])
+        _verify_message_event_type(constraints["type"])  # type: ignore[arg-type]
 
         def func(body: Dict[str, Any]) -> bool:
             if is_event(body):
@@ -122,9 +121,9 @@ def message_event(
     keyword: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     if "type" in constraints and keyword is not None:
-        _verify_message_event_type(constraints["type"])
+        _verify_message_event_type(constraints["type"])  # type: ignore[arg-type]
 
         def func(body: Dict[str, Any]) -> bool:
             if is_event(body):
@@ -181,7 +180,7 @@ def function_executed(
     callback_id: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return is_function(body) and _matches(callback_id, body.get("event", {}).get("function", {}).get("callback_id", ""))
 
@@ -192,7 +191,7 @@ def workflow_step_execute(
     callback_id: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return (
             is_event(body)
@@ -212,7 +211,7 @@ def command(
     command: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return is_slash_command(body) and _matches(command, body["command"])
 
@@ -227,7 +226,7 @@ def shortcut(
     constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     if isinstance(constraints, (str, Pattern)):
         callback_id: Union[str, Pattern] = constraints
 
@@ -249,7 +248,7 @@ def global_shortcut(
     callback_id: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return is_global_shortcut(body) and _matches(callback_id, body["callback_id"])
 
@@ -260,7 +259,7 @@ def message_shortcut(
     callback_id: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return is_message_shortcut(body) and _matches(callback_id, body["callback_id"])
 
@@ -275,7 +274,7 @@ def action(
     constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     if isinstance(constraints, (str, Pattern)):
 
         def func(body: Dict[str, Any]) -> bool:
@@ -321,15 +320,15 @@ def _block_action(
     action = to_action(body)
     if isinstance(constraints, (str, Pattern)):
         action_id = constraints
-        return _matches(action_id, action["action_id"])
+        return _matches(action_id, action["action_id"])  # type: ignore[index]
     elif isinstance(constraints, dict):
         # block_id matching is optional
         block_id: Optional[Union[str, Pattern]] = constraints.get("block_id")
-        action_id: Optional[Union[str, Pattern]] = constraints.get("action_id")
+        action_id = constraints.get("action_id")
         if block_id is None and action_id is None:
             return False
-        block_id_matched = block_id is None or _matches(block_id, action.get("block_id"))
-        action_id_matched = action_id is None or _matches(action_id, action.get("action_id"))
+        block_id_matched = block_id is None or _matches(block_id, action.get("block_id"))  # type: ignore[union-attr]
+        action_id_matched = action_id is None or _matches(action_id, action.get("action_id"))  # type: ignore[union-attr]
         return block_id_matched and action_id_matched
 
 
@@ -337,7 +336,7 @@ def block_action(
     constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return _block_action(constraints, body)
 
@@ -355,7 +354,7 @@ def attachment_action(
     callback_id: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return _attachment_action(callback_id, body)
 
@@ -373,7 +372,7 @@ def dialog_submission(
     callback_id: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return _dialog_submission(callback_id, body)
 
@@ -391,7 +390,7 @@ def dialog_cancellation(
     callback_id: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return _dialog_cancellation(callback_id, body)
 
@@ -409,7 +408,7 @@ def workflow_step_edit(
     callback_id: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return _workflow_step_edit(callback_id, body)
 
@@ -424,7 +423,7 @@ def view(
     constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     if isinstance(constraints, (str, Pattern)):
         return view_submission(constraints, asyncio)
     elif "type" in constraints:
@@ -440,7 +439,7 @@ def view_submission(
     callback_id: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return is_view_submission(body) and _matches(callback_id, body["view"]["callback_id"])
 
@@ -451,7 +450,7 @@ def view_closed(
     callback_id: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return is_view_closed(body) and _matches(callback_id, body["view"]["callback_id"])
 
@@ -462,7 +461,7 @@ def workflow_step_save(
     callback_id: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return is_workflow_step_save(body) and _matches(callback_id, body["view"]["callback_id"])
 
@@ -477,7 +476,7 @@ def options(
     constraints: Union[str, Pattern, Dict[str, Union[str, Pattern]]],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     if isinstance(constraints, (str, Pattern)):
 
         def func(body: Dict[str, Any]) -> bool:
@@ -504,7 +503,7 @@ def block_suggestion(
     action_id: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return _block_suggestion(action_id, body)
 
@@ -522,7 +521,7 @@ def dialog_suggestion(
     callback_id: Union[str, Pattern],
     asyncio: bool = False,
     base_logger: Optional[Logger] = None,
-) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:
+) -> Union[ListenerMatcher, "AsyncListenerMatcher"]:  # type: ignore[name-defined]
     def func(body: Dict[str, Any]) -> bool:
         return _dialog_suggestion(callback_id, body)
 

--- a/slack_bolt/listener_matcher/custom_listener_matcher.py
+++ b/slack_bolt/listener_matcher/custom_listener_matcher.py
@@ -1,5 +1,5 @@
 from logging import Logger
-from typing import Callable, Sequence, Optional
+from typing import Callable, MutableSequence, Optional
 
 from slack_bolt.kwargs_injection import build_required_kwargs
 from slack_bolt.logger import get_bolt_app_logger
@@ -12,7 +12,7 @@ from ..util.utils import get_arg_names_of_callable
 class CustomListenerMatcher(ListenerMatcher):
     app_name: str
     func: Callable[..., bool]
-    arg_names: Sequence[str]
+    arg_names: MutableSequence[str]
     logger: Logger
 
     def __init__(self, *, app_name: str, func: Callable[..., bool], base_logger: Optional[Logger] = None):

--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -74,6 +74,10 @@ def error_installation_store_required_for_builtin_listeners() -> str:
     )
 
 
+def error_oauth_flow_or_authorize_required() -> str:
+    return "`oauth_flow` or `authorize` must be configured to make a Bolt app"
+
+
 # -------------------------------
 # Warning
 # -------------------------------

--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -204,7 +204,7 @@ app.step(ws)
         # @app.action
         action_id_or_callback_id = req.body.get("callback_id")
         if req.body.get("type") == "block_actions":
-            action_id_or_callback_id = req.body.get("actions", [])[0].get("action_id")
+            action_id_or_callback_id = req.body["actions"][0].get("action_id")
         return _build_unhandled_request_suggestion(
             default_message,
             f"""
@@ -218,7 +218,7 @@ app.step(ws)
         # @app.options
         constraints = '"action-id"'
         if req.body.get("action_id") is not None:
-            constraints = '"' + req.body.get("action_id", "") + '"'
+            constraints = '"' + req.body["action_id"] + '"'
         elif req.body.get("type") == "dialog_suggestion":
             constraints = f"""{{"type": "dialog_suggestion", "callback_id": "{req.body.get('callback_id')}"}}"""
         return _build_unhandled_request_suggestion(

--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -93,9 +93,9 @@ def warning_installation_store_conflicts() -> str:
     return "As you gave both `installation_store` and `oauth_settings`/`auth_flow`, the top level one is unused."
 
 
-def warning_unhandled_by_global_middleware(  # type: ignore
-    name: str, req: Union[BoltRequest, "AsyncBoltRequest"]  # type: ignore
-) -> str:  # type: ignore
+def warning_unhandled_by_global_middleware(
+    name: str, req: Union[BoltRequest, "AsyncBoltRequest"]  # type: ignore[name-defined]
+) -> str:
     return (
         f"A global middleware ({name}) skipped calling either `next()` or `next_()` "
         f"without providing a response for the request ({req.body})"
@@ -175,18 +175,16 @@ def _build_unhandled_request_suggestion(default_message: str, code_snippet: str)
     return f"""{default_message}{_unhandled_request_suggestion_prefix}{code_snippet}"""
 
 
-def warning_unhandled_request(  # type: ignore
-    req: Union[BoltRequest, "AsyncBoltRequest"],  # type: ignore
-) -> str:  # type: ignore
+def warning_unhandled_request(
+    req: Union[BoltRequest, "AsyncBoltRequest"],  # type: ignore[name-defined]
+) -> str:
     filtered_body = _build_filtered_body(req.body)
     default_message = f"Unhandled request ({filtered_body})"
     is_async = type(req) != BoltRequest
     if is_workflow_step_edit(req.body) or is_workflow_step_save(req.body) or is_workflow_step_execute(req.body):
         # @app.step
         callback_id = (
-            filtered_body.get("callback_id")
-            or filtered_body.get("view", {}).get("callback_id")  # type: ignore
-            or "your-callback-id"
+            filtered_body.get("callback_id") or filtered_body.get("view", {}).get("callback_id") or "your-callback-id"
         )
         return _build_unhandled_request_suggestion(
             default_message,
@@ -206,7 +204,7 @@ app.step(ws)
         # @app.action
         action_id_or_callback_id = req.body.get("callback_id")
         if req.body.get("type") == "block_actions":
-            action_id_or_callback_id = req.body.get("actions")[0].get("action_id")
+            action_id_or_callback_id = req.body.get("actions", [])[0].get("action_id")
         return _build_unhandled_request_suggestion(
             default_message,
             f"""
@@ -220,7 +218,7 @@ app.step(ws)
         # @app.options
         constraints = '"action-id"'
         if req.body.get("action_id") is not None:
-            constraints = '"' + req.body.get("action_id") + '"'
+            constraints = '"' + req.body.get("action_id", "") + '"'
         elif req.body.get("type") == "dialog_suggestion":
             constraints = f"""{{"type": "dialog_suggestion", "callback_id": "{req.body.get('callback_id')}"}}"""
         return _build_unhandled_request_suggestion(

--- a/slack_bolt/middleware/__init__.py
+++ b/slack_bolt/middleware/__init__.py
@@ -28,7 +28,7 @@ builtin_middleware_classes = [
     AttachingFunctionToken,
 ]
 for cls in builtin_middleware_classes:
-    Middleware.register(cls)
+    Middleware.register(cls)  # type: ignore[arg-type]
 
 __all__ = [
     "SingleTeamAuthorization",

--- a/slack_bolt/middleware/async_custom_middleware.py
+++ b/slack_bolt/middleware/async_custom_middleware.py
@@ -1,6 +1,6 @@
 import inspect
 from logging import Logger
-from typing import Callable, Awaitable, Any, Sequence, Optional
+from typing import Callable, Awaitable, Any, MutableSequence, Optional
 
 from slack_bolt.kwargs_injection.async_utils import build_async_required_kwargs
 from slack_bolt.logger import get_bolt_app_logger
@@ -13,7 +13,7 @@ from slack_bolt.util.utils import get_name_for_callable, get_arg_names_of_callab
 class AsyncCustomMiddleware(AsyncMiddleware):
     app_name: str
     func: Callable[..., Awaitable[Any]]
-    arg_names: Sequence[str]
+    arg_names: MutableSequence[str]
     logger: Logger
 
     def __init__(
@@ -48,7 +48,7 @@ class AsyncCustomMiddleware(AsyncMiddleware):
                 required_arg_names=self.arg_names,
                 request=req,
                 response=resp,
-                next_func=next,
+                next_func=next,  # type: ignore[arg-type]
                 this_func=self.func,
             )
         )

--- a/slack_bolt/middleware/async_middleware_error_handler.py
+++ b/slack_bolt/middleware/async_middleware_error_handler.py
@@ -48,6 +48,7 @@ class AsyncCustomMiddlewareErrorHandler(AsyncMiddlewareErrorHandler):
         )
         returned_response = await self.func(**kwargs)
         if returned_response is not None and isinstance(returned_response, BoltResponse):
+            assert response is not None
             response.status = returned_response.status
             response.headers = returned_response.headers
             response.body = returned_response.body

--- a/slack_bolt/middleware/async_middleware_error_handler.py
+++ b/slack_bolt/middleware/async_middleware_error_handler.py
@@ -48,10 +48,9 @@ class AsyncCustomMiddlewareErrorHandler(AsyncMiddlewareErrorHandler):
         )
         returned_response = await self.func(**kwargs)
         if returned_response is not None and isinstance(returned_response, BoltResponse):
-            assert response is not None, "response should never be 'None' here"
-            response.status = returned_response.status
-            response.headers = returned_response.headers
-            response.body = returned_response.body
+            response.status = returned_response.status  # type: ignore[union-attr]
+            response.headers = returned_response.headers  # type: ignore[union-attr]
+            response.body = returned_response.body  # type: ignore[union-attr]
 
 
 class AsyncDefaultMiddlewareErrorHandler(AsyncMiddlewareErrorHandler):

--- a/slack_bolt/middleware/async_middleware_error_handler.py
+++ b/slack_bolt/middleware/async_middleware_error_handler.py
@@ -48,7 +48,7 @@ class AsyncCustomMiddlewareErrorHandler(AsyncMiddlewareErrorHandler):
         )
         returned_response = await self.func(**kwargs)
         if returned_response is not None and isinstance(returned_response, BoltResponse):
-            assert response is not None
+            assert response is not None, "response should never be 'None' here"
             response.status = returned_response.status
             response.headers = returned_response.headers
             response.body = returned_response.body

--- a/slack_bolt/middleware/attaching_function_token/async_attaching_function_token.py
+++ b/slack_bolt/middleware/attaching_function_token/async_attaching_function_token.py
@@ -5,7 +5,7 @@ from slack_bolt.response import BoltResponse
 from slack_bolt.middleware.async_middleware import AsyncMiddleware
 
 
-class AsyncAttachingFunctionToken(AsyncMiddleware):  # type: ignore
+class AsyncAttachingFunctionToken(AsyncMiddleware):
     async def async_process(
         self,
         *,
@@ -14,7 +14,7 @@ class AsyncAttachingFunctionToken(AsyncMiddleware):  # type: ignore
         # This method is not supposed to be invoked by bolt-python users
         next: Callable[[], Awaitable[BoltResponse]],
     ) -> BoltResponse:
-        if req.context.function_bot_access_token is not None:
+        if req.context.client is not None and req.context.function_bot_access_token is not None:
             req.context.client.token = req.context.function_bot_access_token
 
         return await next()

--- a/slack_bolt/middleware/attaching_function_token/async_attaching_function_token.py
+++ b/slack_bolt/middleware/attaching_function_token/async_attaching_function_token.py
@@ -14,7 +14,7 @@ class AsyncAttachingFunctionToken(AsyncMiddleware):
         # This method is not supposed to be invoked by bolt-python users
         next: Callable[[], Awaitable[BoltResponse]],
     ) -> BoltResponse:
-        if req.context.client is not None and req.context.function_bot_access_token is not None:
-            req.context.client.token = req.context.function_bot_access_token
+        if req.context.function_bot_access_token is not None:
+            req.context.client.token = req.context.function_bot_access_token  # type: ignore[union-attr]
 
         return await next()

--- a/slack_bolt/middleware/attaching_function_token/attaching_function_token.py
+++ b/slack_bolt/middleware/attaching_function_token/attaching_function_token.py
@@ -5,7 +5,7 @@ from slack_bolt.response import BoltResponse
 from slack_bolt.middleware.middleware import Middleware
 
 
-class AttachingFunctionToken(Middleware):  # type: ignore
+class AttachingFunctionToken(Middleware):
     def process(
         self,
         *,
@@ -14,7 +14,7 @@ class AttachingFunctionToken(Middleware):  # type: ignore
         # This method is not supposed to be invoked by bolt-python users
         next: Callable[[], BoltResponse],
     ) -> BoltResponse:
-        if req.context.function_bot_access_token is not None:
+        if req.context.client is not None and req.context.function_bot_access_token is not None:
             req.context.client.token = req.context.function_bot_access_token
 
         return next()

--- a/slack_bolt/middleware/attaching_function_token/attaching_function_token.py
+++ b/slack_bolt/middleware/attaching_function_token/attaching_function_token.py
@@ -14,7 +14,7 @@ class AttachingFunctionToken(Middleware):
         # This method is not supposed to be invoked by bolt-python users
         next: Callable[[], BoltResponse],
     ) -> BoltResponse:
-        if req.context.client is not None and req.context.function_bot_access_token is not None:
-            req.context.client.token = req.context.function_bot_access_token
+        if req.context.function_bot_access_token is not None:
+            req.context.client.token = req.context.function_bot_access_token  # type: ignore[union-attr]
 
         return next()

--- a/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
@@ -96,8 +96,8 @@ class AsyncMultiTeamsAuthorization(AsyncAuthorization):
                     "Although the app should be installed into this workspace, "
                     "the AuthorizeResult (returned value from authorize) for it was not found."
                 )
-                if req.context.response_url is not None and callable(req.context.respond):
-                    await req.context.respond(self.user_facing_authorize_error_message)
+                if req.context.response_url is not None:
+                    await req.context.respond(self.user_facing_authorize_error_message)  # type: ignore[misc]
                     return BoltResponse(status=200, body="")
                 return _build_user_facing_error_response(self.user_facing_authorize_error_message)
 

--- a/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
@@ -86,7 +86,7 @@ class AsyncMultiTeamsAuthorization(AsyncAuthorization):
                 req.context["token"] = token
                 # As AsyncApp#_init_context() generates a new AsyncWebClient for this request,
                 # it's safe to modify this instance.
-                req.context.client.token = token
+                req.context.client.token = token  # type: ignore[union-attr]
                 return await next()
             else:
                 # This situation can arise if:
@@ -96,7 +96,7 @@ class AsyncMultiTeamsAuthorization(AsyncAuthorization):
                     "Although the app should be installed into this workspace, "
                     "the AuthorizeResult (returned value from authorize) for it was not found."
                 )
-                if req.context.response_url is not None:
+                if req.context.response_url is not None and callable(req.context.respond):
                     await req.context.respond(self.user_facing_authorize_error_message)
                     return BoltResponse(status=200, body="")
                 return _build_user_facing_error_response(self.user_facing_authorize_error_message)

--- a/slack_bolt/middleware/authorization/async_single_team_authorization.py
+++ b/slack_bolt/middleware/authorization/async_single_team_authorization.py
@@ -64,8 +64,8 @@ class AsyncSingleTeamAuthorization(AsyncAuthorization):
             else:
                 # Just in case
                 self.logger.error("auth.test API call result is unexpectedly None")
-                if req.context.response_url is not None and callable(req.context.respond):
-                    await req.context.respond(self.user_facing_authorize_error_message)
+                if req.context.response_url is not None:
+                    await req.context.respond(self.user_facing_authorize_error_message)  # type: ignore[misc]
                     return BoltResponse(status=200, body="")
                 return _build_user_facing_error_response(self.user_facing_authorize_error_message)
         except SlackApiError as e:

--- a/slack_bolt/middleware/authorization/async_single_team_authorization.py
+++ b/slack_bolt/middleware/authorization/async_single_team_authorization.py
@@ -50,13 +50,13 @@ class AsyncSingleTeamAuthorization(AsyncAuthorization):
 
         try:
             if self.auth_test_result is None:
-                self.auth_test_result = await req.context.client.auth_test()
+                self.auth_test_result = await req.context.client.auth_test()  # type: ignore[union-attr]
 
             if self.auth_test_result:
                 req.context.set_authorize_result(
                     _to_authorize_result(
                         auth_test_result=self.auth_test_result,
-                        token=req.context.client.token,
+                        token=req.context.client.token,  # type: ignore[union-attr]
                         request_user_id=req.context.user_id,
                     )
                 )
@@ -64,7 +64,7 @@ class AsyncSingleTeamAuthorization(AsyncAuthorization):
             else:
                 # Just in case
                 self.logger.error("auth.test API call result is unexpectedly None")
-                if req.context.response_url is not None:
+                if req.context.response_url is not None and callable(req.context.respond):
                     await req.context.respond(self.user_facing_authorize_error_message)
                     return BoltResponse(status=200, body="")
                 return _build_user_facing_error_response(self.user_facing_authorize_error_message)

--- a/slack_bolt/middleware/authorization/internals.py
+++ b/slack_bolt/middleware/authorization/internals.py
@@ -15,18 +15,18 @@ from slack_bolt.response import BoltResponse
 #
 
 
-def _is_url_verification(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore
+def _is_url_verification(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore[name-defined]
     return req is not None and req.body is not None and req.body.get("type") == "url_verification"
 
 
-def _is_ssl_check(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore
+def _is_ssl_check(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore[name-defined]
     return req is not None and req.body is not None and req.body.get("type") == "ssl_check"
 
 
 no_auth_test_events = ["app_uninstalled", "tokens_revoked", "team_access_revoked"]
 
 
-def _is_no_auth_test_events(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore
+def _is_no_auth_test_events(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore[name-defined]
     return (
         req is not None
         and req.body is not None
@@ -35,11 +35,11 @@ def _is_no_auth_test_events(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool
     )
 
 
-def _is_no_auth_required(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore
+def _is_no_auth_required(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore[name-defined]
     return _is_url_verification(req) or _is_ssl_check(req)
 
 
-def _is_no_auth_test_call_required(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore
+def _is_no_auth_test_call_required(req: Union[BoltRequest, "AsyncBoltRequest"]) -> bool:  # type: ignore[name-defined]
     return _is_no_auth_test_events(req)
 
 
@@ -62,8 +62,8 @@ def _is_bot_token(token: Optional[str]) -> bool:
     return token is not None and token.startswith("xoxb-")
 
 
-def _to_authorize_result(  # type: ignore
-    auth_test_result: Union[SlackResponse, "AsyncSlackResponse"],
+def _to_authorize_result(
+    auth_test_result: Union[SlackResponse, "AsyncSlackResponse"],  # type: ignore[name-defined]
     token: Optional[str],
     request_user_id: Optional[str],
 ) -> AuthorizeResult:

--- a/slack_bolt/middleware/authorization/multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/multi_teams_authorization.py
@@ -89,7 +89,7 @@ class MultiTeamsAuthorization(Authorization):
                 req.context["token"] = token
                 # As App#_init_context() generates a new WebClient for this request,
                 # it's safe to modify this instance.
-                req.context.client.token = token
+                req.context.client.token = token  # type: ignore[union-attr]
                 return next()
             else:
                 # This situation can arise if:
@@ -99,7 +99,7 @@ class MultiTeamsAuthorization(Authorization):
                     "Although the app should be installed into this workspace, "
                     "the AuthorizeResult (returned value from authorize) for it was not found."
                 )
-                if req.context.response_url is not None:
+                if req.context.response_url is not None and callable(req.context.respond):
                     req.context.respond(self.user_facing_authorize_error_message)
                     return BoltResponse(status=200, body="")
                 return _build_user_facing_error_response(self.user_facing_authorize_error_message)

--- a/slack_bolt/middleware/authorization/multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/multi_teams_authorization.py
@@ -99,8 +99,8 @@ class MultiTeamsAuthorization(Authorization):
                     "Although the app should be installed into this workspace, "
                     "the AuthorizeResult (returned value from authorize) for it was not found."
                 )
-                if req.context.response_url is not None and callable(req.context.respond):
-                    req.context.respond(self.user_facing_authorize_error_message)
+                if req.context.response_url is not None:
+                    req.context.respond(self.user_facing_authorize_error_message)  # type: ignore[misc]
                     return BoltResponse(status=200, body="")
                 return _build_user_facing_error_response(self.user_facing_authorize_error_message)
 

--- a/slack_bolt/middleware/authorization/single_team_authorization.py
+++ b/slack_bolt/middleware/authorization/single_team_authorization.py
@@ -76,8 +76,8 @@ class SingleTeamAuthorization(Authorization):
             else:
                 # Just in case
                 self.logger.error("auth.test API call result is unexpectedly None")
-                if req.context.response_url is not None and callable(req.context.respond):
-                    req.context.respond(self.user_facing_authorize_error_message)
+                if req.context.response_url is not None:
+                    req.context.respond(self.user_facing_authorize_error_message)  # type: ignore[misc]
                     return BoltResponse(status=200, body="")
                 return _build_user_facing_error_response(self.user_facing_authorize_error_message)
         except SlackApiError as e:

--- a/slack_bolt/middleware/authorization/single_team_authorization.py
+++ b/slack_bolt/middleware/authorization/single_team_authorization.py
@@ -62,13 +62,13 @@ class SingleTeamAuthorization(Authorization):
 
         try:
             if not self.auth_test_result:
-                self.auth_test_result = req.context.client.auth_test()
+                self.auth_test_result = req.context.client.auth_test()  # type: ignore[union-attr]
 
             if self.auth_test_result:
                 req.context.set_authorize_result(
                     _to_authorize_result(
                         auth_test_result=self.auth_test_result,
-                        token=req.context.client.token,
+                        token=req.context.client.token,  # type: ignore[union-attr]
                         request_user_id=req.context.user_id,
                     )
                 )
@@ -76,7 +76,7 @@ class SingleTeamAuthorization(Authorization):
             else:
                 # Just in case
                 self.logger.error("auth.test API call result is unexpectedly None")
-                if req.context.response_url is not None:
+                if req.context.response_url is not None and callable(req.context.respond):
                     req.context.respond(self.user_facing_authorize_error_message)
                     return BoltResponse(status=200, body="")
                 return _build_user_facing_error_response(self.user_facing_authorize_error_message)

--- a/slack_bolt/middleware/custom_middleware.py
+++ b/slack_bolt/middleware/custom_middleware.py
@@ -1,5 +1,5 @@
 from logging import Logger
-from typing import Callable, Any, Sequence, Optional
+from typing import Callable, Any, MutableSequence, Optional
 
 from slack_bolt.kwargs_injection import build_required_kwargs
 from slack_bolt.logger import get_bolt_app_logger
@@ -12,7 +12,7 @@ from slack_bolt.util.utils import get_name_for_callable, get_arg_names_of_callab
 class CustomMiddleware(Middleware):
     app_name: str
     func: Callable[..., Any]
-    arg_names: Sequence[str]
+    arg_names: MutableSequence[str]
     logger: Logger
 
     def __init__(self, *, app_name: str, func: Callable, base_logger: Optional[Logger] = None):
@@ -37,7 +37,7 @@ class CustomMiddleware(Middleware):
                 required_arg_names=self.arg_names,
                 request=req,
                 response=resp,
-                next_func=next,
+                next_func=next,  # type: ignore[arg-type]
                 this_func=self.func,
             )
         )

--- a/slack_bolt/middleware/ignoring_self_events/async_ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/async_ignoring_self_events.py
@@ -17,7 +17,7 @@ class AsyncIgnoringSelfEvents(IgnoringSelfEvents, AsyncMiddleware):
         auth_result = req.context.authorize_result
         # message events can have $.event.bot_id while it does not have its user_id
         bot_id = req.body.get("event", {}).get("bot_id")
-        if self._is_self_event(auth_result, req.context.user_id, bot_id, req.body):
+        if self._is_self_event(auth_result, req.context.user_id, bot_id, req.body):  # type: ignore[arg-type]
             self._debug_log(req.body)
             return await req.context.ack()
         else:

--- a/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
+++ b/slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py
@@ -23,7 +23,7 @@ class IgnoringSelfEvents(Middleware):
         auth_result = req.context.authorize_result
         # message events can have $.event.bot_id while it does not have its user_id
         bot_id = req.body.get("event", {}).get("bot_id")
-        if self._is_self_event(auth_result, req.context.user_id, bot_id, req.body):
+        if self._is_self_event(auth_result, req.context.user_id, bot_id, req.body):  # type: ignore[arg-type]
             self._debug_log(req.body)
             return req.context.ack()
         else:

--- a/slack_bolt/middleware/message_listener_matches/async_message_listener_matches.py
+++ b/slack_bolt/middleware/message_listener_matches/async_message_listener_matches.py
@@ -1,5 +1,5 @@
 import re
-from typing import Callable, Awaitable, Union, Pattern
+from typing import Callable, Awaitable, Optional, Sequence, Union, Pattern
 
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
@@ -23,7 +23,7 @@ class AsyncMessageListenerMatches(AsyncMiddleware):
     ) -> BoltResponse:
         text = req.body.get("event", {}).get("text", "")
         if text:
-            m = re.findall(self.keyword, text)
+            m: Optional[Union[Sequence]] = re.findall(self.keyword, text)
             if m is not None and m != []:
                 if type(m[0]) is not tuple:
                     m = tuple(m)

--- a/slack_bolt/middleware/message_listener_matches/message_listener_matches.py
+++ b/slack_bolt/middleware/message_listener_matches/message_listener_matches.py
@@ -1,12 +1,12 @@
 import re
-from typing import Callable, Pattern, Union
+from typing import Callable, Optional, Pattern, Sequence, Union
 
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 from slack_bolt.middleware.middleware import Middleware
 
 
-class MessageListenerMatches(Middleware):  # type: ignore
+class MessageListenerMatches(Middleware):
     def __init__(self, keyword: Union[str, Pattern]):
         """Captures matched keywords and saves the values in context."""
         self.keyword = keyword
@@ -23,7 +23,7 @@ class MessageListenerMatches(Middleware):  # type: ignore
     ) -> BoltResponse:
         text = req.body.get("event", {}).get("text", "")
         if text:
-            m = re.findall(self.keyword, text)
+            m: Optional[Union[Sequence]] = re.findall(self.keyword, text)
             if m is not None and m != []:
                 if type(m[0]) is not tuple:
                     m = tuple(m)

--- a/slack_bolt/middleware/middleware_error_handler.py
+++ b/slack_bolt/middleware/middleware_error_handler.py
@@ -48,7 +48,7 @@ class CustomMiddlewareErrorHandler(MiddlewareErrorHandler):
         )
         returned_response = self.func(**kwargs)
         if returned_response is not None and isinstance(returned_response, BoltResponse):
-            assert response is not None
+            assert response is not None, "response should never be 'None' here"
             response.status = returned_response.status
             response.headers = returned_response.headers
             response.body = returned_response.body

--- a/slack_bolt/middleware/middleware_error_handler.py
+++ b/slack_bolt/middleware/middleware_error_handler.py
@@ -14,7 +14,7 @@ class MiddlewareErrorHandler(metaclass=ABCMeta):
         self,
         error: Exception,
         request: BoltRequest,
-        response: Optional[BoltResponse],
+        response: Optional[BoltResponse],  # TODO: why is this optional
     ) -> None:
         """Handles an unhandled exception.
 
@@ -48,10 +48,9 @@ class CustomMiddlewareErrorHandler(MiddlewareErrorHandler):
         )
         returned_response = self.func(**kwargs)
         if returned_response is not None and isinstance(returned_response, BoltResponse):
-            assert response is not None, "response should never be 'None' here"
-            response.status = returned_response.status
-            response.headers = returned_response.headers
-            response.body = returned_response.body
+            response.status = returned_response.status  # type: ignore[union-attr]
+            response.headers = returned_response.headers  # type: ignore[union-attr]
+            response.body = returned_response.body  # type: ignore[union-attr]
 
 
 class DefaultMiddlewareErrorHandler(MiddlewareErrorHandler):

--- a/slack_bolt/middleware/middleware_error_handler.py
+++ b/slack_bolt/middleware/middleware_error_handler.py
@@ -48,6 +48,7 @@ class CustomMiddlewareErrorHandler(MiddlewareErrorHandler):
         )
         returned_response = self.func(**kwargs)
         if returned_response is not None and isinstance(returned_response, BoltResponse):
+            assert response is not None
             response.status = returned_response.status
             response.headers = returned_response.headers
             response.body = returned_response.body

--- a/slack_bolt/middleware/request_verification/request_verification.py
+++ b/slack_bolt/middleware/request_verification/request_verification.py
@@ -9,7 +9,7 @@ from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 
 
-class RequestVerification(Middleware):  # type: ignore
+class RequestVerification(Middleware):
     def __init__(self, signing_secret: str, base_logger: Optional[Logger] = None):
         """Verifies an incoming request by checking the validity of
         `x-slack-signature`, `x-slack-request-timestamp`, and its body data.

--- a/slack_bolt/middleware/ssl_check/ssl_check.py
+++ b/slack_bolt/middleware/ssl_check/ssl_check.py
@@ -7,7 +7,7 @@ from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 
 
-class SslCheck(Middleware):  # type: ignore
+class SslCheck(Middleware):
     verification_token: Optional[str]
     logger: Logger
 

--- a/slack_bolt/middleware/url_verification/url_verification.py
+++ b/slack_bolt/middleware/url_verification/url_verification.py
@@ -7,7 +7,7 @@ from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 
 
-class UrlVerification(Middleware):  # type: ignore
+class UrlVerification(Middleware):
     def __init__(self, base_logger: Optional[Logger] = None):
         """Handles url_verification requests.
 

--- a/slack_bolt/oauth/async_callback_options.py
+++ b/slack_bolt/oauth/async_callback_options.py
@@ -11,12 +11,12 @@ from slack_bolt.response import BoltResponse
 
 
 class AsyncSuccessArgs:
-    def __init__(  # type: ignore
+    def __init__(
         self,
         *,
         request: AsyncBoltRequest,
         installation: Installation,
-        settings: "AsyncOAuthSettings",
+        settings: "AsyncOAuthSettings",  # type: ignore[name-defined]
         default: "AsyncCallbackOptions",
     ):
         """The arguments for a success function.
@@ -34,14 +34,14 @@ class AsyncSuccessArgs:
 
 
 class AsyncFailureArgs:
-    def __init__(  # type: ignore
+    def __init__(
         self,
         *,
         request: AsyncBoltRequest,
         reason: str,
         error: Optional[Exception] = None,
         suggested_status_code: int,
-        settings: "AsyncOAuthSettings",
+        settings: "AsyncOAuthSettings",  # type: ignore[name-defined]
         default: "AsyncCallbackOptions",
     ):
         """The arguments for a failure function.
@@ -91,10 +91,8 @@ class DefaultAsyncCallbackOptions(AsyncCallbackOptions):
             state_utils=state_utils,
             redirect_uri_page_renderer=redirect_uri_page_renderer,
         )
-        # Note that pytype 2021.4.26 misunderstands these assignments.
-        # Thus, we put "type: ignore" for the following two lines
-        self.success = self._success_handler  # type: ignore
-        self.failure = self._failure_handler  # type: ignore
+        self.success = self._success_handler
+        self.failure = self._failure_handler
 
     # --------------------------
     # Internal methods

--- a/slack_bolt/oauth/async_internals.py
+++ b/slack_bolt/oauth/async_internals.py
@@ -1,5 +1,5 @@
 from logging import Logger
-from typing import Optional
+from typing import Dict, Optional
 
 from slack_sdk.oauth.installation_store import FileInstallationStore
 from slack_sdk.oauth.installation_store.async_installation_store import (
@@ -9,7 +9,7 @@ from slack_sdk.oauth.installation_store.async_installation_store import (
 from ..logger.messages import warning_installation_store_conflicts
 
 # key: client_id, value: AsyncInstallationStore
-default_installation_stores = {}
+default_installation_stores: Dict[str, AsyncInstallationStore] = {}
 
 
 def get_or_create_default_installation_store(client_id: str) -> AsyncInstallationStore:

--- a/slack_bolt/oauth/async_oauth_settings.py
+++ b/slack_bolt/oauth/async_oauth_settings.py
@@ -116,26 +116,17 @@ class AsyncOAuthSettings:
             logger: The logger that will be used internally
         """
         # OAuth flow parameters/credentials
-        client_id: Optional[str] = client_id or os.environ.get("SLACK_CLIENT_ID")
-        client_secret: Optional[str] = client_secret or os.environ.get("SLACK_CLIENT_SECRET")
+        client_id = client_id or os.environ.get("SLACK_CLIENT_ID")
+        client_secret = client_secret or os.environ.get("SLACK_CLIENT_SECRET")
         if client_id is None or client_secret is None:
             raise BoltError("Both client_id and client_secret are required")
         self.client_id = client_id
         self.client_secret = client_secret
 
-        # NOTE: pytype says that self.scopes can be str, not Sequence[str].
-        # That's true but we will check the pattern in the following if statement.
-        # Thus, we ignore the warnings here. This is the same for user_scopes too.
-        self.scopes = (  # type: ignore
-            scopes  # type: ignore
-            if scopes is not None
-            else os.environ.get("SLACK_SCOPES", "").split(",")  # type: ignore
-        )  # type: ignore
+        self.scopes = scopes if scopes is not None else os.environ.get("SLACK_SCOPES", "").split(",")
         if isinstance(self.scopes, str):
             self.scopes = self.scopes.split(",")
-        self.user_scopes = (  # type: ignore
-            user_scopes if user_scopes is not None else os.environ.get("SLACK_USER_SCOPES", "").split(",")  # type: ignore
-        )  # type: ignore
+        self.user_scopes = user_scopes if user_scopes is not None else os.environ.get("SLACK_USER_SCOPES", "").split(",")
         if isinstance(self.user_scopes, str):
             self.user_scopes = self.user_scopes.split(",")
 

--- a/slack_bolt/oauth/callback_options.py
+++ b/slack_bolt/oauth/callback_options.py
@@ -11,12 +11,12 @@ from slack_bolt.response import BoltResponse
 
 
 class SuccessArgs:
-    def __init__(  # type: ignore
+    def __init__(
         self,
         *,
         request: BoltRequest,
         installation: Installation,
-        settings: "OAuthSettings",
+        settings: "OAuthSettings",  # type: ignore[name-defined]
         default: "CallbackOptions",
     ):
         """The arguments for a success function.
@@ -34,14 +34,14 @@ class SuccessArgs:
 
 
 class FailureArgs:
-    def __init__(  # type: ignore
+    def __init__(
         self,
         *,
         request: BoltRequest,
         reason: str,
         error: Optional[Exception] = None,
         suggested_status_code: int,
-        settings: "OAuthSettings",
+        settings: "OAuthSettings",  # type: ignore[name-defined]
         default: "CallbackOptions",
     ):
         """The arguments for a failure function.

--- a/slack_bolt/oauth/internals.py
+++ b/slack_bolt/oauth/internals.py
@@ -1,6 +1,6 @@
 import html
 from logging import Logger
-from typing import Optional
+from typing import Dict, Optional
 from typing import Union
 
 from slack_sdk.oauth import InstallationStore
@@ -25,16 +25,16 @@ class CallbackResponseBuilder:
         self._state_utils = state_utils
         self._redirect_uri_page_renderer = redirect_uri_page_renderer
 
-    def _build_callback_success_response(  # type: ignore
+    def _build_callback_success_response(
         self,
-        request: Union[BoltRequest, "AsyncBoltRequest"],
+        request: Union[BoltRequest, "AsyncBoltRequest"],  # type: ignore[name-defined]
         installation: Installation,
     ) -> BoltResponse:
         debug_message = f"Handling an OAuth callback success (request: {request.query})"
         self._logger.debug(debug_message)
 
         page_content = self._redirect_uri_page_renderer.render_success_page(
-            app_id=installation.app_id,
+            app_id=installation.app_id,  # type: ignore[arg-type]
             team_id=installation.team_id,
             is_enterprise_install=installation.is_enterprise_install,
             enterprise_url=installation.enterprise_url,
@@ -48,9 +48,9 @@ class CallbackResponseBuilder:
             body=page_content,
         )
 
-    def _build_callback_failure_response(  # type: ignore
+    def _build_callback_failure_response(
         self,
-        request: Union[BoltRequest, "AsyncBoltRequest"],
+        request: Union[BoltRequest, "AsyncBoltRequest"],  # type: ignore[name-defined]
         reason: str,
         status: int = 500,
         error: Optional[Exception] = None,
@@ -92,7 +92,7 @@ body {{
 
 
 # key: client_id, value: InstallationStore
-default_installation_stores = {}
+default_installation_stores: Dict[str, InstallationStore] = {}
 
 
 def get_or_create_default_installation_store(client_id: str) -> InstallationStore:

--- a/slack_bolt/oauth/oauth_settings.py
+++ b/slack_bolt/oauth/oauth_settings.py
@@ -110,26 +110,17 @@ class OAuthSettings:
             state_expiration_seconds: The seconds that the state value is alive (Default: 600 seconds)
             logger: The logger that will be used internally
         """
-        client_id: Optional[str] = client_id or os.environ.get("SLACK_CLIENT_ID")
-        client_secret: Optional[str] = client_secret or os.environ.get("SLACK_CLIENT_SECRET")
+        client_id = client_id or os.environ.get("SLACK_CLIENT_ID")
+        client_secret = client_secret or os.environ.get("SLACK_CLIENT_SECRET")
         if client_id is None or client_secret is None:
             raise BoltError("Both client_id and client_secret are required")
         self.client_id = client_id
         self.client_secret = client_secret
 
-        # NOTE: pytype says that self.scopes can be str, not Sequence[str].
-        # That's true but we will check the pattern in the following if statement.
-        # Thus, we ignore the warnings here. This is the same for user_scopes too.
-        self.scopes = (  # type: ignore
-            scopes  # type: ignore
-            if scopes is not None
-            else os.environ.get("SLACK_SCOPES", "").split(",")  # type: ignore
-        )  # type: ignore
+        self.scopes = scopes if scopes is not None else os.environ.get("SLACK_SCOPES", "").split(",")
         if isinstance(self.scopes, str):
             self.scopes = self.scopes.split(",")
-        self.user_scopes = (  # type: ignore
-            user_scopes if user_scopes is not None else os.environ.get("SLACK_USER_SCOPES", "").split(",")  # type: ignore
-        )  # type: ignore
+        self.user_scopes = user_scopes if user_scopes is not None else os.environ.get("SLACK_USER_SCOPES", "").split(",")
         if isinstance(self.user_scopes, str):
             self.user_scopes = self.user_scopes.split(",")
         self.redirect_uri = redirect_uri or os.environ.get("SLACK_REDIRECT_URI")

--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -112,7 +112,7 @@ def extract_team_id(payload: Dict[str, Any]) -> Optional[str]:
     if payload.get("event") is not None:
         return extract_team_id(payload["event"])
     if payload.get("user") is not None:
-        return payload.get("user", {})["team_id"]
+        return payload["user"]["team_id"]
     if payload.get("view") is not None:
         return payload.get("view", {})["team_id"]
     return None

--- a/slack_bolt/workflows/step/async_step.py
+++ b/slack_bolt/workflows/step/async_step.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 from functools import wraps
 from logging import Logger
 from typing import Callable, Union, Optional, Awaitable, Sequence, List, Pattern
@@ -298,7 +299,7 @@ class AsyncWorkflowStepBuilder:
                     _matchers.append(AsyncCustomListenerMatcher(app_name=app_name, func=m))
                 else:
                     raise ValueError(f"Invalid matcher: {type(m)}")
-        return _matchers  # type: ignore
+        return _matchers
 
     @staticmethod
     def to_listener_middleware(
@@ -313,7 +314,7 @@ class AsyncWorkflowStepBuilder:
                     _middleware.append(AsyncCustomMiddleware(app_name=app_name, func=m))
                 else:
                     raise ValueError(f"Invalid middleware: {type(m)}")
-        return _middleware  # type: ignore
+        return _middleware
 
 
 class AsyncWorkflowStep:

--- a/slack_bolt/workflows/step/async_step_middleware.py
+++ b/slack_bolt/workflows/step/async_step_middleware.py
@@ -1,7 +1,8 @@
+# mypy: ignore-errors
 from typing import Callable, Optional, Awaitable
 
 from slack_bolt.listener.async_listener import AsyncListener
-from slack_bolt.listener.asyncio_runner import AsyncioListenerRunner  # type: ignore
+from slack_bolt.listener.asyncio_runner import AsyncioListenerRunner
 from slack_bolt.middleware.async_middleware import AsyncMiddleware
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
@@ -9,7 +10,7 @@ from slack_bolt.util.utils import get_name_for_callable
 from slack_bolt.workflows.step.async_step import AsyncWorkflowStep
 
 
-class AsyncWorkflowStepMiddleware(AsyncMiddleware):  # type:ignore
+class AsyncWorkflowStepMiddleware(AsyncMiddleware):
     """Base middleware for step from app specific ones"""
 
     def __init__(self, step: AsyncWorkflowStep, listener_runner: AsyncioListenerRunner):

--- a/slack_bolt/workflows/step/step.py
+++ b/slack_bolt/workflows/step/step.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 from functools import wraps
 from logging import Logger
 from typing import Callable, Union, Optional, Sequence, Pattern, List
@@ -301,7 +302,7 @@ class WorkflowStepBuilder:
                     )
                 else:
                     raise ValueError(f"Invalid matcher: {type(m)}")
-        return _matchers  # type: ignore
+        return _matchers
 
     @staticmethod
     def to_listener_middleware(
@@ -324,7 +325,7 @@ class WorkflowStepBuilder:
                     )
                 else:
                     raise ValueError(f"Invalid middleware: {type(m)}")
-        return _middleware  # type: ignore
+        return _middleware
 
 
 class WorkflowStep:

--- a/slack_bolt/workflows/step/step_middleware.py
+++ b/slack_bolt/workflows/step/step_middleware.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 from typing import Callable, Optional
 
 from slack_bolt.listener import Listener
@@ -9,7 +10,7 @@ from slack_bolt.util.utils import get_name_for_callable
 from slack_bolt.workflows.step.step import WorkflowStep
 
 
-class WorkflowStepMiddleware(Middleware):  # type:ignore
+class WorkflowStepMiddleware(Middleware):
     """Base middleware for step from app specific ones"""
 
     def __init__(self, step: WorkflowStep, listener_runner: ThreadListenerRunner):

--- a/tests/adapter_tests/asgi/test_asgi_lifespan.py
+++ b/tests/adapter_tests/asgi/test_asgi_lifespan.py
@@ -71,4 +71,4 @@ class TestAsgiLifespan:
         with pytest.raises(TypeError) as e:
             await asgi_server.websocket()
 
-        assert e.match("Unsupported scope type: websocket")
+        assert e.match("Unsupported scope type: 'websocket'")


### PR DESCRIPTION
[MyPy](https://mypy.readthedocs.io/en/latest/index.html) was found to execute much fast the [PyType](https://google.github.io/pytype/) in this project, these changes adapt the project to use MyPy instead of PyType

| pytype           | mypy |
| -----------  | ------ |
| <img width="745" alt="Screenshot 2024-08-15 at 5 45 47 PM" src="https://github.com/user-attachments/assets/2049df41-ca7f-4387-ad97-6ff9da9e9774"> | <img width="750" alt="Screenshot 2024-08-15 at 5 46 03 PM" src="https://github.com/user-attachments/assets/e2ece1fa-9e81-47b8-b202-92d0047299f0"> | 
| 11m27s | 43s |

From my short experience with mypy:
- Good documentation 📜 
- Good error surfacing
- Easy to configure
- It offers a language server, this helps with development since it integrate with IDEs

Concern: This tool can be strict if we let it, I think it will lead to "safer", more resilient, code. We should not let it get in the way of writing clear and efficient code.

Note: removing all the `type: ignore` comments from the project may cause breaking changes or have a ripple effect through the entire project


Let me know If we want more tests to cover these changes 🤔 

---
### Category

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
