### PR TITLE
changed auth string to point at api.slack.com instead of slack.com

### DIFF
--- a/docs/static/api-docs/slack_bolt/oauth/async_oauth_settings.html
+++ b/docs/static/api-docs/slack_bolt/oauth/async_oauth_settings.html
@@ -69,7 +69,7 @@ el.replaceWith(d);
     callback_options: Optional[AsyncCallbackOptions] = None
     success_url: Optional[str]
     failure_url: Optional[str]
-    authorization_url: str  # default: https://slack.com/oauth/v2/authorize
+    authorization_url: str  # default: https://api.slack.com/oauth/v2/authorize
     # Installation Management
     installation_store: AsyncInstallationStore
     installation_store_bot_only: bool
@@ -132,7 +132,8 @@ el.replaceWith(d);
             callback_options: Give success/failure functions f you want to customize callback functions.
             success_url: Set a complete URL if you want to redirect end-users when an installation completes.
             failure_url: Set a complete URL if you want to redirect end-users when an installation fails.
-            authorization_url: Set a URL if you want to customize the URL `https://slack.com/oauth/v2/authorize`
+            authorization_url: Set a URL if you want to customize the URL
+            `https://api.slack.com/oauth/v2/authorize`
             installation_store: Specify the instance of `InstallationStore` (Default: `FileInstallationStore`)
             installation_store_bot_only: Use `InstallationStore#find_bot()` if True (Default: False)
             token_rotation_expiration_minutes: Minutes before refreshing tokens (Default: 2 hours)
@@ -170,7 +171,7 @@ el.replaceWith(d);
         self.callback_options = callback_options
         self.success_url = success_url
         self.failure_url = failure_url
-        self.authorization_url = authorization_url or &#34;https://slack.com/oauth/v2/authorize&#34;
+        self.authorization_url = authorization_url or &#34;https://api.slack.com/oauth/v2/authorize&#34;
         # Installation Management
         self.installation_store = installation_store or get_or_create_default_installation_store(client_id)
         self.user_token_resolution = user_token_resolution or &#34;authed_user&#34;
@@ -238,7 +239,7 @@ el.replaceWith(d);
 <dt><strong><code>failure_url</code></strong></dt>
 <dd>Set a complete URL if you want to redirect end-users when an installation fails.</dd>
 <dt><strong><code>authorization_url</code></strong></dt>
-<dd>Set a URL if you want to customize the URL <code>https://slack.com/oauth/v2/authorize</code></dd>
+<dd>Set a URL if you want to customize the URL <code>https://api.slack.com/oauth/v2/authorize</code></dd>
 <dt><strong><code>installation_store</code></strong></dt>
 <dd>Specify the instance of <code>InstallationStore</code> (Default: <code>FileInstallationStore</code>)</dd>
 <dt><strong><code>installation_store_bot_only</code></strong></dt>

--- a/docs/static/api-docs/slack_bolt/oauth/oauth_settings.html
+++ b/docs/static/api-docs/slack_bolt/oauth/oauth_settings.html
@@ -69,7 +69,7 @@ el.replaceWith(d);
     callback_options: Optional[CallbackOptions] = None
     success_url: Optional[str]
     failure_url: Optional[str]
-    authorization_url: str  # default: https://slack.com/oauth/v2/authorize
+    authorization_url: str  # default: https://api.slack.com/oauth/v2/authorize
     # Installation Management
     installation_store: InstallationStore
     installation_store_bot_only: bool
@@ -132,7 +132,8 @@ el.replaceWith(d);
             callback_options: Give success/failure functions f you want to customize callback functions.
             success_url: Set a complete URL if you want to redirect end-users when an installation completes.
             failure_url: Set a complete URL if you want to redirect end-users when an installation fails.
-            authorization_url: Set a URL if you want to customize the URL `https://slack.com/oauth/v2/authorize`
+            authorization_url: Set a URL if you want to customize the URL
+            `https://api.slack.com/oauth/v2/authorize`
             installation_store: Specify the instance of `InstallationStore` (Default: `FileInstallationStore`)
             installation_store_bot_only: Use `InstallationStore#find_bot()` if True (Default: False)
             token_rotation_expiration_minutes: Minutes before refreshing tokens (Default: 2 hours)
@@ -168,7 +169,7 @@ el.replaceWith(d);
         self.callback_options = callback_options
         self.success_url = success_url
         self.failure_url = failure_url
