### PR TITLE
Add listener_runner to context object to enable developers to leverage lazy listeners in middleware

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -14,6 +14,5 @@ then
   black slack_bolt/ tests/ && \
     pytest -vv $1
 else
-    black slack_bolt/ tests/ && pytest
-  fi
+  black slack_bolt/ tests/ && pytest
 fi

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -735,7 +735,7 @@ class App:
         elif not isinstance(step, WorkflowStep):
             raise BoltError(f"Invalid step object ({type(step)})")
 
-        self.use(WorkflowStepMiddleware(step, self.listener_runner))
+        self.use(WorkflowStepMiddleware(step))
 
     # -------------------------
     # global error handler
@@ -1349,6 +1349,10 @@ class App:
             retry_handlers=self._client.retry_handlers.copy() if self._client.retry_handlers is not None else None,
         )
         req.context["client"] = client_per_request
+
+        # Most apps do not need this "listener_runner" instance.
+        # It is intended for apps that start lazy listeners from their custom global middleware.
+        req.context["listener_runner"] = self.listener_runner
 
     @staticmethod
     def _to_listener_functions(

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -761,7 +761,7 @@ class AsyncApp:
         elif not isinstance(step, AsyncWorkflowStep):
             raise BoltError(f"Invalid step object ({type(step)})")
 
-        self.use(AsyncWorkflowStepMiddleware(step, self._async_listener_runner))
+        self.use(AsyncWorkflowStepMiddleware(step))
 
     # -------------------------
     # global error handler
@@ -1389,6 +1389,10 @@ class AsyncApp:
             ),
         )
         req.context["client"] = client_per_request
+
+        # Most apps do not need this "listener_runner" instance.
+        # It is intended for apps that start lazy listeners from their custom global middleware.
+        req.context["listener_runner"] = self.listener_runner
 
     @staticmethod
     def _to_listener_functions(

--- a/slack_bolt/context/async_context.py
+++ b/slack_bolt/context/async_context.py
@@ -34,8 +34,9 @@ class AsyncBoltContext(BaseContext):
                     )
         return AsyncBoltContext(new_dict)
 
+    # The return type is intentionally string to avoid circular imports
     @property
-    def listener_runner(self) -> "AsyncioListenerRunner":  # to avoid circular imports
+    def listener_runner(self) -> "AsyncioListenerRunner":  # type: ignore[name-defined]
         """The properly configured listener_runner that is available for middleware/listeners."""
         return self["listener_runner"]
 

--- a/slack_bolt/context/base_context.py
+++ b/slack_bolt/context/base_context.py
@@ -7,7 +7,7 @@ from slack_bolt.authorization import AuthorizeResult
 class BaseContext(dict):
     """Context object associated with a request from Slack."""
 
-    standard_property_names = [
+    copyable_standard_property_names = [
         "logger",
         "token",
         "enterprise_id",
@@ -35,6 +35,11 @@ class BaseContext(dict):
         "complete",
         "fail",
     ]
+    non_copyable_standard_property_names = [
+        "listener_runner",
+    ]
+
+    standard_property_names = copyable_standard_property_names + non_copyable_standard_property_names
 
     @property
     def logger(self) -> Logger:

--- a/slack_bolt/context/context.py
+++ b/slack_bolt/context/context.py
@@ -17,9 +17,12 @@ class BoltContext(BaseContext):
     def to_copyable(self) -> "BoltContext":
         new_dict = {}
         for prop_name, prop_value in self.items():
-            if prop_name in self.standard_property_names:
+            if prop_name in self.copyable_standard_property_names:
                 # all the standard properties are copiable
                 new_dict[prop_name] = prop_value
+            elif prop_name in self.non_copyable_standard_property_names:
+                # Do nothing with this property (e.g., listener_runner)
+                continue
             else:
                 try:
                     copied_value = create_copy(prop_value)
@@ -31,6 +34,11 @@ class BoltContext(BaseContext):
                         f"(error: {te})"
                     )
         return BoltContext(new_dict)
