### PR TITLE
ci: send a notification of scheduled failing tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
     name: Regression notifications
     runs-on: ubuntu-latest
     needs: build
-    if: failure() && github.ref == 'refs/heads/main'
+    if: failure()
     steps:
       - name: Send notifications of failing tests
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
     name: Regression notifications
     runs-on: ubuntu-latest
     needs: build
-    if: failure() && github.ref == 'refs/pull/1323/merge' && github.event_name != 'workflow_dispatch'
+    if: failure() && github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch'
     steps:
       - name: Send notifications of failing tests
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
     name: Regression notifications
     runs-on: ubuntu-latest
     needs: build
-    if: failure()
+    if: failure() && github.ref == 'refs/heads/main'
     steps:
       - name: Send notifications of failing tests
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
     name: Regression notifications
     runs-on: ubuntu-latest
     needs: build
-    if: failure() && github.ref == 'refs/heads/zimeg-ci-notifications'
+    if: failure() && github.ref == 'refs/heads/zimeg-ci-notifications' && github.event_name != 'workflow_dispatch'
     steps:
       - name: Send notifications of failing tests
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
     name: Regression notifications
     runs-on: ubuntu-latest
     needs: build
-    if: failure() && github.ref == 'refs/heads/zimeg-ci-notifications' && github.event_name != 'workflow_dispatch'
+    if: failure() && github.ref == 'refs/pull/1323/merge' && github.event_name != 'workflow_dispatch'
     steps:
       - name: Send notifications of failing tests
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
       - name: Send notifications of failing tests
-        if: failure() && github.ref == 'refs/heads/main'
+        if: failure()
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           errors: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,14 +73,6 @@ jobs:
         run: |
           pytest tests/slack_bolt_async/ --junitxml=reports/test_slack_bolt_async.xml
           pytest tests/scenario_tests_async/ --junitxml=reports/test_scenario_async.xml
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
-        with:
-          directory: ./reports/
-          flags: ${{ matrix.python-version }}
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
       - name: Send notifications of failing tests
         if: failure() && github.ref == 'refs/heads/main'
         uses: slackapi/slack-github-action@v2.1.0
@@ -90,3 +82,11 @@ jobs:
           payload: |
             action_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             repository: "${{ github.repository }}"
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
+        with:
+          directory: ./reports/
+          flags: ${{ matrix.python-version }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
     name: Regression notifications
     runs-on: ubuntu-latest
     needs: build
-    if: failure()
+    if: failure() && github.ref == 'refs/heads/zimeg-ci-notifications'
     steps:
       - name: Send notifications of failing tests
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,8 +85,8 @@ jobs:
         if: failure() && github.ref == 'refs/heads/main'
         uses: slackapi/slack-github-action@v2.1.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_REGRESSION_FAILURES_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: |
             action_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            repository: ${{ github.repository }}
+            repository: "${{ github.repository }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
           pytest tests/scenario_tests_async/ --junitxml=reports/test_scenario_async.xml
       - name: Send notifications of failing tests
         if: failure() && github.ref == 'refs/heads/main'
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           webhook: ${{ secrets.SLACK_REGRESSION_FAILURES_WEBHOOK_URL }}
           webhook-type: webhook-trigger

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,15 +73,6 @@ jobs:
         run: |
           pytest tests/slack_bolt_async/ --junitxml=reports/test_slack_bolt_async.xml
           pytest tests/scenario_tests_async/ --junitxml=reports/test_scenario_async.xml
-      - name: Send notifications of failing tests
-        if: failure() && github.ref == 'refs/heads/main'
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_REGRESSION_FAILURES_WEBHOOK_URL }}
-          webhook-type: webhook-trigger
-          payload: |
-            action_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            repository: "${{ github.repository }}"
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
@@ -90,3 +81,13 @@ jobs:
           flags: ${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+      - name: Send notifications of failing tests
+        if: failure() && github.ref == 'refs/heads/main'
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          errors: true
+          webhook: ${{ secrets.SLACK_REGRESSION_FAILURES_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            action_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            repository: "${{ github.repository }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,3 +81,12 @@ jobs:
           flags: ${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+      - name: Send notifications of failing tests
+        if: failure() && github.ref == 'refs/heads/main'
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            action_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            repository: ${{ github.repository }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,11 @@ jobs:
           flags: ${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+  notifications:
+    runs-on: ubuntu-latest
+    needs: build
+    if: failure()
+    steps:
       - name: Send notifications of failing tests
         if: failure()
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
   notifications:
-    name: Notifications
+    name: Regression notifications
     runs-on: ubuntu-latest
     needs: build
     if: failure()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,12 +82,12 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
   notifications:
+    name: Notifications
     runs-on: ubuntu-latest
     needs: build
     if: failure()
     steps:
       - name: Send notifications of failing tests
-        if: failure()
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           errors: true

--- a/tests/scenario_tests/test_app.py
+++ b/tests/scenario_tests/test_app.py
@@ -264,7 +264,7 @@ class TestApp:
 
         req = BoltRequest(body=app_mention_event_body, headers={}, mode="socket_mode")
         response = app.dispatch(req)
-        assert response.status == 418
+        assert response.status == 200
         assert result["called"] is True
 
     def test_argument_logger_propagation(self):

--- a/tests/scenario_tests/test_app.py
+++ b/tests/scenario_tests/test_app.py
@@ -264,7 +264,7 @@ class TestApp:
 
         req = BoltRequest(body=app_mention_event_body, headers={}, mode="socket_mode")
         response = app.dispatch(req)
-        assert response.status == 200
+        assert response.status == 418
         assert result["called"] is True
 
     def test_argument_logger_propagation(self):


### PR DESCRIPTION
## Summary

This PR sends a notification of scheduled failing tests using the new "regression failures" workflow!

### Testing

On schedule and according to #1322 🫡 

### Notes

I plan to test a few combinations in this PR to make sure notifications are sent 🚀 ✨ 

### Category

* [x] Others

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
