### PR TITLE
chore: group docusaurus dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
     directory: "/docs"
     schedule:
       interval: "monthly"
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"


### PR DESCRIPTION
#1148 Failed with the following error message found in the CI pipeline
```
[cause]: Error: Invalid name=docusaurus-plugin-content-docs version number=3.5.2.
  All official @docusaurus/* packages should have the exact same version as @docusaurus/core (number=3.4.0).
  Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
```

This PR attempts to configure [dependabot grouping](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) for `docusaurus` dependencies. This should allow dependabot to update all `docusaurus` dependencies in one since PR preventing this type of breakage 🤔 

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
