### PR TITLE
feat: expose auto acknowledge for `function` handlers

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -877,6 +877,7 @@ class App:
         callback_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., bool]]] = None,
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
+        auto_acknowledge: bool = True,
     ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new Function listener.
         This method can be used as either a decorator or a method.
@@ -911,7 +912,7 @@ class App:
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
             primary_matcher = builtin_matchers.function_executed(callback_id=callback_id, base_logger=self._base_logger)
-            return self._register_listener(functions, primary_matcher, matchers, middleware, True)
+            return self._register_listener(functions, primary_matcher, matchers, middleware, auto_acknowledge)
 
         return __call__
 

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -911,6 +911,7 @@ class AsyncApp:
         callback_id: Union[str, Pattern],
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]] = None,
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
+        auto_acknowledge: bool = True,
     ) -> Callable[..., Optional[Callable[..., Awaitable[BoltResponse]]]]:
         """Registers a new Function listener.
         This method can be used as either a decorator or a method.
@@ -947,7 +948,7 @@ class AsyncApp:
             primary_matcher = builtin_matchers.function_executed(
                 callback_id=callback_id, base_logger=self._base_logger, asyncio=True
             )
-            return self._register_listener(functions, primary_matcher, matchers, middleware, True)
+            return self._register_listener(functions, primary_matcher, matchers, middleware, auto_acknowledge)
 
         return __call__
 

--- a/tests/scenario_tests/test_function.py
+++ b/tests/scenario_tests/test_function.py
@@ -112,6 +112,31 @@ class TestFunction:
         with pytest.raises(TypeError):
             func("hello world")
 
+    def test_auto_acknowledge_false_without_acknowledging(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        app.function("reverse", auto_acknowledge=False)(just_no_ack)
+
+        request = self.build_request_from_body(function_body)
+        response = app.dispatch(request)
+
+        assert response.status == 404
+        assert_auth_test_count(self, 1)
+
+    def test_auto_acknowledge_false_with_acknowledging(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        app.function("reverse", auto_acknowledge=False)(just_ack)
+
+        request = self.build_request_from_body(function_body)
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert_auth_test_count(self, 1)
+
 
 function_body = {
     "token": "verification_token",
@@ -230,3 +255,14 @@ def complete_it(body, event, complete):
     assert body == function_body
     assert event == function_body["event"]
     complete(outputs={})
+
+
+def just_ack(ack, body, event):
+    assert body == function_body
+    assert event == function_body["event"]
+    ack()
+
+
+def just_no_ack(ack, body, event):
+    assert body == function_body
+    assert event == function_body["event"]


### PR DESCRIPTION
**DO NOT MERGE**

This PR exposes the `auto_acknowledge` flag at the at the `function` listener initialization level. This will allow the developer to build functions that call `complete` or `fail` before `ack()` (responding) the the slack request.

This will be used for `dynamic options` support

NOTE: the 3 second time out may prove to be a limitation since function have a timeout of 15 seconds, a follow up PR may be needed to imporve this behavior

### Category

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