+
+    @property
+    def listener_runner(self) -> "ThreadListenerRunner":  # to avoid circular imports
+        """The properly configured listener_runner that is available for middleware/listeners."""
+        return self["listener_runner"]
 
     @property
     def client(self) -> Optional[WebClient]:

--- a/slack_bolt/context/context.py
+++ b/slack_bolt/context/context.py
@@ -35,8 +35,9 @@ class BoltContext(BaseContext):
                     )
         return BoltContext(new_dict)
 
+    # The return type is intentionally string to avoid circular imports
     @property
-    def listener_runner(self) -> "ThreadListenerRunner":  # to avoid circular imports
+    def listener_runner(self) -> "ThreadListenerRunner":  # type: ignore[name-defined]
         """The properly configured listener_runner that is available for middleware/listeners."""
         return self["listener_runner"]
 

--- a/slack_bolt/listener/asyncio_runner.py
+++ b/slack_bolt/listener/asyncio_runner.py
@@ -174,12 +174,12 @@ class AsyncioListenerRunner:
         copied_request = self._build_lazy_request(request, func_name)
         self.lazy_listener_runner.start(function=lazy_func, request=copied_request)
 
-    @staticmethod
-    def _build_lazy_request(request: AsyncBoltRequest, lazy_func_name: str) -> AsyncBoltRequest:
-        copied_request = create_copy(request.to_copyable())
+    def _build_lazy_request(self, request: AsyncBoltRequest, lazy_func_name: str) -> AsyncBoltRequest:
+        copied_request: AsyncBoltRequest = create_copy(request.to_copyable())
         copied_request.method = "NONE"
         copied_request.lazy_only = True
         copied_request.lazy_function_name = lazy_func_name
+        copied_request.context["listener_runner"] = self
         return copied_request
 
     def _debug_log_completion(self, starting_time: float, response: BoltResponse) -> None:

--- a/slack_bolt/listener/asyncio_runner.py
+++ b/slack_bolt/listener/asyncio_runner.py
@@ -176,7 +176,6 @@ class AsyncioListenerRunner:
 
     def _build_lazy_request(self, request: AsyncBoltRequest, lazy_func_name: str) -> AsyncBoltRequest:
         copied_request: AsyncBoltRequest = create_copy(request.to_copyable())
-        copied_request.method = "NONE"
         copied_request.lazy_only = True
         copied_request.lazy_function_name = lazy_func_name
         copied_request.context["listener_runner"] = self

--- a/slack_bolt/listener/thread_runner.py
+++ b/slack_bolt/listener/thread_runner.py
@@ -187,7 +187,6 @@ class ThreadListenerRunner:
 
     def _build_lazy_request(self, request: BoltRequest, lazy_func_name: str) -> BoltRequest:
         copied_request: BoltRequest = create_copy(request.to_copyable())
-        copied_request.method = "NONE"
         copied_request.lazy_only = True
         copied_request.lazy_function_name = lazy_func_name
         copied_request.context["listener_runner"] = self

--- a/slack_bolt/listener/thread_runner.py
+++ b/slack_bolt/listener/thread_runner.py
@@ -185,12 +185,12 @@ class ThreadListenerRunner:
         copied_request = self._build_lazy_request(request, func_name)
         self.lazy_listener_runner.start(function=lazy_func, request=copied_request)
 
-    @staticmethod
-    def _build_lazy_request(request: BoltRequest, lazy_func_name: str) -> BoltRequest:
-        copied_request = create_copy(request.to_copyable())
+    def _build_lazy_request(self, request: BoltRequest, lazy_func_name: str) -> BoltRequest:
+        copied_request: BoltRequest = create_copy(request.to_copyable())
         copied_request.method = "NONE"
         copied_request.lazy_only = True
         copied_request.lazy_function_name = lazy_func_name
