### PR TITLE
Add title argument to SetSuggestedPrompts arguments

### DIFF
--- a/slack_bolt/context/set_suggested_prompts/async_set_suggested_prompts.py
+++ b/slack_bolt/context/set_suggested_prompts/async_set_suggested_prompts.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Optional
 
 from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.web.async_slack_response import AsyncSlackResponse
@@ -19,7 +19,11 @@ class AsyncSetSuggestedPrompts:
         self.channel_id = channel_id
         self.thread_ts = thread_ts
 
-    async def __call__(self, prompts: List[Union[str, Dict[str, str]]]) -> AsyncSlackResponse:
+    async def __call__(
+        self,
+        prompts: List[Union[str, Dict[str, str]]],
+        title: Optional[str] = None,
+    ) -> AsyncSlackResponse:
         prompts_arg: List[Dict[str, str]] = []
         for prompt in prompts:
             if isinstance(prompt, str):
@@ -31,4 +35,5 @@ class AsyncSetSuggestedPrompts:
             channel_id=self.channel_id,
             thread_ts=self.thread_ts,
             prompts=prompts_arg,
+            title=title,
         )

--- a/slack_bolt/context/set_suggested_prompts/set_suggested_prompts.py
+++ b/slack_bolt/context/set_suggested_prompts/set_suggested_prompts.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Optional
 
 from slack_sdk import WebClient
 from slack_sdk.web import SlackResponse
@@ -19,7 +19,11 @@ class SetSuggestedPrompts:
         self.channel_id = channel_id
         self.thread_ts = thread_ts
 
-    def __call__(self, prompts: List[Union[str, Dict[str, str]]]) -> SlackResponse:
+    def __call__(
+        self,
+        prompts: List[Union[str, Dict[str, str]]],
+        title: Optional[str] = None,
+    ) -> SlackResponse:
         prompts_arg: List[Dict[str, str]] = []
         for prompt in prompts:
             if isinstance(prompt, str):
@@ -31,4 +35,5 @@ class SetSuggestedPrompts:
             channel_id=self.channel_id,
             thread_ts=self.thread_ts,
             prompts=prompts_arg,
+            title=title,
         )

--- a/tests/scenario_tests/test_events_assistant.py
+++ b/tests/scenario_tests/test_events_assistant.py
@@ -46,6 +46,9 @@ class TestEventsAssistant:
             assert context.thread_ts == "1726133698.626339"
             say("Hi, how can I help you today?")
             set_suggested_prompts(prompts=[{"title": "What does SLACK stand for?", "message": "What does SLACK stand for?"}])
+            set_suggested_prompts(
+                prompts=[{"title": "What does SLACK stand for?", "message": "What does SLACK stand for?"}], title="foo"
+            )
             state["called"] = True
 
         @assistant.thread_context_changed

--- a/tests/scenario_tests_async/test_events_assistant.py
+++ b/tests/scenario_tests_async/test_events_assistant.py
@@ -61,6 +61,10 @@ class TestAsyncEventsAssistant:
             await set_suggested_prompts(
                 prompts=[{"title": "What does SLACK stand for?", "message": "What does SLACK stand for?"}]
             )
+            await set_suggested_prompts(
+                prompts=[{"title": "What does SLACK stand for?", "message": "What does SLACK stand for?"}],
+                title="foo",
+            )
             state["called"] = True
 
         @assistant.thread_context_changed


### PR DESCRIPTION
This pull request adds title arugment to SetSuggestedPrompts argument list

### Category (place an `x` in each of the `[ ]`)

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements (place an `x` in each `[ ]`)

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
