### PR TITLE
Improve metadata resolution timing in assistant app's say method

### DIFF
--- a/slack_bolt/context/assistant/assistant_utilities.py
+++ b/slack_bolt/context/assistant/assistant_utilities.py
@@ -63,14 +63,17 @@ class AssistantUtilities:
 
     @property
     def say(self) -> Say:
+        def build_metadata() -> Optional[dict]:
+            thread_context = self.get_thread_context()
+            if thread_context is not None:
+                return {"event_type": "assistant_thread_context", "event_payload": thread_context}
+            return None
+
         return Say(
             self.client,
             channel=self.channel_id,
             thread_ts=self.thread_ts,
-            metadata={
-                "event_type": "assistant_thread_context",
-                "event_payload": self.get_thread_context(),
-            },
+            build_metadata=build_metadata,
         )
 
     @property

--- a/slack_bolt/context/say/say.py
+++ b/slack_bolt/context/say/say.py
@@ -15,7 +15,7 @@ class Say:
     channel: Optional[str]
     thread_ts: Optional[str]
     metadata: Optional[Union[Dict, Metadata]]
-    build_metadata: Optional[Callable[[], Union[Dict, Metadata]]]
+    build_metadata: Optional[Callable[[], Optional[Union[Dict, Metadata]]]]
 
     def __init__(
         self,
@@ -23,7 +23,7 @@ class Say:
         channel: Optional[str],
         thread_ts: Optional[str] = None,
         metadata: Optional[Union[Dict, Metadata]] = None,
-        build_metadata: Optional[Callable[[], Union[Dict, Metadata]]] = None,
+        build_metadata: Optional[Callable[[], Optional[Union[Dict, Metadata]]]] = None,
     ):
         self.client = client
         self.channel = channel


### PR DESCRIPTION
This pull request improves the Assistant middleware's internals. Like the asyncio version already does, the get_thread_context method call should be delayed until it's really necessary: https://github.com/slackapi/bolt-python/blob/v1.21.1/slack_bolt/context/assistant/async_assistant_utilities.py#L69-L80

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
