### PR TITLE
test: add tests around the logger experience of bolt

### DIFF
--- a/tests/scenario_tests/test_web_client_customization.py
+++ b/tests/scenario_tests/test_web_client_customization.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from time import time
 from urllib.parse import quote
 
@@ -21,6 +22,7 @@ class TestWebClientCustomization:
     signing_secret = "secret"
     mock_api_server_base_url = "http://localhost:8888"
     signature_verifier = SignatureVerifier(signing_secret)
+    test_logger = logging.getLogger("test.logger")
     web_client = WebClient(
         token=valid_token,
         base_url=mock_api_server_base_url,
@@ -68,6 +70,24 @@ class TestWebClientCustomization:
         assert response.status == 200
         assert response.body == ""
         assert_auth_test_count(self, 1)
+
+    def test_web_client_logger_is_default_app_logger(self):
+        app = App(token=self.valid_token, signing_secret=self.signing_secret, token_verification_enabled=False)
+        app.client.base_url = self.mock_api_server_base_url
+
+        assert app.client.logger == app.logger
+
+    def test_web_client_logger_is_app_logger(self):
+        app = App(
+            token=self.valid_token,
+            signing_secret=self.signing_secret,
+            logger=self.test_logger,
+            token_verification_enabled=False,
+        )
+        app.client.base_url = self.mock_api_server_base_url
+
+        assert app.client.logger == app.logger
+        assert app.client.logger == self.test_logger
 
 
 block_actions_body = {

--- a/tests/scenario_tests/test_web_client_customization.py
+++ b/tests/scenario_tests/test_web_client_customization.py
@@ -73,7 +73,7 @@ class TestWebClientCustomization:
 
     def test_web_client_logger_is_default_app_logger(self):
         app = App(token=self.valid_token, signing_secret=self.signing_secret, token_verification_enabled=False)
-        assert app.client.logger == app.logger
+        assert app.client._logger == app.logger  # TODO: use client.logger when available
 
     def test_web_client_logger_is_app_logger(self):
         app = App(
@@ -82,8 +82,8 @@ class TestWebClientCustomization:
             logger=self.test_logger,
             token_verification_enabled=False,
         )
-        assert app.client.logger == app.logger
-        assert app.client.logger == self.test_logger
+        assert app.client._logger == app.logger  # TODO: use client.logger when available
+        assert app.client._logger == self.test_logger  # TODO: use client.logger when available
 
 
 block_actions_body = {

--- a/tests/scenario_tests/test_web_client_customization.py
+++ b/tests/scenario_tests/test_web_client_customization.py
@@ -73,8 +73,6 @@ class TestWebClientCustomization:
 
     def test_web_client_logger_is_default_app_logger(self):
         app = App(token=self.valid_token, signing_secret=self.signing_secret, token_verification_enabled=False)
-        app.client.base_url = self.mock_api_server_base_url
-
         assert app.client.logger == app.logger
 
     def test_web_client_logger_is_app_logger(self):
@@ -84,8 +82,6 @@ class TestWebClientCustomization:
             logger=self.test_logger,
             token_verification_enabled=False,
         )
-        app.client.base_url = self.mock_api_server_base_url
-
         assert app.client.logger == app.logger
         assert app.client.logger == self.test_logger
 

--- a/tests/scenario_tests_async/test_web_client_customization.py
+++ b/tests/scenario_tests_async/test_web_client_customization.py
@@ -91,12 +91,12 @@ class TestWebClientCustomization:
 
     def test_web_client_logger_is_default_app_logger(self):
         app = AsyncApp(token=self.valid_token, signing_secret=self.signing_secret)
-        assert app.client.logger == app.logger
+        assert app.client._logger == app.logger  # TODO: use client.logger when available
 
     def test_web_client_logger_is_app_logger(self):
         app = AsyncApp(token=self.valid_token, signing_secret=self.signing_secret, logger=self.test_logger)
-        assert app.client.logger == app.logger
-        assert app.client.logger == self.test_logger
+        assert app.client._logger == app.logger  # TODO: use client.logger when available
+        assert app.client._logger == self.test_logger  # TODO: use client.logger when available
 
 
 block_actions_body = {

--- a/tests/scenario_tests_async/test_web_client_customization.py
+++ b/tests/scenario_tests_async/test_web_client_customization.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from time import time
 from urllib.parse import quote
@@ -23,6 +24,7 @@ class TestWebClientCustomization:
     signing_secret = "secret"
     mock_api_server_base_url = "http://localhost:8888"
     signature_verifier = SignatureVerifier(signing_secret)
+    test_logger = logging.getLogger("test.logger")
     web_client = AsyncWebClient(
         token=valid_token,
         base_url=mock_api_server_base_url,
@@ -86,6 +88,19 @@ class TestWebClientCustomization:
         assert response.status == 200
         assert response.body == ""
         await assert_auth_test_count_async(self, 1)
+
+    def test_web_client_logger_is_default_app_logger(self):
+        app = AsyncApp(token=self.valid_token, signing_secret=self.signing_secret)
+        app.client.base_url = self.mock_api_server_base_url
+
+        assert app.client.logger == app.logger
+
+    def test_web_client_logger_is_app_logger(self):
+        app = AsyncApp(token=self.valid_token, signing_secret=self.signing_secret, logger=self.test_logger)
+        app.client.base_url = self.mock_api_server_base_url
+
+        assert app.client.logger == app.logger
+        assert app.client.logger == self.test_logger
 
 
 block_actions_body = {

--- a/tests/scenario_tests_async/test_web_client_customization.py
+++ b/tests/scenario_tests_async/test_web_client_customization.py
@@ -91,14 +91,10 @@ class TestWebClientCustomization:
 
     def test_web_client_logger_is_default_app_logger(self):
         app = AsyncApp(token=self.valid_token, signing_secret=self.signing_secret)
-        app.client.base_url = self.mock_api_server_base_url
-
         assert app.client.logger == app.logger
 
     def test_web_client_logger_is_app_logger(self):
         app = AsyncApp(token=self.valid_token, signing_secret=self.signing_secret, logger=self.test_logger)
-        app.client.base_url = self.mock_api_server_base_url
-
         assert app.client.logger == app.logger
         assert app.client.logger == self.test_logger
 


### PR DESCRIPTION
## Summary

This PR aims to add tests around the behavior of loggers used between `Bolt` and `WebClient`

This is the first step to solve #1255

### Testing

Run the unit tests

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
