### PR TITLE
Fix double quoted img alt text

### DIFF
--- a/slack_bolt/oauth/internals.py
+++ b/slack_bolt/oauth/internals.py
@@ -85,7 +85,7 @@ body {{
 </head>
 <body>
 <h2>Slack App Installation</h2>
-<p><a href="{html.escape(url)}"><img alt=""Add to Slack"" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a></p>
+<p><a href="{html.escape(url)}"><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a></p>
 </body>
 </html>
 """  # noqa: E501

--- a/tests/adapter_tests_async/test_async_falcon.py
+++ b/tests/adapter_tests_async/test_async_falcon.py
@@ -201,5 +201,5 @@ class TestAsyncFalcon:
         response = client.simulate_get("/slack/install")
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert response.headers.get("content-length") == "609"
+        assert response.headers.get("content-length") == "607"
         assert "https://slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests_async/test_async_fastapi.py
+++ b/tests/adapter_tests_async/test_async_fastapi.py
@@ -209,7 +209,7 @@ class TestFastAPI:
         response = client.get("/slack/install", allow_redirects=False)
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert response.headers.get("content-length") == "609"
+        assert response.headers.get("content-length") == "607"
         assert "https://slack.com/oauth/v2/authorize?state=" in response.text
 
     def test_custom_props(self):

--- a/tests/adapter_tests_async/test_async_sanic.py
+++ b/tests/adapter_tests_async/test_async_sanic.py
@@ -221,6 +221,6 @@ class TestSanic:
 
         # NOTE: Although sanic-testing 0.6 does not have this value,
         # Sanic apps properly generate the content-length header
-        # assert response.headers.get("content-length") == "609"
+        # assert response.headers.get("content-length") == "607"
 
         assert "https://slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests_async/test_async_starlette.py
+++ b/tests/adapter_tests_async/test_async_starlette.py
@@ -219,5 +219,5 @@ class TestAsyncStarlette:
         response = client.get("/slack/install", allow_redirects=False)
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert response.headers.get("content-length") == "609"
+        assert response.headers.get("content-length") == "607"
         assert "https://slack.com/oauth/v2/authorize?state=" in response.text


### PR DESCRIPTION
This attribute looks like it was erroneously double quoted, causing the HTML element as rendered by most browsers to not have alt text. Adjust the quoting to match the other attributes.

### Category (place an `x` in each of the `[ ]`)

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.