### PR TITLE
Revert "Remove py36 references"

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -25,6 +25,7 @@ $ pyenv local 3.8.5
 
 $ pyenv versions
   system
+  3.6.10
   3.7.7
 * 3.8.5 (set by /path-to-bolt-python/.python-version)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A Python framework to build Slack apps in a flash with the latest platform featu
 ## Setup
 
 ```bash
-# Python 3.7+ required
+# Python 3.6+ required
 python -m venv .venv
 source .venv/bin/activate
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dynamic = ["version", "readme", "dependencies", "authors"]
 description = "The Bolt Framework for Python"
 license = { text = "MIT" }
 classifiers = [
+	"Programming Language :: Python :: 3.6",
 	"Programming Language :: Python :: 3.7",
 	"Programming Language :: Python :: 3.8",
 	"Programming Language :: Python :: 3.9",
@@ -19,7 +20,7 @@ classifiers = [
 	"License :: OSI Approved :: MIT License",
 	"Operating System :: OS Independent",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.6"
 
 
 [project.urls]

--- a/scripts/install_all_and_run_tests.sh
+++ b/scripts/install_all_and_run_tests.sh
@@ -16,7 +16,12 @@ pip uninstall python-lambda
 test_target="$1"
 python_version=`python --version | awk '{print $2}'`
 
-pip install -e .
+if [ ${python_version:0:3} == "3.6" ]
+then
+  pip install -U -r requirements.txt
+else
+  pip install -e .
+fi
 
 if [[ $test_target != "" ]]
 then

--- a/slack_bolt/async_app.py
+++ b/slack_bolt/async_app.py
@@ -5,7 +5,7 @@
 If you'd prefer to build your app with [asyncio](https://docs.python.org/3/library/asyncio.html), you can import the [AIOHTTP](https://docs.aiohttp.org/en/stable/) library and call the `AsyncApp` constructor. Within async apps, you can use the async/await pattern.
 
 ```bash
-# Python 3.7+ required
+# Python 3.6+ required
 python -m venv .venv
 source .venv/bin/activate
 


### PR DESCRIPTION
Begins to resolve [Issue 603](https://github.com/slackapi/bolt-python/issues/603). This PR removes all explicit references and workarounds for Python 3.6 across the codebase and documentation to support minimum Python version 3.7+.
