### PR TITLE
Fix #1131 A class with async "__call__" method fails to work as a middleware

### DIFF
--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -24,7 +24,7 @@ from slack_bolt.middleware.message_listener_matches.async_message_listener_match
     AsyncMessageListenerMatches,
 )
 from slack_bolt.oauth.async_internals import select_consistent_installation_store
-from slack_bolt.util.utils import get_name_for_callable
+from slack_bolt.util.utils import get_name_for_callable, is_coroutine_function
 from slack_bolt.workflows.step.async_step import (
     AsyncWorkflowStep,
     AsyncWorkflowStepBuilder,
@@ -778,7 +778,7 @@ class AsyncApp:
             func: The function that is supposed to be executed
                 when getting an unhandled error in Bolt app.
         """
-        if not inspect.iscoroutinefunction(func):
+        if not is_coroutine_function(func):
             name = get_name_for_callable(func)
             raise BoltError(error_listener_function_must_be_coro_func(name))
         self._async_listener_runner.listener_error_handler = AsyncCustomListenerErrorHandler(
@@ -1410,7 +1410,7 @@ class AsyncApp:
             value_to_return = functions[0]
 
         for func in functions:
-            if not inspect.iscoroutinefunction(func):
+            if not is_coroutine_function(func):
                 name = get_name_for_callable(func)
                 raise BoltError(error_listener_function_must_be_coro_func(name))
 
@@ -1422,7 +1422,7 @@ class AsyncApp:
         for m in middleware or []:
             if isinstance(m, AsyncMiddleware):
                 listener_middleware.append(m)
-            elif isinstance(m, Callable) and inspect.iscoroutinefunction(m):
+            elif isinstance(m, Callable) and is_coroutine_function(m):
                 listener_middleware.append(AsyncCustomMiddleware(app_name=self.name, func=m, base_logger=self._base_logger))
             else:
                 raise ValueError(error_unexpected_listener_middleware(type(m)))

--- a/slack_bolt/middleware/async_custom_middleware.py
+++ b/slack_bolt/middleware/async_custom_middleware.py
@@ -1,4 +1,3 @@
-import inspect
 from logging import Logger
 from typing import Callable, Awaitable, Any, Sequence, Optional
 
@@ -7,7 +6,7 @@ from slack_bolt.logger import get_bolt_app_logger
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 from .async_middleware import AsyncMiddleware
-from slack_bolt.util.utils import get_name_for_callable, get_arg_names_of_callable
+from slack_bolt.util.utils import get_name_for_callable, get_arg_names_of_callable, is_coroutine_function
 
 
 class AsyncCustomMiddleware(AsyncMiddleware):
@@ -24,7 +23,7 @@ class AsyncCustomMiddleware(AsyncMiddleware):
         base_logger: Optional[Logger] = None,
     ):
         self.app_name = app_name
-        if inspect.iscoroutinefunction(func):
+        if is_coroutine_function(func):
             self.func = func
         else:
             raise ValueError("Async middleware function must be an async function")

--- a/slack_bolt/util/utils.py
+++ b/slack_bolt/util/utils.py
@@ -88,3 +88,9 @@ def get_name_for_callable(func: Callable) -> str:
 
 def get_arg_names_of_callable(func: Callable) -> List[str]:
     return inspect.getfullargspec(inspect.unwrap(func)).args
+
+
+def is_coroutine_function(func: Optional[Any]) -> bool:
+    return func is not None and (
+        inspect.iscoroutinefunction(func) or (hasattr(func, "__call__") and inspect.iscoroutinefunction(func.__call__))
+    )

--- a/tests/scenario_tests_async/test_app_using_methods_in_class.py
+++ b/tests/scenario_tests_async/test_app_using_methods_in_class.py
@@ -150,6 +150,14 @@ class TestAppUsingMethodsInClass:
         await self.run_app_and_verify(app)
 
     @pytest.mark.asyncio
+    async def test_callable_class(self):
+        app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret)
+        instance = CallableClass("Slackbot")
+        app.use(instance)
+        app.shortcut("test-shortcut")(instance.event_handler)
+        await self.run_app_and_verify(app)
+
+    @pytest.mark.asyncio
     async def test_instance_methods_uncommon_name_1(self):
         app = AsyncApp(client=self.web_client, signing_secret=self.signing_secret)
         awesome = AwesomeClass("Slackbot")
@@ -223,6 +231,18 @@ class AwesomeClass:
     async def static_method(context: AsyncBoltContext, say: AsyncSay, ack: AsyncAck):
         await ack()
         await say(f"Hello <@{context.user_id}>!")
+
+
+class CallableClass:
+    def __init__(self, name: str):
+        self.name = name
+
+    async def __call__(self, next: Callable):
+        await next()
+
+    async def event_handler(self, context: AsyncBoltContext, say: AsyncSay, ack: AsyncAck):
+        await ack()
+        await say(f"Hello <@{context.user_id}>! My name is {self.name}")
 
 
 async def top_level_function(invalid_arg, ack, say):


### PR DESCRIPTION
This pull request resolves #1131

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
