### PR TITLE
docs: fix broken link in commands.md

### DIFF
--- a/docs/content/concepts/commands.md
+++ b/docs/content/concepts/commands.md
@@ -8,7 +8,7 @@ Your app can use the `command()` method to listen to incoming slash command requ
 
 Commands must be acknowledged with `ack()` to inform Slack your app has received the request.
 
-There are two ways to respond to slash commands. The first way is to use `say()`, which accepts a string or JSON payload. The second is `respond()` which is a utility for the `response_url`. These are explained in more depth in the [responding to actions](/concepts/action-respond) section.
+There are two ways to respond to slash commands. The first way is to use `say()`, which accepts a string or JSON payload. The second is `respond()` which is a utility for the `response_url`. These are explained in more depth in the [responding to actions](/bolt-python/concepts/actions) section.
 
 When setting up commands within your app configuration, you'll append `/slack/events` to your request URL.
 

--- a/docs/content/concepts/commands.md
+++ b/docs/content/concepts/commands.md
@@ -8,7 +8,7 @@ Your app can use the `command()` method to listen to incoming slash command requ
 
 Commands must be acknowledged with `ack()` to inform Slack your app has received the request.
 
-There are two ways to respond to slash commands. The first way is to use `say()`, which accepts a string or JSON payload. The second is `respond()` which is a utility for the `response_url`. These are explained in more depth in the [responding to actions](/bolt-python/concepts/actions) section.
+There are two ways to respond to slash commands. The first way is to use `say()`, which accepts a string or JSON payload. The second is `respond()` which is a utility for the `response_url`. These are explained in more depth in the [responding to actions](/concepts/actions) section.
 
 When setting up commands within your app configuration, you'll append `/slack/events` to your request URL.
 


### PR DESCRIPTION
## Summary

This PR aims to fix a broken link in the docs

### Testing

Try it out

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