-        self.authorization_url = authorization_url or &#34;https://slack.com/oauth/v2/authorize&#34;
+        self.authorization_url = authorization_url or &#34;https://api.slack.com/oauth/v2/authorize&#34;
         # Installation Management
         self.installation_store = installation_store or get_or_create_default_installation_store(client_id)
         self.user_token_resolution = user_token_resolution or &#34;authed_user&#34;
@@ -236,7 +237,7 @@ el.replaceWith(d);
 <dt><strong><code>failure_url</code></strong></dt>
 <dd>Set a complete URL if you want to redirect end-users when an installation fails.</dd>
 <dt><strong><code>authorization_url</code></strong></dt>
-<dd>Set a URL if you want to customize the URL <code>https://slack.com/oauth/v2/authorize</code></dd>
+<dd>Set a URL if you want to customize the URL <code>https://api.slack.com/oauth/v2/authorize</code></dd>
 <dt><strong><code>installation_store</code></strong></dt>
 <dd>Specify the instance of <code>InstallationStore</code> (Default: <code>FileInstallationStore</code>)</dd>
 <dt><strong><code>installation_store_bot_only</code></strong></dt>

--- a/slack_bolt/oauth/async_oauth_settings.py
+++ b/slack_bolt/oauth/async_oauth_settings.py
@@ -37,7 +37,7 @@ class AsyncOAuthSettings:
     callback_options: Optional[AsyncCallbackOptions] = None
     success_url: Optional[str]
     failure_url: Optional[str]
-    authorization_url: str  # default: https://slack.com/oauth/v2/authorize
+    authorization_url: str  # default: https://api.slack.com/oauth/v2/authorize
     # Installation Management
     installation_store: AsyncInstallationStore
     installation_store_bot_only: bool
@@ -100,7 +100,8 @@ class AsyncOAuthSettings:
             callback_options: Give success/failure functions f you want to customize callback functions.
             success_url: Set a complete URL if you want to redirect end-users when an installation completes.
             failure_url: Set a complete URL if you want to redirect end-users when an installation fails.
-            authorization_url: Set a URL if you want to customize the URL `https://slack.com/oauth/v2/authorize`
+            authorization_url: Set a URL if you want to customize the URL
+            `https://api.slack.com/oauth/v2/authorize`
             installation_store: Specify the instance of `InstallationStore` (Default: `FileInstallationStore`)
             installation_store_bot_only: Use `InstallationStore#find_bot()` if True (Default: False)
             token_rotation_expiration_minutes: Minutes before refreshing tokens (Default: 2 hours)
@@ -138,7 +139,7 @@ class AsyncOAuthSettings:
         self.callback_options = callback_options
         self.success_url = success_url
         self.failure_url = failure_url
-        self.authorization_url = authorization_url or "https://slack.com/oauth/v2/authorize"
+        self.authorization_url = authorization_url or "https://api.slack.com/oauth/v2/authorize"
         # Installation Management
         self.installation_store = installation_store or get_or_create_default_installation_store(client_id)
         self.user_token_resolution = user_token_resolution or "authed_user"

--- a/slack_bolt/oauth/oauth_settings.py
+++ b/slack_bolt/oauth/oauth_settings.py
@@ -32,7 +32,7 @@ class OAuthSettings:
     callback_options: Optional[CallbackOptions] = None
     success_url: Optional[str]
     failure_url: Optional[str]
-    authorization_url: str  # default: https://slack.com/oauth/v2/authorize
+    authorization_url: str  # default: https://api.slack.com/oauth/v2/authorize
     # Installation Management
     installation_store: InstallationStore
     installation_store_bot_only: bool
@@ -95,7 +95,8 @@ class OAuthSettings:
             callback_options: Give success/failure functions f you want to customize callback functions.
             success_url: Set a complete URL if you want to redirect end-users when an installation completes.
             failure_url: Set a complete URL if you want to redirect end-users when an installation fails.
-            authorization_url: Set a URL if you want to customize the URL `https://slack.com/oauth/v2/authorize`
+            authorization_url: Set a URL if you want to customize the URL
+            `https://api.slack.com/oauth/v2/authorize`
             installation_store: Specify the instance of `InstallationStore` (Default: `FileInstallationStore`)
             installation_store_bot_only: Use `InstallationStore#find_bot()` if True (Default: False)
             token_rotation_expiration_minutes: Minutes before refreshing tokens (Default: 2 hours)
@@ -131,7 +132,7 @@ class OAuthSettings:
         self.callback_options = callback_options
         self.success_url = success_url
         self.failure_url = failure_url
