### PR TITLE
disc: remove the optional typing of client

### DIFF
--- a/slack_bolt/authorization/async_authorize.py
+++ b/slack_bolt/authorization/async_authorize.py
@@ -331,10 +331,10 @@ class AsyncInstallationStoreAuthorize(AsyncAuthorize):
             return self.authorize_result_cache[token]
 
         try:
-            auth_test_api_response = await context.client.auth_test(token=token)  # type: ignore[union-attr]
+            auth_test_api_response = await context.client.auth_test(token=token)
             user_auth_test_response = None
             if user_token is not None and token != user_token:
-                user_auth_test_response = await context.client.auth_test(token=user_token)  # type: ignore[union-attr]
+                user_auth_test_response = await context.client.auth_test(token=user_token)
             authorize_result = AuthorizeResult.from_auth_test_response(
                 auth_test_response=auth_test_api_response,
                 user_auth_test_response=user_auth_test_response,

--- a/slack_bolt/authorization/async_authorize_args.py
+++ b/slack_bolt/authorization/async_authorize_args.py
@@ -32,7 +32,7 @@ class AsyncAuthorizeArgs:
         """
         self.context = context
         self.logger = context.logger
-        self.client = context.client  # type: ignore[assignment]
+        self.client = context.client
         self.enterprise_id = enterprise_id
         self.team_id = team_id
         self.user_id = user_id

--- a/slack_bolt/authorization/authorize.py
+++ b/slack_bolt/authorization/authorize.py
@@ -328,10 +328,10 @@ class InstallationStoreAuthorize(Authorize):
             return self.authorize_result_cache[token]
 
         try:
-            auth_test_api_response = context.client.auth_test(token=token)  # type: ignore[union-attr]
+            auth_test_api_response = context.client.auth_test(token=token)
             user_auth_test_response = None
             if user_token is not None and token != user_token:
-                user_auth_test_response = context.client.auth_test(token=user_token)  # type: ignore[union-attr]
+                user_auth_test_response = context.client.auth_test(token=user_token)
             authorize_result = AuthorizeResult.from_auth_test_response(
                 auth_test_response=auth_test_api_response,
                 user_auth_test_response=user_auth_test_response,

--- a/slack_bolt/authorization/authorize_args.py
+++ b/slack_bolt/authorization/authorize_args.py
@@ -32,7 +32,7 @@ class AuthorizeArgs:
         """
         self.context = context
         self.logger = context.logger
-        self.client = context.client  # type: ignore[assignment]
+        self.client = context.client
         self.enterprise_id = enterprise_id
         self.team_id = team_id
         self.user_id = user_id

--- a/slack_bolt/context/async_context.py
+++ b/slack_bolt/context/async_context.py
@@ -41,7 +41,7 @@ class AsyncBoltContext(BaseContext):
         return self["listener_runner"]
 
     @property
-    def client(self) -> Optional[AsyncWebClient]:
+    def client(self) -> AsyncWebClient:
         """The `AsyncWebClient` instance available for this request.
 
             @app.event("app_mention")
@@ -129,8 +129,8 @@ class AsyncBoltContext(BaseContext):
         if "respond" not in self:
             self["respond"] = AsyncRespond(
                 response_url=self.response_url,
-                proxy=self.client.proxy,  # type: ignore[union-attr]
-                ssl=self.client.ssl,  # type: ignore[union-attr]
+                proxy=self.client.proxy,
+                ssl=self.client.ssl,
             )
         return self["respond"]
 
@@ -156,7 +156,7 @@ class AsyncBoltContext(BaseContext):
         """
         if "complete" not in self:
             self["complete"] = AsyncComplete(
-                client=self.client, function_execution_id=self.function_execution_id  # type: ignore[arg-type]
+                client=self.client, function_execution_id=self.function_execution_id
             )
         return self["complete"]
 
@@ -182,6 +182,6 @@ class AsyncBoltContext(BaseContext):
         """
         if "fail" not in self:
             self["fail"] = AsyncFail(
-                client=self.client, function_execution_id=self.function_execution_id  # type: ignore[arg-type]
+                client=self.client, function_execution_id=self.function_execution_id
             )
         return self["fail"]

--- a/slack_bolt/context/context.py
+++ b/slack_bolt/context/context.py
@@ -42,7 +42,7 @@ class BoltContext(BaseContext):
         return self["listener_runner"]
 
     @property
-    def client(self) -> Optional[WebClient]:
+    def client(self) -> WebClient:
         """The `WebClient` instance available for this request.
 
             @app.event("app_mention")
@@ -130,8 +130,8 @@ class BoltContext(BaseContext):
         if "respond" not in self:
             self["respond"] = Respond(
                 response_url=self.response_url,
-                proxy=self.client.proxy,  # type: ignore[union-attr]
-                ssl=self.client.ssl,  # type: ignore[union-attr]
+                proxy=self.client.proxy,
+                ssl=self.client.ssl,
             )
         return self["respond"]
 
@@ -157,7 +157,7 @@ class BoltContext(BaseContext):
         """
         if "complete" not in self:
             self["complete"] = Complete(
-                client=self.client, function_execution_id=self.function_execution_id  # type: ignore[arg-type]
+                client=self.client, function_execution_id=self.function_execution_id
             )
         return self["complete"]
 
@@ -183,6 +183,6 @@ class BoltContext(BaseContext):
         """
         if "fail" not in self:
             self["fail"] = Fail(
-                client=self.client, function_execution_id=self.function_execution_id  # type: ignore[arg-type]
+                client=self.client, function_execution_id=self.function_execution_id
             )
         return self["fail"]

--- a/slack_bolt/middleware/attaching_function_token/async_attaching_function_token.py
+++ b/slack_bolt/middleware/attaching_function_token/async_attaching_function_token.py
@@ -15,6 +15,6 @@ class AsyncAttachingFunctionToken(AsyncMiddleware):
         next: Callable[[], Awaitable[BoltResponse]],
     ) -> BoltResponse:
         if req.context.function_bot_access_token is not None:
