### PR TITLE
health: publish test results to code cov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,60 +35,47 @@ jobs:
           pip install -r requirements/testing_without_asyncio.txt
       - name: Run tests without aiohttp
         run: |
-          pytest tests/slack_bolt/
-          pytest tests/scenario_tests/
+          pytest tests/slack_bolt/ --junitxml=reports/slack_bolt.xml
+          pytest tests/scenario_tests/ --junitxml=reports/scenario_tests.xml
       - name: Install adapter dependencies
         run: |
           pip install -r requirements/adapter.txt
           pip install -r requirements/adapter_testing.txt
-      - name: Run tests for HTTP Mode adapters (AWS)
+      - name: Run tests for HTTP Mode adapters
         run: |
-          pytest tests/adapter_tests/aws/
-      - name: Run tests for HTTP Mode adapters (Bottle)
-        run: |
-          pytest tests/adapter_tests/bottle/
-      - name: Run tests for HTTP Mode adapters (CherryPy)
-        run: |
-          pytest tests/adapter_tests/cherrypy/
-      - name: Run tests for HTTP Mode adapters (Django)
-        run: |
-          pytest tests/adapter_tests/django/
-      - name: Run tests for HTTP Mode adapters (Falcon)
-        run: |
-          pytest tests/adapter_tests/falcon/
-      - name: Run tests for HTTP Mode adapters (Flask)
-        run: |
-          pytest tests/adapter_tests/flask/
-      - name: Run tests for HTTP Mode adapters (Pyramid)
-        run: |
-          pytest tests/adapter_tests/pyramid/
-      - name: Run tests for HTTP Mode adapters (Starlette)
-        run: |
-          pytest tests/adapter_tests/starlette/
-      - name: Run tests for HTTP Mode adapters (Tornado)
-        run: |
-          pytest tests/adapter_tests/tornado/
-      - name: Run tests for HTTP Mode adapters (WSGI)
-        run: |
-          pytest tests/adapter_tests/wsgi/
+          pytest tests/adapter_tests/ \
+          --ignore=tests/adapter_tests/socket_mode/ \
+          --ignore=tests/adapter_tests/asgi/ \
+          --junitxml=reports/adapter_tests.xml
       - name: Install async dependencies
         run: |
           pip install -r requirements/async.txt
-      - name: Run tests for Socket Mode adapters
-        run: |
-          # Requires async test dependencies
-          pytest tests/adapter_tests/socket_mode/
-      - name: Run tests for HTTP Mode adapters (asyncio-based libraries)
-        run: |
-          pytest tests/adapter_tests_async/
       - name: Run tests for HTTP Mode adapters (ASGI)
         run: |
           # Requires async test dependencies
-          pytest tests/adapter_tests/asgi/
+          pytest tests/adapter_tests/asgi/ --junitxml=reports/adapter_tests_asgi.xml
+      - name: Run tests for Socket Mode adapters
+        run: |
+          # Requires async test dependencies
+          pytest tests/adapter_tests/socket_mode/ --junitxml=reports/adapter_tests_socket_mode.xml
+      - name: Run tests for HTTP Mode adapters (asyncio-based libraries)
+        run: |
+          pytest tests/adapter_tests_async/ --junitxml=reports/adapter_tests_async.xml
       - name: Install all dependencies
         run: |
           pip install -r requirements/testing.txt
       - name: Run asynchronous tests
         run: |
-          pytest tests/slack_bolt_async/
-          pytest tests/scenario_tests_async/
+          pytest tests/slack_bolt_async/ --junitxml=reports/slack_bolt_async.xml
+          pytest tests/scenario_tests_async/ --junitxml=reports/scenario_tests_async.xml
+      - name: Merge junit xml testsuite results
+        run: |
+          python scripts/merge_junit_results.py reports/*.xml >&0 | cat > report.xml
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          directory: ./reports/
+          flags: ${{ matrix.python-version }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,8 +72,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
-          directory: ./reports/
-          files: test*.xml
+          files: ./reports/test_*.xml
           flags: ${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,8 +35,8 @@ jobs:
           pip install -r requirements/testing_without_asyncio.txt
       - name: Run tests without aiohttp
         run: |
-          pytest tests/slack_bolt/ --junitxml=reports/slack_bolt.xml
-          pytest tests/scenario_tests/ --junitxml=reports/scenario_tests.xml
+          pytest tests/slack_bolt/ --junitxml=reports/test_slack_bolt.xml
+          pytest tests/scenario_tests/ --junitxml=reports/test_scenario.xml
       - name: Install adapter dependencies
         run: |
           pip install -r requirements/adapter.txt
@@ -46,36 +46,34 @@ jobs:
           pytest tests/adapter_tests/ \
           --ignore=tests/adapter_tests/socket_mode/ \
           --ignore=tests/adapter_tests/asgi/ \
-          --junitxml=reports/adapter_tests.xml
+          --junitxml=reports/test_adapter.xml
       - name: Install async dependencies
         run: |
           pip install -r requirements/async.txt
       - name: Run tests for HTTP Mode adapters (ASGI)
         run: |
           # Requires async test dependencies
-          pytest tests/adapter_tests/asgi/ --junitxml=reports/adapter_tests_asgi.xml
+          pytest tests/adapter_tests/asgi/ --junitxml=reports/test_adapter_asgi.xml
       - name: Run tests for Socket Mode adapters
         run: |
           # Requires async test dependencies
-          pytest tests/adapter_tests/socket_mode/ --junitxml=reports/adapter_tests_socket_mode.xml
+          pytest tests/adapter_tests/socket_mode/ --junitxml=reports/test_adapter_socket_mode.xml
       - name: Run tests for HTTP Mode adapters (asyncio-based libraries)
         run: |
-          pytest tests/adapter_tests_async/ --junitxml=reports/adapter_tests_async.xml
+          pytest tests/adapter_tests_async/ --junitxml=reports/test_adapter_async.xml
       - name: Install all dependencies
         run: |
           pip install -r requirements/testing.txt
       - name: Run asynchronous tests
         run: |
-          pytest tests/slack_bolt_async/ --junitxml=reports/slack_bolt_async.xml
-          pytest tests/scenario_tests_async/ --junitxml=reports/scenario_tests_async.xml
-      - name: Merge junit xml testsuite results
-        run: |
-          python scripts/merge_junit_results.py reports/*.xml >&0 | cat > report.xml
+          pytest tests/slack_bolt_async/ --junitxml=reports/test_slack_bolt_async.xml
+          pytest tests/scenario_tests_async/ --junitxml=reports/test_scenario_async.xml
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
           directory: ./reports/
+          files: test*.xml
           flags: ${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
-          files: ./reports/test_*.xml
+          directory: ./reports/
           flags: ${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ venv/
 .coverage
 cov_*
 coverage.xml
+reports/
 
 # due to using tox and pytest
 .tox


### PR DESCRIPTION
## Summary

This PR is inspired by https://github.com/slackapi/node-slack-sdk/pull/2178

It updates the CI pipeline to publish the test results to codcov and provide some [neat reporting details](https://docs.codecov.com/docs/test-analytics#reporting)

### Testing

Check out [the results](https://app.codecov.io/gh/slackapi/bolt-python/tests/code-cov-test-reporting) on codcov

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
