### PR TITLE
Docs: Fixed incorrect link

### DIFF
--- a/docs/content/tutorial/custom-steps-for-jira.md
+++ b/docs/content/tutorial/custom-steps-for-jira.md
@@ -21,7 +21,7 @@ If you'd rather skip the tutorial and just head straight to the code, you can us
 
 1. Navigate to the [app creation page](https://api.slack.com/apps/new) and select **From a manifest**.
 2. Select the workspace you want to install the application in, then click **Next**.
-3. Copy the contents of the [`manifest.json`](https://github.com/slack-samples/bolt-python-ai-chatbot/blob/main/manifest.json) file below into the text box that says **Paste your manifest code here** (within the **JSON** tab), then click **Next**:
+3. Copy the contents of the [`manifest.json`](https://github.com/slack-samples/bolt-python-jira-functions/blob/main/manifest.json) file below into the text box that says **Paste your manifest code here** (within the **JSON** tab), then click **Next**:
 
 ```js reference title="manifest.json"
 https://github.com/slack-samples/bolt-python-jira-functions/blob/main/manifest.json


### PR DESCRIPTION
## Summary

Small fix to the linked manifest. The correct one is shown in the code sample.

### Testing

Pull the branch locally, `cd` to the docs folder and run `npm start`. Navigate to the "Custom steps for JIRA" tutorial and notice that the linked manifest in step 3 under **Creating your app** is now correct.

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