-        self.authorization_url = authorization_url or "https://slack.com/oauth/v2/authorize"
+        self.authorization_url = authorization_url or "https://api.slack.com/oauth/v2/authorize"
         # Installation Management
         self.installation_store = installation_store or get_or_create_default_installation_store(client_id)
         self.user_token_resolution = user_token_resolution or "authed_user"

--- a/tests/adapter_tests/asgi/test_asgi_http.py
+++ b/tests/adapter_tests/asgi/test_asgi_http.py
@@ -194,7 +194,7 @@ class TestAsgiHttp:
 
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert "https://slack.com/oauth/v2/authorize?state=" in response.body
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in response.body
 
     @pytest.mark.asyncio
     async def test_url_verification(self):

--- a/tests/adapter_tests/aws/test_aws_chalice.py
+++ b/tests/adapter_tests/aws/test_aws_chalice.py
@@ -401,4 +401,4 @@ class TestAwsChalice:
         )
         assert response["statusCode"] == 200
         assert response["headers"]["content-type"] == "text/html; charset=utf-8"
-        assert "https://slack.com/oauth/v2/authorize?state=" in response.get("body")
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in response.get("body")

--- a/tests/adapter_tests/aws/test_aws_lambda.py
+++ b/tests/adapter_tests/aws/test_aws_lambda.py
@@ -319,7 +319,7 @@ class TestAWSLambda:
         response = SlackRequestHandler(app).handle(event, self.context)
         assert response["statusCode"] == 200
         assert response["headers"]["content-type"] == "text/html; charset=utf-8"
-        assert "https://slack.com/oauth/v2/authorize?state=" in response.get("body")
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in response.get("body")
 
     @mock_aws
     def test_oauth_redirect(self):

--- a/tests/adapter_tests/bottle/test_bottle_oauth.py
+++ b/tests/adapter_tests/bottle/test_bottle_oauth.py
@@ -28,4 +28,4 @@ class TestBottle:
             response_body = install()
             assert response.status_code == 200
             assert response.headers.get("content-type") == "text/html; charset=utf-8"
-            assert "https://slack.com/oauth/v2/authorize?state=" in response_body
+            assert "https://api.slack.com/oauth/v2/authorize?state=" in response_body

--- a/tests/adapter_tests/django/test_django.py
+++ b/tests/adapter_tests/django/test_django.py
@@ -266,4 +266,4 @@ class TestDjango(TestCase):
         response = SlackRequestHandler(app).handle(request)
         assert response.status_code == 200
         assert response.get("content-type") == "text/html; charset=utf-8"
-        assert "https://slack.com/oauth/v2/authorize?state=" in response.content.decode("utf-8")
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in response.content.decode("utf-8")

--- a/tests/adapter_tests/falcon/test_falcon.py
+++ b/tests/adapter_tests/falcon/test_falcon.py
@@ -204,4 +204,4 @@ class TestFalcon:
         client = testing.TestClient(api)
         response = client.simulate_get("/slack/install")
         assert response.status_code == 200
-        assert "https://slack.com/oauth/v2/authorize?state=" in response.text
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests/pyramid/test_pyramid.py
+++ b/tests/adapter_tests/pyramid/test_pyramid.py
@@ -186,4 +186,4 @@ class TestPyramid(TestCase):
         request.method = "GET"
         response: Response = SlackRequestHandler(app).handle(request)
         assert response.status_code == 200
-        assert "https://slack.com/oauth/v2/authorize?state=" in response.body.decode("utf-8")
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in response.body.decode("utf-8")