+        copied_request.context["listener_runner"] = self
         return copied_request
 
     def _debug_log_completion(self, starting_time: float, response: BoltResponse) -> None:

--- a/slack_bolt/workflows/step/async_step_middleware.py
+++ b/slack_bolt/workflows/step/async_step_middleware.py
@@ -2,7 +2,6 @@
 from typing import Callable, Optional, Awaitable
 
 from slack_bolt.listener.async_listener import AsyncListener
-from slack_bolt.listener.asyncio_runner import AsyncioListenerRunner
 from slack_bolt.middleware.async_middleware import AsyncMiddleware
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
@@ -13,9 +12,8 @@ from slack_bolt.workflows.step.async_step import AsyncWorkflowStep
 class AsyncWorkflowStepMiddleware(AsyncMiddleware):
     """Base middleware for step from app specific ones"""
 
-    def __init__(self, step: AsyncWorkflowStep, listener_runner: AsyncioListenerRunner):
+    def __init__(self, step: AsyncWorkflowStep):
         self.step = step
-        self.listener_runner = listener_runner
 
     async def async_process(
         self,
@@ -40,8 +38,8 @@ class AsyncWorkflowStepMiddleware(AsyncMiddleware):
 
         return await next()
 
+    @staticmethod
     async def _run(
-        self,
         listener: AsyncListener,
         req: AsyncBoltRequest,
         resp: BoltResponse,
@@ -50,7 +48,7 @@ class AsyncWorkflowStepMiddleware(AsyncMiddleware):
         if next_was_not_called:
             return None
 
-        return await self.listener_runner.run(
+        return await req.context.listener_runner.run(
             request=req,
             response=resp,
             listener_name=get_name_for_callable(listener.ack_function),

--- a/slack_bolt/workflows/step/step_middleware.py
+++ b/slack_bolt/workflows/step/step_middleware.py
@@ -2,7 +2,6 @@
 from typing import Callable, Optional
 
 from slack_bolt.listener import Listener
-from slack_bolt.listener.thread_runner import ThreadListenerRunner
 from slack_bolt.middleware import Middleware
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
@@ -13,9 +12,8 @@ from slack_bolt.workflows.step.step import WorkflowStep
 class WorkflowStepMiddleware(Middleware):
     """Base middleware for step from app specific ones"""
 
-    def __init__(self, step: WorkflowStep, listener_runner: ThreadListenerRunner):
+    def __init__(self, step: WorkflowStep):
         self.step = step
-        self.listener_runner = listener_runner
 
     def process(
         self,
@@ -43,8 +41,8 @@ class WorkflowStepMiddleware(Middleware):
 
         return next()
 
+    @staticmethod
     def _run(
-        self,
         listener: Listener,
         req: BoltRequest,
         resp: BoltResponse,
@@ -53,7 +51,7 @@ class WorkflowStepMiddleware(Middleware):
         if next_was_not_called:
             return None
 
-        return self.listener_runner.run(
+        return req.context.listener_runner.run(
             request=req,
             response=resp,
             listener_name=get_name_for_callable(listener.ack_function),


### PR DESCRIPTION
This pull request adds "listener_runner," a foundational module for running listener matchers/middleware and lazy listeners in Bolt apps, to the context object. This enhancement enables third-party app developers to start lazy listeners within global custom middleware. Without it, developers need to manually pass the App's current listener_runner to their global middleware, which is quite inflexible and hard to maintain. 

Additionally, our new project (the one our team members should know but **we cannot publicly mention yet!**) requires this functionality.

To see what the use case looks like, please take a look at the test code in this PR. While the `LazyListenerStarter` middleware in test code is quite simple, the actual use case would involve creating a more complex object that can accept a few functions and dispatch requests to the relevant ones. If none of the functions matches, it would pass the request to other middleware and listeners by calling `next()`.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
