### PR TITLE
chore: remove 3.6 CI support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,14 +7,12 @@ on:
 
 jobs:
   build:
-    # Avoiding -latest due to https://github.com/actions/setup-python/issues/162
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"


### PR DESCRIPTION
## Summary

The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-15 (https://github.com/actions/runner-images/issues/11101). The next [available image](https://github.com/actions/runner-images?tab=readme-ov-file#available-images) is [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md), but it does not support Python 3.6.
```
Error: The version '3.6' with architecture 'x64' was not found for Ubuntu 22.04.
```
The project is in the process of dropping support for `python 3.6` until this is done the team will need to manually validate compatibility with `python 3.6`

Steps:
1. `pyenv shell 3.6.15`
2. `python --version` -> `Python 3.6.15`
3. `python -m venv env_3.6.15`
4. `source env_3.6.15/bin/activate`
5.  `scripts/install_all_and_run_tests.sh`
6. No tests fail

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
