### PR TITLE
docs: update packaging notation for local development requirements

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -103,11 +103,11 @@ If you want to test the package locally you can.
    - This will create a `.whl` file in the `./dist` folder
 2. Use the built package
    - Example `/dist/slack_bolt-1.2.3-py2.py3-none-any.whl` was created
-   - From anywhere on your machine you can install this package to a project with 
+   - From anywhere on your machine you can install this package to a project with
      ```bash
      pip install <project path>/dist/slack_bolt-1.2.3-py2.py3-none-any.whl
      ```
-   - It is also possible to include `<project path>/dist/slack_bolt-1.2.3-py2.py3-none-any.whl` in a [requirements.txt](https://pip.pypa.io/en/stable/user_guide/#requirements-files) file
+   - It is also possible to include `slack_bolt @ file:///<project path>/dist/slack_bolt-1.2.3-py2.py3-none-any.whl` in a [requirements.txt](https://pip.pypa.io/en/stable/user_guide/#requirements-files) file
 
 ### Releasing
 


### PR DESCRIPTION
## Summary

This PR updates the `maintainers_guide.md` packaging step for local build developments to match a [recent change](https://github.com/slackapi/python-slack-sdk/pull/1672#discussion_r1994275536) to the `slack_sdk` notes 📚 

### Testing

An expanded version of these line can be found with `pip freeze`!

### Category

* [ ] Document pages under `/docs`
* [x] `maintainers_guide.md`
* [x] Others

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
