### PR TITLE
Fix a bug where parsing assistant thread message event fails for beta feature enabled apps

### DIFF
--- a/slack_bolt/context/assistant/assistant_utilities.py
+++ b/slack_bolt/context/assistant/assistant_utilities.py
@@ -7,6 +7,7 @@ from slack_bolt.context.assistant.thread_context_store.default_store import Defa
 
 from slack_bolt.context.context import BoltContext
 from slack_bolt.context.say import Say
+from .internals import has_channel_id_and_thread_ts
 from ..get_thread_context.get_thread_context import GetThreadContext
 from ..save_thread_context import SaveThreadContext
 from ..set_status import SetStatus
@@ -32,7 +33,7 @@ class AssistantUtilities:
         self.client = context.client
         self.thread_context_store = thread_context_store or DefaultAssistantThreadContextStore(context)
 
-        if self.payload.get("assistant_thread") is not None:
+        if has_channel_id_and_thread_ts(self.payload):
             # assistant_thread_started
             thread = self.payload["assistant_thread"]
             self.channel_id = thread["channel_id"]

--- a/slack_bolt/context/assistant/async_assistant_utilities.py
+++ b/slack_bolt/context/assistant/async_assistant_utilities.py
@@ -10,6 +10,7 @@ from slack_bolt.context.assistant.thread_context_store.default_async_store impor
 
 from slack_bolt.context.async_context import AsyncBoltContext
 from slack_bolt.context.say.async_say import AsyncSay
+from .internals import has_channel_id_and_thread_ts
 from ..get_thread_context.async_get_thread_context import AsyncGetThreadContext
 from ..save_thread_context.async_save_thread_context import AsyncSaveThreadContext
 from ..set_status.async_set_status import AsyncSetStatus
@@ -35,7 +36,7 @@ class AsyncAssistantUtilities:
         self.client = context.client
         self.thread_context_store = thread_context_store or DefaultAsyncAssistantThreadContextStore(context)
 
-        if self.payload.get("assistant_thread") is not None:
+        if has_channel_id_and_thread_ts(self.payload):
             # assistant_thread_started
             thread = self.payload["assistant_thread"]
             self.channel_id = thread["channel_id"]

--- a/slack_bolt/context/assistant/internals.py
+++ b/slack_bolt/context/assistant/internals.py
@@ -1,0 +1,9 @@
+def has_channel_id_and_thread_ts(payload: dict) -> bool:
+    """Verifies if the given payload has both channel_id and thread_ts under assistant_thread property.
+    This data pattern is available for assistant_* events.
+    """
+    return (
+        payload.get("assistant_thread") is not None
+        and payload["assistant_thread"].get("channel_id") is not None
+        and payload["assistant_thread"].get("thread_ts") is not None
+    )

--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -220,8 +220,14 @@ def extract_thread_ts(payload: Dict[str, Any]) -> Optional[str]:
     # Thus, blindly setting this thread_ts to say utility can break existing apps' behaviors.
     if is_assistant_event(payload):
         event = payload["event"]
-        if event.get("assistant_thread") is not None:
+        if (
+            event.get("assistant_thread") is not None
+            and event["assistant_thread"].get("channel_id") is not None
+            and event["assistant_thread"].get("thread_ts") is not None
+        ):
             # assistant_thread_started, assistant_thread_context_changed
+            # "assistant_thread" property can exist for message event without channel_id and thread_ts
+            # Thus, the above if check verifies these properties exist
             return event["assistant_thread"]["thread_ts"]
         elif event.get("channel") is not None:
             if event.get("thread_ts") is not None:

--- a/tests/scenario_tests/test_events_assistant.py
+++ b/tests/scenario_tests/test_events_assistant.py
@@ -82,6 +82,11 @@ class TestEventsAssistant:
         assert response.status == 200
         assert_target_called()
 
+        request = BoltRequest(body=user_message_event_body_with_assistant_thread, mode="socket_mode")
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert_target_called()
+
         request = BoltRequest(body=message_changed_event_body, mode="socket_mode")
         response = app.dispatch(request)
         assert response.status == 200
@@ -162,6 +167,25 @@ user_message_event_body = build_payload(
     }
 )
 
+
+user_message_event_body_with_assistant_thread = build_payload(
+    {
+        "user": "W222",
+        "type": "message",
+        "ts": "1726133700.887259",
+        "text": "When Slack was released?",
+        "team": "T111",
+        "user_team": "T111",
+        "source_team": "T222",
+        "user_profile": {},
+        "thread_ts": "1726133698.626339",
+        "parent_user_id": "W222",
+        "channel": "D111",
+        "event_ts": "1726133700.887259",
+        "channel_type": "im",
+        "assistant_thread": {"XXX": "YYY"},
+    }
+)
 
 message_changed_event_body = build_payload(
     {

--- a/tests/scenario_tests_async/test_events_assistant.py
+++ b/tests/scenario_tests_async/test_events_assistant.py
@@ -97,6 +97,11 @@ class TestAsyncEventsAssistant:
         assert response.status == 200
         await assert_target_called()
 
+        request = AsyncBoltRequest(body=user_message_event_body_with_assistant_thread, mode="socket_mode")
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_target_called()
+
         request = AsyncBoltRequest(body=message_changed_event_body, mode="socket_mode")
         response = await app.async_dispatch(request)
         assert response.status == 200
@@ -174,6 +179,26 @@ user_message_event_body = build_payload(
         "channel": "D111",
         "event_ts": "1726133700.887259",
         "channel_type": "im",
+    }
+)
+
+
+user_message_event_body_with_assistant_thread = build_payload(
+    {
+        "user": "W222",
+        "type": "message",
+        "ts": "1726133700.887259",
+        "text": "When Slack was released?",
+        "team": "T111",
+        "user_team": "T111",
+        "source_team": "T222",
+        "user_profile": {},
+        "thread_ts": "1726133698.626339",
+        "parent_user_id": "W222",
+        "channel": "D111",
+        "event_ts": "1726133700.887259",
+        "channel_type": "im",
+        "assistant_thread": {"XXX": "YYY"},
     }
 )
 


### PR DESCRIPTION
This pull request resolves a bug where parsing assistant thread message event fails for beta feature enabled apps.

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
