### PR TITLE
ci: run unit tests on main once a day

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

This PR runs the unit tests once a day to confirm the latest versions of scoped requirements continue to pass 🤖 

Related: https://github.com/slackapi/python-slack-sdk/pull/1697
Perhaps also https://github.com/slackapi/bolt-python/pull/1317: https://github.com/slackapi/bolt-python/actions/runs/15833832234/job/44799314169

### Testing

If this is merged to `main` I believe the tests will repeat! Reference: [`schedule`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule)

I'm hoping to run the tests in CI with this PR also 👾 ✨ 

### Notes

I'd be open to making a similar change for other testing related workflows, but this might be enough to catch problems soon?

- [`codecov.yml`](https://github.com/slackapi/bolt-python/blob/main/.github/workflows/codecov.yml)
- [`flake8.yml`](https://github.com/slackapi/bolt-python/blob/main/.github/workflows/flake8.yml)
- [`mypy.yml`](https://github.com/slackapi/bolt-python/blob/main/.github/workflows/mypy.yml)

### Category

* [x] Others

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
