### PR TITLE
chore: run CI tests from the Github UI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,9 @@ on:
     branches:
       - main
   pull_request:
-  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Allow maintainers to trigger CI tests from the Github UI

### Testing

N/A

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
