### PR TITLE
chore: naming of is_coroutine_function

### DIFF
--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -25,7 +25,7 @@ from slack_bolt.middleware.message_listener_matches.async_message_listener_match
     AsyncMessageListenerMatches,
 )
 from slack_bolt.oauth.async_internals import select_consistent_installation_store
-from slack_bolt.util.utils import get_name_for_callable, is_coroutine_function
+from slack_bolt.util.utils import get_name_for_callable, is_callable_coroutine
 from slack_bolt.workflows.step.async_step import (
     AsyncWorkflowStep,
     AsyncWorkflowStepBuilder,
@@ -786,7 +786,7 @@ class AsyncApp:
             func: The function that is supposed to be executed
                 when getting an unhandled error in Bolt app.
         """
-        if not is_coroutine_function(func):
+        if not is_callable_coroutine(func):
             name = get_name_for_callable(func)
             raise BoltError(error_listener_function_must_be_coro_func(name))
         self._async_listener_runner.listener_error_handler = AsyncCustomListenerErrorHandler(
@@ -1418,7 +1418,7 @@ class AsyncApp:
             value_to_return = functions[0]
 
         for func in functions:
-            if not is_coroutine_function(func):
+            if not is_callable_coroutine(func):
                 name = get_name_for_callable(func)
                 raise BoltError(error_listener_function_must_be_coro_func(name))
 
@@ -1430,7 +1430,7 @@ class AsyncApp:
         for m in middleware or []:
             if isinstance(m, AsyncMiddleware):
                 listener_middleware.append(m)
-            elif callable(m) and is_coroutine_function(m):
+            elif callable(m) and is_callable_coroutine(m):
                 listener_middleware.append(AsyncCustomMiddleware(app_name=self.name, func=m, base_logger=self._base_logger))
             else:
                 raise ValueError(error_unexpected_listener_middleware(type(m)))

--- a/slack_bolt/middleware/async_custom_middleware.py
+++ b/slack_bolt/middleware/async_custom_middleware.py
@@ -6,7 +6,7 @@ from slack_bolt.logger import get_bolt_app_logger
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 from .async_middleware import AsyncMiddleware
-from slack_bolt.util.utils import get_name_for_callable, get_arg_names_of_callable, is_coroutine_function
+from slack_bolt.util.utils import get_name_for_callable, get_arg_names_of_callable, is_callable_coroutine
 
 
 class AsyncCustomMiddleware(AsyncMiddleware):
@@ -23,7 +23,7 @@ class AsyncCustomMiddleware(AsyncMiddleware):
         base_logger: Optional[Logger] = None,
     ):
         self.app_name = app_name
-        if is_coroutine_function(func):
+        if is_callable_coroutine(func):
             self.func = func
         else:
             raise ValueError("Async middleware function must be an async function")

--- a/slack_bolt/util/utils.py
+++ b/slack_bolt/util/utils.py
@@ -90,7 +90,7 @@ def get_arg_names_of_callable(func: Callable) -> List[str]:
     return inspect.getfullargspec(inspect.unwrap(func)).args
 
 
-def is_coroutine_function(func: Optional[Any]) -> bool:
+def is_callable_coroutine(func: Optional[Any]) -> bool:
     return func is not None and (
         inspect.iscoroutinefunction(func) or (hasattr(func, "__call__") and inspect.iscoroutinefunction(func.__call__))
     )


### PR DESCRIPTION
This is a follow up to #1132, take it or leave it

These changes rename `is_coroutine_function` to `is_callable_coroutine`. [Callables](https://docs.python.org/3/library/functions.html#callable) can be a function/method or an instances of a class that has a [\_\_call\_\_()](https://docs.python.org/3/reference/datamodel.html#object.__call__) method. This naming aims to be more descriptive.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
