### PR TITLE
Add option for additional context to Sanic adapter handler

### DIFF
--- a/slack_bolt/adapter/sanic/async_handler.py
+++ b/slack_bolt/adapter/sanic/async_handler.py
@@ -9,9 +9,7 @@ from slack_bolt.async_app import AsyncApp, AsyncBoltRequest
 from slack_bolt.oauth.async_oauth_flow import AsyncOAuthFlow
 
 
-def to_async_bolt_request(
-    req: Request, addition_context_properties: Optional[Dict[str, Any]] = None
-) -> AsyncBoltRequest:
+def to_async_bolt_request(req: Request, addition_context_properties: Optional[Dict[str, Any]] = None) -> AsyncBoltRequest:
     request = AsyncBoltRequest(
         body=req.body.decode("utf-8"),
         query=req.query_string,
@@ -51,27 +49,19 @@ class AsyncSlackRequestHandler:
     def __init__(self, app: AsyncApp):
         self.app = app
 
-    async def handle(
-        self, req: Request, addition_context_properties: Optional[Dict[str, Any]] = None
-    ) -> HTTPResponse:
+    async def handle(self, req: Request, addition_context_properties: Optional[Dict[str, Any]] = None) -> HTTPResponse:
         if req.method == "GET":
             if self.app.oauth_flow is not None:
                 oauth_flow: AsyncOAuthFlow = self.app.oauth_flow
                 if req.path == oauth_flow.install_path:
-                    bolt_resp = await oauth_flow.handle_installation(
-                        to_async_bolt_request(req, addition_context_properties)
-                    )
+                    bolt_resp = await oauth_flow.handle_installation(to_async_bolt_request(req, addition_context_properties))
                     return to_sanic_response(bolt_resp)
                 elif req.path == oauth_flow.redirect_uri_path:
-                    bolt_resp = await oauth_flow.handle_callback(
-                        to_async_bolt_request(req, addition_context_properties)
-                    )
+                    bolt_resp = await oauth_flow.handle_callback(to_async_bolt_request(req, addition_context_properties))
                     return to_sanic_response(bolt_resp)
 
         elif req.method == "POST":
-            bolt_resp = await self.app.async_dispatch(
-                to_async_bolt_request(req, addition_context_properties)
-            )
+            bolt_resp = await self.app.async_dispatch(to_async_bolt_request(req, addition_context_properties))
             return to_sanic_response(bolt_resp)
 
         return HTTPResponse(

--- a/slack_bolt/adapter/sanic/async_handler.py
+++ b/slack_bolt/adapter/sanic/async_handler.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Any, Dict, Optional
 
 from sanic.request import Request
 from sanic.response import HTTPResponse
@@ -8,12 +9,20 @@ from slack_bolt.async_app import AsyncApp, AsyncBoltRequest
 from slack_bolt.oauth.async_oauth_flow import AsyncOAuthFlow
 
 
-def to_async_bolt_request(req: Request) -> AsyncBoltRequest:
-    return AsyncBoltRequest(
+def to_async_bolt_request(
+    req: Request, addition_context_properties: Optional[Dict[str, Any]] = None
+) -> AsyncBoltRequest:
+    request = AsyncBoltRequest(
         body=req.body.decode("utf-8"),
         query=req.query_string,
         headers=req.headers,  # type: ignore[arg-type]
     )
+
+    if addition_context_properties is not None:
+        for k, v in addition_context_properties.items():
+            request.context[k] = v
+
+    return request
 
 
 def to_sanic_response(bolt_resp: BoltResponse) -> HTTPResponse:
@@ -42,19 +51,27 @@ class AsyncSlackRequestHandler:
     def __init__(self, app: AsyncApp):
         self.app = app
 
-    async def handle(self, req: Request) -> HTTPResponse:
+    async def handle(
+        self, req: Request, addition_context_properties: Optional[Dict[str, Any]] = None
+    ) -> HTTPResponse:
         if req.method == "GET":
             if self.app.oauth_flow is not None:
                 oauth_flow: AsyncOAuthFlow = self.app.oauth_flow
                 if req.path == oauth_flow.install_path:
-                    bolt_resp = await oauth_flow.handle_installation(to_async_bolt_request(req))
+                    bolt_resp = await oauth_flow.handle_installation(
+                        to_async_bolt_request(req, addition_context_properties)
+                    )
                     return to_sanic_response(bolt_resp)
                 elif req.path == oauth_flow.redirect_uri_path:
-                    bolt_resp = await oauth_flow.handle_callback(to_async_bolt_request(req))
+                    bolt_resp = await oauth_flow.handle_callback(
+                        to_async_bolt_request(req, addition_context_properties)
+                    )
                     return to_sanic_response(bolt_resp)
 
         elif req.method == "POST":
-            bolt_resp = await self.app.async_dispatch(to_async_bolt_request(req))
+            bolt_resp = await self.app.async_dispatch(
+                to_async_bolt_request(req, addition_context_properties)
+            )
             return to_sanic_response(bolt_resp)
 
         return HTTPResponse(


### PR DESCRIPTION
I'd like to pass additional context to the `AsyncBoltRequest` object, similar to what we do in the `starlette` adapter. 

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
