### PR TITLE
chore: support python 3.13

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.13"]
     env:
       BOLT_PYTHON_CODECOV_RUNNING: "1"
     steps:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,15 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -47,14 +55,6 @@ jobs:
       - name: Run tests for HTTP Mode adapters (Falcon 3.x)
         run: |
           pytest tests/adapter_tests/falcon/
-      - name: Run tests for HTTP Mode adapters (Falcon 2.x)
-        run: |
-          # Falcon 2.x does not support Python 3.11 or newer
-          # See also: https://github.com/slackapi/bolt-python/issues/757
-          if [ ${{ matrix.python-version }} != "3.11" ]; then
-            pip install "falcon<3"
-            pytest tests/adapter_tests/falcon/
-          fi
       - name: Run tests for HTTP Mode adapters (Flask)
         run: |
           pytest tests/adapter_tests/flask/
@@ -76,8 +76,6 @@ jobs:
           pytest tests/adapter_tests/socket_mode/
       - name: Run tests for HTTP Mode adapters (asyncio-based libraries)
         run: |
-          # Falcon supports Python 3.11 since its v3.1.1
-          pip install "falcon>=3.1.1,<4"
           pytest tests/adapter_tests_async/
       - name: Run tests for HTTP Mode adapters (ASGI)
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
 	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
 	"Programming Language :: Python :: 3.12",
+	"Programming Language :: Python :: 3.13",
 	"Programming Language :: Python :: Implementation :: CPython",
 	"License :: OSI Approved :: MIT License",
 	"Operating System :: OS Independent",


### PR DESCRIPTION
This PR aims to add official support for [python 3.13](https://docs.python.org/3/whatsnew/3.13.html)

### Category 

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
