### PR TITLE
fix: sanic dependencies for tests

### DIFF
--- a/requirements/adapter.txt
+++ b/requirements/adapter.txt
@@ -14,7 +14,7 @@ Flask>=1,<4
 Werkzeug>=2,<4
 pyramid>=1,<3
 sanic>=20,<21; python_version=="3.6"
-sanic>=21,<24; python_version>"3.6" and python_version<="3.8"
+sanic>=21,<23; python_version>"3.6" and python_version<="3.8"
 sanic>=21,<26; python_version>"3.8"
 starlette>=0.19.1,<1
 tornado>=6,<7


### PR DESCRIPTION
## Summary

Fix sanic dependencies for testing 

### Testing

Run the ci pipeline

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
