### PR TITLE
Docs: new URL (HOLD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
     <br>
     <a href="https://pypi.org/project/slack-bolt/">
         <img alt="Python Versions" src="https://img.shields.io/pypi/pyversions/slack-bolt.svg"></a>
-    <a href="https://slack.dev/bolt-python/">
+    <a href="https://tools.slack.dev/bolt-python/">
         <img alt="Documentation" src="https://img.shields.io/badge/dev-docs-yellow"></a>
 </p>
 
-A Python framework to build Slack apps in a flash with the latest platform features. Read the [getting started guide](https://slack.dev/bolt-python/getting-started) and look at our [code examples](https://github.com/slackapi/bolt-python/tree/main/examples) to learn how to build apps using Bolt. The Python module documents are available [here](https://slack.dev/bolt-python/api-docs/slack_bolt/).
+A Python framework to build Slack apps in a flash with the latest platform features. Read the [getting started guide](https://tools.slack.dev/bolt-python/getting-started) and look at our [code examples](https://github.com/slackapi/bolt-python/tree/main/examples) to learn how to build apps using Bolt. The Python module documents are available [here](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/).
 
 ## Setup
 
@@ -140,10 +140,10 @@ Most of the app's functionality will be inside listener functions (the `fn` para
 | `body` | Dictionary that contains the entire body of the request (superset of `payload`). Some accessory data is only available outside of the payload (such as `trigger_id` and `authorizations`).
 | `payload` | Contents of the incoming event. The payload structure depends on the listener. For example, for an Events API event, `payload` will be the [event type structure](https://api.slack.com/events-api#event_type_structure). For a block action, it will be the action from within the `actions` list. The `payload` dictionary is also accessible via the alias corresponding to the listener (`message`, `event`, `action`, `shortcut`, `view`, `command`, or `options`). For example, if you were building a `message()` listener, you could use the `payload` and `message` arguments interchangably. **An easy way to understand what's in a payload is to log it**. |
 | `context` | Event context. This dictionary contains data about the event and app, such as the `botId`. Middleware can add additional context before the event is passed to listeners.
-| `ack` | Function that **must** be called to acknowledge that your app received the incoming event. `ack` exists for all actions, shortcuts, view submissions, slash command and options requests. `ack` returns a promise that resolves when complete. Read more in [Acknowledging events](https://slack.dev/bolt-python/concepts/acknowledge).
+| `ack` | Function that **must** be called to acknowledge that your app received the incoming event. `ack` exists for all actions, shortcuts, view submissions, slash command and options requests. `ack` returns a promise that resolves when complete. Read more in [Acknowledging events](https://tools.slack.dev/bolt-python/concepts/acknowledge).
 | `respond` | Utility function that responds to incoming events **if** it contains a `response_url` (shortcuts, actions, and slash commands).
 | `say` | Utility function to send a message to the channel associated with the incoming event. This argument is only available when the listener is triggered for events that contain a `channel_id` (the most common being `message` events). `say` accepts simple strings (for plain-text messages) and dictionaries (for messages containing blocks).
-| `client` | Web API client that uses the token associated with the event. For single-workspace installations, the token is provided to the constructor. For multi-workspace installations, the token is returned by using [the OAuth library](https://slack.dev/bolt-python/concepts/authenticating-oauth), or manually using the `authorize` function.
+| `client` | Web API client that uses the token associated with the event. For single-workspace installations, the token is provided to the constructor. For multi-workspace installations, the token is returned by using [the OAuth library](https://tools.slack.dev/bolt-python/concepts/authenticating-oauth), or manually using the `authorize` function.
 | `logger` | The built-in [`logging.Logger`](https://docs.python.org/3/library/logging.html) instance you can use in middleware/listeners.
 | `complete` | Utility function used to signal the successful completion of a custom step execution. This tells Slack to proceed with the next steps in the workflow. This argument is only available with the `.function` and `.action` listener when handling custom workflow step executions.
 | `fail` | Utility function used to signal that a custom step failed to complete. This tells Slack to stop the workflow execution. This argument is only available with the `.function` and `.action` listener when handling custom workflow step executions.
@@ -192,7 +192,7 @@ Apps can be run the same way as the syncronous example above. If you'd prefer an
 
 ## Getting Help
 
-[The documentation](https://slack.dev/bolt-python) has more information on basic and advanced concepts for Bolt for Python. Also, all the Python module documents of this library are available [here](https://slack.dev/bolt-python/api-docs/slack_bolt/).
+[The documentation](https://tools.slack.dev/bolt-python) has more information on basic and advanced concepts for Bolt for Python. Also, all the Python module documents of this library are available [here](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/).
 
 If you otherwise get stuck, we're here to help. The following are the best ways to get assistance working through your issue:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# slack.dev/bolt-python
+# tools.slack.dev/bolt-python
 
 This website is built using [Docusaurus](https://docusaurus.io/). 'Tis cool.
 

--- a/docs/content/advanced/global-middleware.md
+++ b/docs/content/advanced/global-middleware.md
@@ -11,7 +11,7 @@ Both global and listener middleware must call `next()` to pass control of the ex
 
 
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 ```python
 @app.use
 def auth_acme(client, context, logger, payload, next):

--- a/docs/content/advanced/listener-middleware.md
+++ b/docs/content/advanced/listener-middleware.md
@@ -8,7 +8,7 @@ Listener middleware is only run for the listener in which it's passed. You can p
 
 If your listener middleware is a quite simple one, you can use a listener matcher, which returns `bool` value (`True` for proceeding) instead of requiring `next()` method call.
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 
 ```python
 # Listener middleware which filters out messages with "bot_message" subtype

--- a/docs/content/basic/acknowledge.md
+++ b/docs/content/basic/acknowledge.md
@@ -16,7 +16,7 @@ When working in a FaaS / serverless environment, our guidelines for when to `ack
 
 :::
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 ```python
 # Example of responding to an external_select options request
 @app.options("menu_selection")

--- a/docs/content/basic/action-listening.md
+++ b/docs/content/basic/action-listening.md
@@ -10,7 +10,7 @@ Actions can be filtered on an `action_id` of type `str` or `re.Pattern`. `action
 
 You'll notice in all `action()` examples, `ack()` is used. It is required to call the `ack()` function within an action listener to acknowledge that the request was received from Slack. This is discussed in the [acknowledging requests section](/concepts/acknowledge).
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 ```python
 # Your listener will be called every time a block element with the action_id "approve_button" is triggered
 @app.action("approve_button")

--- a/docs/content/basic/action-respond.md
+++ b/docs/content/basic/action-respond.md
@@ -8,7 +8,7 @@ There are two main ways to respond to actions. The first (and most common) way i
 
 The second way to respond to actions is using `respond()`, which is a utility to use the `response_url` associated with the action.
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 ```python
 # Your listener will be called every time an interactive component with the action_id “approve_button” is triggered
 @app.action("approve_button")

--- a/docs/content/basic/app-home.md
+++ b/docs/content/basic/app-home.md
@@ -8,7 +8,7 @@ slug: /concepts/app-home
 
 You can subscribe to the <a href="https://api.slack.com/events/app_home_opened">`app_home_opened`</a> event to listen for when users open your App Home.
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 ```python
 @app.event("app_home_opened")
 def update_home_tab(client, event, logger):

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -4,7 +4,7 @@ lang: en
 slug: /concepts/authenticating-oauth
 ---
 
-Slack apps installed on multiple workspaces will need to implement OAuth, then store installation information (like access tokens) securely. By providing `client_id`, `client_secret`, `scopes`, `installation_store`, and `state_store` when initializing App, Bolt for Python will handle the work of setting up OAuth routes and verifying state. If you're implementing a custom adapter, you can make use of our [OAuth library](https://slack.dev/python-slack-sdk/oauth/), which is what Bolt for Python uses under the hood.
+Slack apps installed on multiple workspaces will need to implement OAuth, then store installation information (like access tokens) securely. By providing `client_id`, `client_secret`, `scopes`, `installation_store`, and `state_store` when initializing App, Bolt for Python will handle the work of setting up OAuth routes and verifying state. If you're implementing a custom adapter, you can make use of our [OAuth library](https://tools.slack.dev/python-slack-sdk/oauth/), which is what Bolt for Python uses under the hood.
 
 Bolt for Python will create a **Redirect URL** `slack/oauth_redirect`, which Slack uses to redirect users after they complete your app's installation flow. You will need to add this **Redirect URL** in your app configuration settings under **OAuth and Permissions**. This path can be configured in the `OAuthSettings` argument described below.
 

--- a/docs/content/basic/commands.md
+++ b/docs/content/basic/commands.md
@@ -12,7 +12,7 @@ There are two ways to respond to slash commands. The first way is to use `say()`
 
 When setting up commands within your app configuration, you'll append `/slack/events` to your request URL.
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 ```python
 # The echo command simply echoes on command
 @app.command("/echo")

--- a/docs/content/basic/custom-steps.md
+++ b/docs/content/basic/custom-steps.md
@@ -11,7 +11,7 @@ Your app can use the `function()` method to listen to incoming [custom step requ
 
 You can reference your custom step's inputs using the `inputs` listener argument of type `dict`.
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn about the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn about the available listener arguments.
 
 ```python
 # This sample custom step formats an input and outputs it

--- a/docs/content/basic/event-listening.md
+++ b/docs/content/basic/event-listening.md
@@ -8,7 +8,7 @@ You can listen to [any Events API event](https://api.slack.com/events) using the
 
 The `event()` method requires an `eventType` of type `str`.
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 ```python
 # When a user joins the workspace, send a message in a predefined channel asking them to introduce themselves
 @app.event("team_join")

--- a/docs/content/basic/message-listening.md
+++ b/docs/content/basic/message-listening.md
@@ -10,7 +10,7 @@ To listen to messages that [your app has access to receive](https://api.slack.co
 
 :::info
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 
 :::
 

--- a/docs/content/basic/message-sending.md
+++ b/docs/content/basic/message-sending.md
@@ -8,7 +8,7 @@ Within your listener function, `say()` is available whenever there is an associa
 
 In the case that you'd like to send a message outside of a listener or you want to do something more advanced (like handle specific errors), you can call `client.chat_postMessage` [using the client attached to your Bolt instance](/concepts/web-api).
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 ```python
 # Listens for messages containing "knock knock" and responds with an italicized "who's there?"
 @app.message("knock knock")

--- a/docs/content/basic/opening-modals.md
+++ b/docs/content/basic/opening-modals.md
@@ -10,7 +10,7 @@ Your app receives `trigger_id`s in payloads sent to your Request URL that are tr
 
 Read more about modal composition in the [API documentation](https://api.slack.com/surfaces/modals/using#composing_views).
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 
 ```python
 # Listen for a shortcut invocation

--- a/docs/content/basic/options.md
+++ b/docs/content/basic/options.md
@@ -11,9 +11,9 @@ While it's recommended to use `action_id` for `external_select` menus, dialogs d
 
 To respond to options requests, you'll need to call `ack()` with a valid `options` or `option_groups` list. Both [external select response examples](https://api.slack.com/reference/messaging/block-elements#external-select) and [dialog response examples](https://api.slack.com/dialogs#dynamic_select_elements_external) can be found on our API site.
 
-Additionally, you may want to apply filtering logic to the returned options based on user input. This can be accomplished by using the `payload` argument to your options listener and checking for the contents of the `value` property within it. Based on the `value` you can return different options. All listeners and middleware handlers in Bolt for Python have access to [many useful arguments](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) - be sure to check them out!
+Additionally, you may want to apply filtering logic to the returned options based on user input. This can be accomplished by using the `payload` argument to your options listener and checking for the contents of the `value` property within it. Based on the `value` you can return different options. All listeners and middleware handlers in Bolt for Python have access to [many useful arguments](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) - be sure to check them out!
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 ```python
 # Example of responding to an external_select options request
 @app.options("external_action")

--- a/docs/content/basic/shortcuts.md
+++ b/docs/content/basic/shortcuts.md
@@ -16,7 +16,7 @@ When setting up shortcuts within your app configuration, as with other URLs, you
 
 ⚠️ Note that global shortcuts do **not** include a channel ID. If your app needs access to a channel ID, you may use a [`conversations_select`](https://api.slack.com/reference/block-kit/block-elements#conversation_select) element within a modal. Message shortcuts do include a channel ID.
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 ```python
 # The open_modal shortcut listens to a shortcut with the callback_id "open_modal"
 @app.shortcut("open_modal")

--- a/docs/content/basic/updating-pushing-views.md
+++ b/docs/content/basic/updating-pushing-views.md
@@ -16,7 +16,7 @@ To push a new view onto the view stack, you can use the built-in client to call 
 
 Learn more about updating and pushing views in our <a href="https://api.slack.com/surfaces/modals/using#modifying">API documentation</a>.
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 ```python
 # Listen for a button invocation with action_id `button_abc` (assume it's inside of a modal)
 @app.action("button_abc")

--- a/docs/content/basic/view_submissions.md
+++ b/docs/content/basic/view_submissions.md
@@ -66,7 +66,7 @@ def handle_view_closed(ack, body, logger):
 
 
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 ```python
 # Handle a view_submission request
 @app.view("view_1")

--- a/docs/content/basic/web-api.md
+++ b/docs/content/basic/web-api.md
@@ -4,13 +4,13 @@ lang: en
 slug: /concepts/web-api
 ---
 
-You can call [any Web API method](https://api.slack.com/methods) using the [`WebClient`](https://slack.dev/python-slack-sdk/basic_usage.html) provided to your Bolt app as either `app.client` or `client` in middleware/listener arguments (given that your app has the appropriate scopes). When you call one the client's methods, it returns a `SlackResponse` which contains the response from Slack.
+You can call [any Web API method](https://api.slack.com/methods) using the [`WebClient`](https://tools.slack.dev/python-slack-sdk/basic_usage.html) provided to your Bolt app as either `app.client` or `client` in middleware/listener arguments (given that your app has the appropriate scopes). When you call one the client's methods, it returns a `SlackResponse` which contains the response from Slack.
 
 The token used to initialize Bolt can be found in the `context` object, which is required to call most Web API methods.
 
 :::info 
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 
 :::
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -184,7 +184,7 @@ app = App(token=os.environ.get("SLACK_BOT_TOKEN"))
 
 # Listens to incoming messages that contain "hello"
 # To learn available listener arguments,
-# visit https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html
+# visit https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html
 @app.message("hello")
 def message_hello(message, say):
     # say() sends a message to the channel where the event was triggered

--- a/docs/content/steps/adding-editing-steps.md
+++ b/docs/content/steps/adding-editing-steps.md
@@ -22,7 +22,7 @@ Within the `edit` callback, the `configure()` utility can be used to easily open
 
 To learn more about opening configuration modals, [read the documentation](https://api.slack.com/workflows/steps#handle_config_view).
 
-Refer to the module documents (<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">common</a> / <a href="https://slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">step-specific</a>) to learn the available arguments.
+Refer to the module documents (<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">common</a> / <a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">step-specific</a>) to learn the available arguments.
 
 ```python
 def edit(ack, step, configure):

--- a/docs/content/steps/creating-steps.md
+++ b/docs/content/steps/creating-steps.md
@@ -22,9 +22,9 @@ The configuration object contains three keys: `edit`, `save`, and `execute`. Eac
 
 After instantiating a `WorkflowStep`, you can pass it into `app.step()`. Behind the scenes, your app will listen and respond to the step’s events using the callbacks provided in the configuration object.
 
-Alternatively, steps from apps can also be created using the `WorkflowStepBuilder` class alongside a decorator pattern. For more information, including an example of this approach, [refer to the documentation](https://slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/step.html#slack_bolt.workflows.step.step.WorkflowStepBuilder).
+Alternatively, steps from apps can also be created using the `WorkflowStepBuilder` class alongside a decorator pattern. For more information, including an example of this approach, [refer to the documentation](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/step.html#slack_bolt.workflows.step.step.WorkflowStepBuilder).
 
-Refer to the module documents (<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">common</a> / <a href="https://slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">step-specific</a>) to learn the available arguments.
+Refer to the module documents (<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">common</a> / <a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">step-specific</a>) to learn the available arguments.
 
 ```python
 import os

--- a/docs/content/steps/executing-steps.md
+++ b/docs/content/steps/executing-steps.md
@@ -20,7 +20,7 @@ Using the `inputs` from the `save` callback, this is where you can make third-pa
 
 Within the `execute` callback, your app must either call `complete()` to indicate that the step's execution was successful, or `fail()` to indicate that the step's execution failed.
 
-Refer to the module documents (<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">common</a> / <a href="https://slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">step-specific</a>) to learn the available arguments.
+Refer to the module documents (<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">common</a> / <a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">step-specific</a>) to learn the available arguments.
 ```python
 def execute(step, complete, fail):
     inputs = step["inputs"]

--- a/docs/content/steps/saving-steps.md
+++ b/docs/content/steps/saving-steps.md
@@ -25,7 +25,7 @@ Within the `save` callback, the `update()` method can be used to save the builde
 
 To learn more about how to structure these parameters, [read the documentation](https://api.slack.com/reference/workflows/workflow_step).
 
-Refer to the module documents (<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">common</a> / <a href="https://slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">step-specific</a>) to learn the available arguments.
+Refer to the module documents (<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">common</a> / <a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">step-specific</a>) to learn the available arguments.
 ```python
 def save(ack, view, update):
     ack()

--- a/docs/content/tutorial/getting-started-http.md
+++ b/docs/content/tutorial/getting-started-http.md
@@ -177,7 +177,7 @@ app = App(
 
 # Listens to incoming messages that contain "hello"
 # To learn available listener arguments,
-# visit https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html
+# visit https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html
 @app.message("hello")
 def message_hello(message, say):
     # say() sends a message to the channel where the event was triggered

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -12,7 +12,7 @@ const config = {
   tagline: "Official frameworks, libraries, and SDKs for Slack developers",
   favicon: "img/favicon.ico",
 
-  url: "https://slack.dev",
+  url: "https://tools.slack.dev",
   baseUrl: "/bolt-python/",
   organizationName: "slackapi",
   projectName: "bolt-python",
@@ -84,7 +84,7 @@ const config = {
         logo: {
           alt: "Slack logo",
           src: "img/slack-logo.svg",
-          href: "https://slack.dev",
+          href: "https://tools.slack.dev",
           target: "_self",
         },
         items: [
@@ -95,17 +95,17 @@ const config = {
             items: [
               {
                 label: "Java",
-                to: "https://slack.dev/java-slack-sdk/guides/bolt-basics",
+                to: "https://tools.slack.dev/java-slack-sdk/guides/bolt-basics",
                 target: "_self",
               },
               {
                 label: "JavaScript",
-                to: "https://slack.dev/bolt-js",
+                to: "https://tools.slack.dev/bolt-js",
                 target: "_self",
               },
               {
                 label: "Python",
-                to: "https://slack.dev/bolt-python",
+                to: "https://tools.slack.dev/bolt-python",
                 target: "_self",
               },
             ],
@@ -117,17 +117,17 @@ const config = {
             items: [
               {
                 label: "Java Slack SDK",
-                to: "https://slack.dev/java-slack-sdk/",
+                to: "https://tools.slack.dev/java-slack-sdk/",
                 target: "_self",
               },
               {
                 label: "Node Slack SDK",
-                to: "https://slack.dev/node-slack-sdk/",
+                to: "https://tools.slack.dev/node-slack-sdk/",
                 target: "_self",
               },
               {
                 label: "Python Slack SDK",
-                to: "https://slack.dev/python-slack-sdk/",
+                to: "https://tools.slack.dev/python-slack-sdk/",
                 target: "_self",
               },
               {
@@ -144,7 +144,7 @@ const config = {
             items: [
               {
                 label: "Community tools",
-                to: "https://slack.dev/community-tools",
+                to: "https://tools.slack.dev/community-tools",
                 target: "_self",
               },
               {

--- a/docs/i18n/ja-jp/README.md
+++ b/docs/i18n/ja-jp/README.md
@@ -118,4 +118,4 @@ For example:
   },
 ```
 
-Be careful changing `code.json`. If you change something in this repo, it will likely need to be changed in the other Slack.dev repos too, like the Bolt-Python repo. We want these translations to match for all Slack.dev sites. 
+Be careful changing `code.json`. If you change something in this repo, it will likely need to be changed in the other tools.slack.dev repos too, like the Bolt-Python repo. We want these translations to match for all tools.slack.dev sites. 

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/advanced/global-middleware.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/advanced/global-middleware.md
@@ -9,7 +9,7 @@ order: 8
 
 グローバルミドルウェアでもリスナーミドルウェアでも、次のミドルウェアに実行チェーンの制御をリレーするために、`next()` を呼び出す必要があります。 
 
-<span>指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
+<span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 
 ```python
 @app.use

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/advanced/listener-middleware.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/advanced/listener-middleware.md
@@ -8,7 +8,7 @@ slug: /concepts/listener-middleware
 
 非常にシンプルなリスナーミドルウェアの場合であれば、`next()` メソッドを呼び出す代わりに `bool` 値（処理を継続したい場合は `True`）を返すだけで済む「リスナーマッチャー」を使うとよいでしょう。
 
-<span>指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
+<span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 
 ```python
 # "bot_message" サブタイプのメッセージを抽出するリスナーミドルウェア

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/acknowledge.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/acknowledge.md
@@ -16,7 +16,7 @@ slug: /concepts/acknowledge
 
 
 
-<span>指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
+<span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 ```python
 # 外部データを使用する選択メニューオプションに応答するサンプル
 @app.options("menu_selection")

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/action-listening.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/action-listening.md
@@ -10,7 +10,7 @@ Bolt アプリは `action` メソッドを用いて、ボタンのクリック�
 
 `action()` を使ったすべての例で `ack()` が使用されていることに注目してください。アクションのリスナー内では、Slack からのリクエストを受信したことを確認するために、`ack()` 関数を呼び出す必要があります。これについては、[リクエストの確認](/concepts/acknowledge)セクションで説明しています。
 
-<span>指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
+<span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 ```python
 # 'approve_button' という action_id のブロックエレメントがトリガーされるたびに、このリスナーが呼び出させれる
 @app.action("approve_button")

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/action-respond.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/action-respond.md
@@ -8,7 +8,7 @@ slug: /concepts/action-respond
 
 2 つ目は、`respond()` を使用する方法です。これは、アクションに関連づけられた `response_url` を使ったメッセージ送信を行うためのユーティリティです。
 
-<span>指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
+<span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 ```python
 # 'approve_button' という action_id のインタラクティブコンポーネントがトリガーされると、このリスナーが呼ばれる
 @app.action("approve_button")

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/app-home.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/app-home.md
@@ -8,7 +8,7 @@ slug: /concepts/app-home
 
 <a href="https://api.slack.com/events/app_home_opened">`app_home_opened`</a> イベントをサブスクライブすると、ユーザーが App Home を開く操作をリッスンできます。
 
-<span>指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
+<span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 ```python
 @app.event("app_home_opened")
 def update_home_tab(client, event, logger):

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/authenticating-oauth.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/authenticating-oauth.md
@@ -4,7 +4,7 @@ lang: ja-jp
 slug: /concepts/authenticating-oauth
 ---
 
-Slack アプリを複数のワークスペースにインストールできるようにするためには、OAuth フローを実装した上で、アクセストークンなどのインストールに関する情報をセキュアな方法で保存する必要があります。アプリを初期化する際に `client_id`、`client_secret`、`scopes`、`installation_store`、`state_store` を指定することで、OAuth のエンドポイントのルート情報や stateパラメーターの検証をBolt for Python にハンドリングさせることができます。カスタムのアダプターを実装する場合は、SDK が提供する組み込みの[OAuth ライブラリ](https://slack.dev/python-slack-sdk/oauth/)を利用するのが便利です。これは Slack が開発したモジュールで、Bolt for Python 内部でも利用しています。
+Slack アプリを複数のワークスペースにインストールできるようにするためには、OAuth フローを実装した上で、アクセストークンなどのインストールに関する情報をセキュアな方法で保存する必要があります。アプリを初期化する際に `client_id`、`client_secret`、`scopes`、`installation_store`、`state_store` を指定することで、OAuth のエンドポイントのルート情報や stateパラメーターの検証をBolt for Python にハンドリングさせることができます。カスタムのアダプターを実装する場合は、SDK が提供する組み込みの[OAuth ライブラリ](https://tools.slack.dev/python-slack-sdk/oauth/)を利用するのが便利です。これは Slack が開発したモジュールで、Bolt for Python 内部でも利用しています。
 
 Bolt for Python によって `slack/oauth_redirect` という**リダイレクト URL** が生成されます。Slack はアプリのインストールフローを完了させたユーザーをこの URL にリダイレクトします。この**リダイレクト URL** は、アプリの設定の「**OAuth and Permissions**」であらかじめ追加しておく必要があります。この URL は、後ほど説明するように `OAuthSettings` というコンストラクタの引数で指定することもできます。
 

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/commands.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/commands.md
@@ -12,7 +12,7 @@ slug: /concepts/commands
 
 アプリの設定でコマンドを登録するときは、リクエスト URL の末尾に `/slack/events` をつけます。
 
-<span>指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
+<span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 ```python
 # echoコマンドは受け取ったコマンドをそのまま返す
 @app.command("/echo")

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/custom-steps.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/custom-steps.md
@@ -11,7 +11,7 @@ Your app can use the `function()` method to listen to incoming [custom step requ
 
 You can reference your custom step's inputs using the `inputs` listener argument of type `dict`.
 
-Refer to [the module document](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn about the available listener arguments.
+Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn about the available listener arguments.
 
 ```python
 # This sample custom step formats an input and outputs it

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/event-listening.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/event-listening.md
@@ -8,7 +8,7 @@ slug: /concepts/event-listening
 
 `event()` メソッドには `str` 型の `eventType` を指定する必要があります。
 
-<span>指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
+<span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 ```python
 # ユーザーがワークスペースに参加した際に、自己紹介を促すメッセージを指定のチャンネルに送信
 @app.event("team_join")

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/message-listening.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/message-listening.md
@@ -8,7 +8,7 @@ slug: /concepts/message-listening
 
 `message()` の引数には `str` 型または `re.Pattern` オブジェクトを指定できます。この条件のパターンに一致しないメッセージは除外されます。
 
-<span>指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
+<span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 ```python
 # '👋' が含まれるすべてのメッセージに一致
 @app.message(":wave:")

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/message-sending.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/message-sending.md
@@ -8,7 +8,7 @@ slug: /concepts/message-sending
 
 リスナー関数の外でメッセージを送信したい場合や、より高度な処理（特定のエラーの処理など）を実行したい場合は、[Bolt インスタンスにアタッチされたクライアント](/concepts/web-api)の `client.chat_postMessage` を呼び出します。
 
-<span>指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
+<span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 ```python
 # 'knock knock' が含まれるメッセージをリッスンし、イタリック体で 'Who's there?' と返信
 @app.message("knock knock")

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/opening-modals.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/opening-modals.md
@@ -10,7 +10,7 @@ slug: /concepts/opening-modals
 
 モーダルの生成方法についての詳細は、<a href="https://api.slack.com/surfaces/modals/using#composing_views">API ドキュメント</a>を参照してください。
 
-<span>指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
+<span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 
 ```python
 # ショートカットの呼び出しをリッスン

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/options.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/options.md
@@ -12,9 +12,9 @@ slug: /concepts/options
 
 オプションのリクエストに応答するときは、有効なオプションを含む `options` または `option_groups` のリストとともに `ack()` を呼び出す必要があります。API サイトにある[外部データを使用する選択メニューに応答するサンプル例](https://api.slack.com/reference/messaging/block-elements#external-select)と、[ダイアログでの応答例](https://api.slack.com/dialogs#dynamic_select_elements_external)を参考にしてください。
 
-さらに、ユーザーが入力したキーワードに基づいたオプションを返すようフィルタリングロジックを適用することもできます。 これは `payload` という引数の ` value` の値に基づいて、それぞれのパターンで異なるオプションの一覧を返すように実装することができます。 Bolt for Python のすべてのリスナーやミドルウェアでは、[多くの有用な引数](https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html)にアクセスすることができますので、チェックしてみてください。
+さらに、ユーザーが入力したキーワードに基づいたオプションを返すようフィルタリングロジックを適用することもできます。 これは `payload` という引数の ` value` の値に基づいて、それぞれのパターンで異なるオプションの一覧を返すように実装することができます。 Bolt for Python のすべてのリスナーやミドルウェアでは、[多くの有用な引数](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html)にアクセスすることができますので、チェックしてみてください。
 
-<span>指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
+<span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 ```python
 # 外部データを使用する選択メニューオプションに応答するサンプル例
 @app.options("external_action")

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/shortcuts.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/shortcuts.md
@@ -16,7 +16,7 @@ slug: /concepts/shortcuts
 
 ⚠️ グローバルショートカットのペイロードにはチャンネル ID が **含まれません**。アプリでチャンネル ID を取得する必要がある場合は、モーダル内に [`conversations_select`](https://api.slack.com/reference/block-kit/block-elements#conversation_select) エレメントを配置します。メッセージショートカットにはチャンネル ID が含まれます。
 
-<span>指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
+<span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 ```python
 # 'open_modal' という callback_id のショートカットをリッスン
 @app.shortcut("open_modal")

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/updating-pushing-views.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/updating-pushing-views.md
@@ -16,7 +16,7 @@ slug: /concepts/updating-pushing-views
 
 モーダルの更新と多重表示に関する詳細は、<a href="https://api.slack.com/surfaces/modals/using#modifying">API ドキュメント</a>を参照してください。
 
-指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。
+指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。
 
 ```python
 # モーダルに含まれる、`button_abc` という action_id のボタンの呼び出しをリッスン

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/view_submissions.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/view_submissions.md
@@ -60,7 +60,7 @@ def handle_view_closed(ack, body, logger):
     logger.info(body)
 ```
 
-指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。
+指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。
 
 ```python
 # view_submission リクエストを処理

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/web-api.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/basic/web-api.md
@@ -4,11 +4,11 @@ lang: ja-jp
 slug: /concepts/web-api
 ---
 
-`app.client`、またはミドルウェア・リスナーの引数 `client` として Bolt アプリに提供されている [`WebClient`](https://slack.dev/python-slack-sdk/basic_usage.html) は必要な権限を付与されており、これを利用することで[あらゆる Web API メソッド](https://api.slack.com/methods)を呼び出すことができます。このクライアントのメソッドを呼び出すと `SlackResponse` という Slack からの応答情報を含むオブジェクトが返されます。
+`app.client`、またはミドルウェア・リスナーの引数 `client` として Bolt アプリに提供されている [`WebClient`](https://tools.slack.dev/python-slack-sdk/basic_usage.html) は必要な権限を付与されており、これを利用することで[あらゆる Web API メソッド](https://api.slack.com/methods)を呼び出すことができます。このクライアントのメソッドを呼び出すと `SlackResponse` という Slack からの応答情報を含むオブジェクトが返されます。
 
 Bolt の初期化に使用するトークンは `context` オブジェクトに設定されます。このトークンは、多くの Web API メソッドを呼び出す際に必要となります。
 
-<span>指定可能な引数の一覧は<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
+<span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 ```python
 @app.message("wake me up")
 def say_hello(client, message):

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/getting-started.md
@@ -180,7 +180,7 @@ app = App(token=os.environ.get("SLACK_BOT_TOKEN"))
 
 # 'こんにちは' を含むメッセージをリッスンします
 # 指定可能なリスナーのメソッド引数の一覧は以下のモジュールドキュメントを参考にしてください：
-# https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html
+# https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html
 @app.message("こんにちは")
 def message_hello(message, say):
     # イベントがトリガーされたチャンネルへ say() でメッセージを送信します

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/steps/adding-editing-steps.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/steps/adding-editing-steps.md
@@ -12,7 +12,7 @@ slug: /concepts/adding-editing-steps
 
 設定モーダルの開き方に関する詳細は、[こちらのドキュメント](https://api.slack.com/workflows/steps#handle_config_view)を参照してください。
 
-指定可能な引数の一覧はモジュールドキュメントを参考にしてください（<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">共通</a> / <a href="https://slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">ステップ用</a>
+指定可能な引数の一覧はモジュールドキュメントを参考にしてください（<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">共通</a> / <a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">ステップ用</a>
 
 ```python
 def edit(ack, step, configure):

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/steps/creating-steps.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/steps/creating-steps.md
@@ -12,9 +12,9 @@ slug: /concepts/creating-steps
 
 `WorkflowStep` のインスタンスを作成したら、それを`app.step()` メソッドに渡します。これによって、アプリがワークフローステップのイベントをリッスンし、設定オブジェクトで指定されたコールバックを使ってそれに応答できるようになります。
 
-また、デコレーターとして利用できる `WorkflowStepBuilder` クラスを使ってワークフローステップを定義することもできます。 詳細は、[こちらのドキュメント](https://slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/step.html#slack_bolt.workflows.step.step.WorkflowStepBuilder)のコード例などを参考にしてください。
+また、デコレーターとして利用できる `WorkflowStepBuilder` クラスを使ってワークフローステップを定義することもできます。 詳細は、[こちらのドキュメント](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/step.html#slack_bolt.workflows.step.step.WorkflowStepBuilder)のコード例などを参考にしてください。
 
-指定可能な引数の一覧はモジュールドキュメントを参考にしてください（<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">共通</a> / <a href="https://slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">ステップ用</a>
+指定可能な引数の一覧はモジュールドキュメントを参考にしてください（<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">共通</a> / <a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">ステップ用</a>
 
 ```python
 import os

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/steps/executing-steps.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/steps/executing-steps.md
@@ -10,7 +10,7 @@ slug: /concepts/executing-steps
 
 `execute` コールバック内では、`complete()` を呼び出してステップの実行が成功したことを示すか、`fail()` を呼び出してステップの実行が失敗したことを示す必要があります。
 
-<span>指定可能な引数の一覧はモジュールドキュメントを参考にしてください（<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">共通</a> / <a href="https://slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">ステップ用</a>）</span>
+<span>指定可能な引数の一覧はモジュールドキュメントを参考にしてください（<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">共通</a> / <a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">ステップ用</a>）</span>
 ```python
 def execute(step, complete, fail):
     inputs = step["inputs"]

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/steps/saving-steps.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/steps/saving-steps.md
@@ -15,7 +15,7 @@ slug: /concepts/saving-steps
 
 これらのパラメータの構成方法に関する詳細は、[こちらのドキュメント](https://api.slack.com/reference/workflows/workflow_step)を参照してください。
 
-指定可能な引数の一覧はモジュールドキュメントを参考にしてください（<a href="https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">共通</a> / <a href="https://slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">ステップ用</a>
+指定可能な引数の一覧はモジュールドキュメントを参考にしてください（<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">共通</a> / <a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/workflows/step/utilities/index.html">ステップ用</a>
 
 ```python
 def save(ack, view, update):

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/tutorial/getting-started-http.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/tutorial/getting-started-http.md
@@ -179,7 +179,7 @@ app = App(
 
 # 'hello' を含むメッセージをリッスンします
 # 指定可能なリスナーのメソッド引数の一覧は以下のモジュールドキュメントを参考にしてください：
-# https://slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html
+# https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html
 @app.message("hello")
 def message_hello(message, say):
     # イベントがトリガーされたチャンネルへ say() でメッセージを送信します

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -89,7 +89,7 @@ const sidebars = {
     {
       type: 'link',
       label: 'Reference',
-      href: 'https://slack.dev/bolt-python/api-docs/slack_bolt/',
+      href: 'https://tools.slack.dev/bolt-python/api-docs/slack_bolt/',
     },
     { type: 'html', value: '<hr>' },
     {


### PR DESCRIPTION
Switching from slack.dev to tools.slack.dev

### Category (place an `x` in each of the `[ ]`)

* [X] Document pages under `/docs`

## Requirements 

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes. (just docs tho)