-            req.context.client.token = req.context.function_bot_access_token  # type: ignore[union-attr]
+            req.context.client.token = req.context.function_bot_access_token
 
         return await next()

--- a/slack_bolt/middleware/attaching_function_token/attaching_function_token.py
+++ b/slack_bolt/middleware/attaching_function_token/attaching_function_token.py
@@ -15,6 +15,6 @@ class AttachingFunctionToken(Middleware):
         next: Callable[[], BoltResponse],
     ) -> BoltResponse:
         if req.context.function_bot_access_token is not None:
-            req.context.client.token = req.context.function_bot_access_token  # type: ignore[union-attr]
+            req.context.client.token = req.context.function_bot_access_token
 
         return next()

--- a/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/async_multi_teams_authorization.py
@@ -86,7 +86,7 @@ class AsyncMultiTeamsAuthorization(AsyncAuthorization):
                 req.context["token"] = token
                 # As AsyncApp#_init_context() generates a new AsyncWebClient for this request,
                 # it's safe to modify this instance.
-                req.context.client.token = token  # type: ignore[union-attr]
+                req.context.client.token = token
                 return await next()
             else:
                 # This situation can arise if:

--- a/slack_bolt/middleware/authorization/async_single_team_authorization.py
+++ b/slack_bolt/middleware/authorization/async_single_team_authorization.py
@@ -50,13 +50,13 @@ class AsyncSingleTeamAuthorization(AsyncAuthorization):
 
         try:
             if self.auth_test_result is None:
-                self.auth_test_result = await req.context.client.auth_test()  # type: ignore[union-attr]
+                self.auth_test_result = await req.context.client.auth_test()
 
             if self.auth_test_result:
                 req.context.set_authorize_result(
                     _to_authorize_result(
                         auth_test_result=self.auth_test_result,
-                        token=req.context.client.token,  # type: ignore[union-attr]
+                        token=req.context.client.token,
                         request_user_id=req.context.user_id,
                     )
                 )

--- a/slack_bolt/middleware/authorization/multi_teams_authorization.py
+++ b/slack_bolt/middleware/authorization/multi_teams_authorization.py
@@ -89,7 +89,7 @@ class MultiTeamsAuthorization(Authorization):
                 req.context["token"] = token
                 # As App#_init_context() generates a new WebClient for this request,
                 # it's safe to modify this instance.
-                req.context.client.token = token  # type: ignore[union-attr]
+                req.context.client.token = token
                 return next()
             else:
                 # This situation can arise if:

--- a/slack_bolt/middleware/authorization/single_team_authorization.py
+++ b/slack_bolt/middleware/authorization/single_team_authorization.py
@@ -62,13 +62,13 @@ class SingleTeamAuthorization(Authorization):
 
         try:
             if not self.auth_test_result:
-                self.auth_test_result = req.context.client.auth_test()  # type: ignore[union-attr]
+                self.auth_test_result = req.context.client.auth_test()
 
             if self.auth_test_result:
                 req.context.set_authorize_result(
                     _to_authorize_result(
                         auth_test_result=self.auth_test_result,
-                        token=req.context.client.token,  # type: ignore[union-attr]
+                        token=req.context.client.token,
                         request_user_id=req.context.user_id,
                     )
                 )


### PR DESCRIPTION
This PR opens the discussion to why the `context.client` property is `Optional`

Looking back to #31 its seems like the [original implementation](https://github.com/slackapi/bolt-python/pull/43/files#diff-b0be37fba6306a268dcad5ef5c39c6b3404e0f66d759cc16cb4419a62b18023bR13-R16) of the client property could return `None`, but this implementation has now changed. 
Original implementation:
```
    @property
    def client(self) -> Optional[WebClient]:
        return self.get("client", None)
```

Can we now remove this `Optional` type annotation, I cannot come up with a use case where `context.client` could be `None`, let me know if missing context around this 🤔 


### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