--- a/tests/adapter_tests/starlette/test_fastapi.py
+++ b/tests/adapter_tests/starlette/test_fastapi.py
@@ -210,7 +210,7 @@ class TestFastAPI:
         response = client.get("/slack/install")
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert "https://slack.com/oauth/v2/authorize?state=" in response.text
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in response.text
 
     def test_custom_props(self):
         app = App(

--- a/tests/adapter_tests/starlette/test_starlette.py
+++ b/tests/adapter_tests/starlette/test_starlette.py
@@ -219,4 +219,4 @@ class TestStarlette:
         response = client.get("/slack/install")
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert "https://slack.com/oauth/v2/authorize?state=" in response.text
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests/wsgi/test_wsgi_http.py
+++ b/tests/adapter_tests/wsgi/test_wsgi_http.py
@@ -185,7 +185,7 @@ class TestWsgiHttp:
 
         assert response.status == "200 OK"
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert "https://slack.com/oauth/v2/authorize?state=" in response.body
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in response.body
 
     def test_url_verification(self):
         app = App(

--- a/tests/adapter_tests_async/test_async_asgi.py
+++ b/tests/adapter_tests_async/test_async_asgi.py
@@ -194,7 +194,7 @@ class TestAsyncAsgi:
 
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert "https://slack.com/oauth/v2/authorize?state=" in response.body
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in response.body
 
     @pytest.mark.asyncio
     async def test_url_verification(self):

--- a/tests/adapter_tests_async/test_async_falcon.py
+++ b/tests/adapter_tests_async/test_async_falcon.py
@@ -201,5 +201,5 @@ class TestAsyncFalcon:
         response = client.simulate_get("/slack/install")
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert response.headers.get("content-length") == "607"
+        assert response.headers.get("content-length") == "611"
         assert "https://api.slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests_async/test_async_falcon.py
+++ b/tests/adapter_tests_async/test_async_falcon.py
@@ -202,4 +202,4 @@ class TestAsyncFalcon:
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
         assert response.headers.get("content-length") == "607"
-        assert "https://slack.com/oauth/v2/authorize?state=" in response.text
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests_async/test_async_fastapi.py
+++ b/tests/adapter_tests_async/test_async_fastapi.py
@@ -211,7 +211,7 @@ class TestFastAPI:
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
         assert response.headers.get("content-length") == "607"
-        assert "https://slack.com/oauth/v2/authorize?state=" in response.text
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in response.text
 
     def test_custom_props(self):
         app = AsyncApp(

--- a/tests/adapter_tests_async/test_async_fastapi.py
+++ b/tests/adapter_tests_async/test_async_fastapi.py
@@ -210,7 +210,7 @@ class TestFastAPI:
         response = client.get("/slack/install")
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert response.headers.get("content-length") == "607"
+        assert response.headers.get("content-length") == "611"
         assert "https://api.slack.com/oauth/v2/authorize?state=" in response.text
 
     def test_custom_props(self):

--- a/tests/adapter_tests_async/test_async_sanic.py
+++ b/tests/adapter_tests_async/test_async_sanic.py
@@ -225,4 +225,4 @@ class TestSanic:
         # Sanic apps properly generate the content-length header
         # assert response.headers.get("content-length") == "607"
 
-        assert "https://slack.com/oauth/v2/authorize?state=" in response.text
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests_async/test_async_starlette.py
+++ b/tests/adapter_tests_async/test_async_starlette.py
@@ -220,5 +220,5 @@ class TestAsyncStarlette:
         response = client.get("/slack/install")
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
-        assert response.headers.get("content-length") == "607"
+        assert response.headers.get("content-length") == "611"
         assert "https://api.slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/adapter_tests_async/test_async_starlette.py
+++ b/tests/adapter_tests_async/test_async_starlette.py
@@ -221,4 +221,4 @@ class TestAsyncStarlette:
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
         assert response.headers.get("content-length") == "607"
-        assert "https://slack.com/oauth/v2/authorize?state=" in response.text
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in response.text

--- a/tests/slack_bolt/middleware/authorization/test_single_team_authorization.py
+++ b/tests/slack_bolt/middleware/authorization/test_single_team_authorization.py
@@ -40,7 +40,7 @@ class TestSingleTeamAuthorization:
         auth_test_result: SlackResponse = SlackResponse(
             client=client,
             http_verb="POST",
-            api_url="https://slack.com/api/auth.test",
+            api_url="https://api.slack.com/api/auth.test",
             req_args={},
             data={},
             headers={"x-oauth-scopes": "chat:write,commands"},

--- a/tests/slack_bolt/oauth/test_internals.py
+++ b/tests/slack_bolt/oauth/test_internals.py
@@ -33,8 +33,8 @@ class TestOAuthInternals:
     def test_build_default_install_page_html(self):
         test_patterns = [
             {
-                "input": "https://slack.com/oauth/v2/authorize?state=random&client_id=111.222&scope=commands",
-                "expected": "https://slack.com/oauth/v2/authorize?state=random&amp;client_id=111.222&amp;scope=commands",
+                "input": "https://api.slack.com/oauth/v2/authorize?state=random&client_id=111.222&scope=commands",
+                "expected": "https://api.slack.com/oauth/v2/authorize?state=random&amp;client_id=111.222&amp;scope=commands",
             },
             {
                 "input": "<b>test</b>",

--- a/tests/slack_bolt/oauth/test_oauth_flow.py
+++ b/tests/slack_bolt/oauth/test_oauth_flow.py
@@ -60,7 +60,7 @@ class TestOAuthFlow:
         assert resp.status == 200
         assert resp.headers.get("content-type") == ["text/html; charset=utf-8"]
         assert resp.headers.get("set-cookie") is not None
-        assert "https://slack.com/oauth/v2/authorize?state=" in resp.body
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in resp.body
 
     # https://github.com/slackapi/bolt-python/issues/183
     # For direct install URL support
@@ -80,7 +80,7 @@ class TestOAuthFlow:
         resp = oauth_flow.handle_installation(req)
         assert resp.status == 302
         location_header = resp.headers.get("location")[0]
-        assert "https://slack.com/oauth/v2/authorize?state=" in location_header
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in location_header
         assert resp.headers.get("set-cookie") is not None
 
     def test_handle_installation_team_param(self):
@@ -99,7 +99,7 @@ class TestOAuthFlow:
         resp = oauth_flow.handle_installation(req)
         assert resp.status == 302
         location_header = resp.headers.get("location")[0]
-        assert "https://slack.com/oauth/v2/authorize?state=" in location_header
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in location_header
         assert "&team=T12345" in location_header
         assert resp.headers.get("set-cookie") is not None
 

--- a/tests/slack_bolt/oauth/test_oauth_flow_sqlite3.py
+++ b/tests/slack_bolt/oauth/test_oauth_flow_sqlite3.py
@@ -41,7 +41,7 @@ class TestOAuthFlowSQLite3:
         resp = oauth_flow.handle_installation(req)
         assert resp.status == 200
         assert resp.headers.get("content-type") == ["text/html; charset=utf-8"]
-        assert "https://slack.com/oauth/v2/authorize?state=" in resp.body
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in resp.body
 
     def test_handle_callback(self):
         oauth_flow = OAuthFlow.sqlite3(

--- a/tests/slack_bolt_async/oauth/test_async_oauth_flow.py
+++ b/tests/slack_bolt_async/oauth/test_async_oauth_flow.py
@@ -108,7 +108,7 @@ class TestAsyncOAuthFlow:
         resp = await oauth_flow.handle_installation(req)
         assert resp.status == 200
         assert resp.headers.get("content-type") == ["text/html; charset=utf-8"]
-        assert "https://slack.com/oauth/v2/authorize?state=" in resp.body
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in resp.body
         assert resp.headers.get("set-cookie") is not None
 
     @pytest.mark.asyncio
@@ -127,7 +127,7 @@ class TestAsyncOAuthFlow:
         resp = await oauth_flow.handle_installation(req)
         assert resp.status == 302
         location_header = resp.headers.get("location")[0]
-        assert "https://slack.com/oauth/v2/authorize?state=" in location_header
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in location_header
         assert resp.headers.get("set-cookie") is not None
 
     @pytest.mark.asyncio
@@ -146,7 +146,7 @@ class TestAsyncOAuthFlow:
         resp = await oauth_flow.handle_installation(req)
         assert resp.status == 302
         location_header = resp.headers.get("location")[0]
-        assert "https://slack.com/oauth/v2/authorize?state=" in location_header
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in location_header
         assert "&team=T12345" in location_header
         assert resp.headers.get("set-cookie") is not None
 
@@ -167,7 +167,7 @@ class TestAsyncOAuthFlow:
         resp = await oauth_flow.handle_installation(req)
         assert resp.status == 302
         location_header = resp.headers.get("location")[0]
-        assert "https://slack.com/oauth/v2/authorize?state=" in location_header
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in location_header
         assert resp.headers.get("set-cookie") is None
 
     @pytest.mark.asyncio

--- a/tests/slack_bolt_async/oauth/test_async_oauth_flow_sqlite3.py
+++ b/tests/slack_bolt_async/oauth/test_async_oauth_flow_sqlite3.py
@@ -54,7 +54,7 @@ class TestAsyncOAuthFlowSQLite3:
         resp = await oauth_flow.handle_installation(req)
         assert resp.status == 200
         assert resp.headers.get("content-type") == ["text/html; charset=utf-8"]
-        assert "https://slack.com/oauth/v2/authorize?state=" in resp.body
+        assert "https://api.slack.com/oauth/v2/authorize?state=" in resp.body
 
     @pytest.mark.asyncio
     async def test_handle_callback(self):


### PR DESCRIPTION
## Summary

<!-- Describe the goal of this PR. Mention any related issue numbers -->
slack.com and api.slack.com appear to be interchangeable with regards to api calls. Migrating the oauth call to api.slack.com removes organizations having to allowlist slack.com allowing them to avoid allowlisting broad scope domains.
### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [x] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
