### PR TITLE
test: fix broken tests due to wild card import

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.6"

--- a/requirements/adapter.txt
+++ b/requirements/adapter.txt
@@ -16,7 +16,7 @@ pyramid>=1,<3
 sanic>=20,<21; python_version=="3.6"
 sanic>=21,<24; python_version>"3.6" and python_version<="3.8"
 sanic>=21,<25; python_version>"3.8"
-starlette>=0.14,<1
+starlette>=0.19.1,<1
 tornado>=6,<7
 uvicorn<1                                # The oldest version can vary among Python runtime versions
 gunicorn>=20,<24

--- a/tests/adapter_tests/starlette/test_fastapi.py
+++ b/tests/adapter_tests/starlette/test_fastapi.py
@@ -206,7 +206,8 @@ class TestFastAPI:
             return await app_handler.handle(req)
 
         client = TestClient(api)
-        response = client.get("/slack/install", allow_redirects=False)
+        client.follow_redirects = False
+        response = client.get("/slack/install")
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
         assert "https://slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests/starlette/test_starlette.py
+++ b/tests/adapter_tests/starlette/test_starlette.py
@@ -215,7 +215,8 @@ class TestStarlette:
             routes=[Route("/slack/install", endpoint=endpoint, methods=["GET"])],
         )
         client = TestClient(api)
-        response = client.get("/slack/install", allow_redirects=False)
+        client.follow_redirects = False
+        response = client.get("/slack/install")
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
         assert "https://slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests_async/test_async_fastapi.py
+++ b/tests/adapter_tests_async/test_async_fastapi.py
@@ -206,7 +206,8 @@ class TestFastAPI:
             return await app_handler.handle(req)
 
         client = TestClient(api)
-        response = client.get("/slack/install", allow_redirects=False)
+        client.follow_redirects = False
+        response = client.get("/slack/install")
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
         assert response.headers.get("content-length") == "607"

--- a/tests/adapter_tests_async/test_async_starlette.py
+++ b/tests/adapter_tests_async/test_async_starlette.py
@@ -216,7 +216,8 @@ class TestAsyncStarlette:
         )
 
         client = TestClient(api)
-        response = client.get("/slack/install", allow_redirects=False)
+        client.follow_redirects = False
+        response = client.get("/slack/install")
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
         assert response.headers.get("content-length") == "607"


### PR DESCRIPTION
## Summary

The unit tests of #1239 are failing due to wild card imports of adapter dependencies, this PR aims to update the unit tests to allow them to pass with the changes introduced to dependencies

### Testing

Run the unit tests

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
