### PR TITLE
docs: filter against bot_id in listener middleware example

### DIFF
--- a/docs/content/concepts/listener-middleware.md
+++ b/docs/content/concepts/listener-middleware.md
@@ -11,11 +11,10 @@ If your listener middleware is a quite simple one, you can use a listener matche
 Refer to [the module document](https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html) to learn the available listener arguments.
 
 ```python
-# Listener middleware which filters out messages with "bot_message" subtype
+# Listener middleware which filters out messages from a bot
 def no_bot_messages(message, next):
-    subtype = message.get("subtype")
-    if subtype != "bot_message":
-       next()
+    if "bot_id" not in message:
+        next()
 
 # This listener only receives messages from humans
 @app.event(event="message", middleware=[no_bot_messages])
@@ -24,10 +23,10 @@ def log_message(logger, event):
 
 # Listener matchers: simplified version of listener middleware
 def no_bot_messages(message) -> bool:
-    return message.get("subtype") != "bot_message"
+    return "bot_id" not in message
 
 @app.event(
-    event="message", 
+    event="message",
     matchers=[no_bot_messages]
     # or matchers=[lambda message: message.get("subtype") != "bot_message"]
 )

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/concepts/listener-middleware.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/concepts/listener-middleware.md
@@ -11,11 +11,10 @@ slug: /concepts/listener-middleware
 <span>指定可能な引数の一覧は<a href="https://tools.slack.dev/bolt-python/api-docs/slack_bolt/kwargs_injection/args.html">モジュールドキュメント</a>を参考にしてください。</span>
 
 ```python
-# "bot_message" サブタイプのメッセージを抽出するリスナーミドルウェア
+# ボットからのメッセージをフィルタリングするリスナーミドルウェア
 def no_bot_messages(message, next):
-    subtype = message.get("subtype")
-    if subtype != "bot_message":
-       next()
+    if "bot_id" not in message:
+        next()
 
 # このリスナーは人間によって送信されたメッセージのみを受け取ります
 @app.event(event="message", middleware=[no_bot_messages])
@@ -24,10 +23,10 @@ def log_message(logger, event):
 
 # リスナーマッチャー： 簡略化されたバージョンのリスナーミドルウェア
 def no_bot_messages(message) -> bool:
-    return message.get("subtype") != "bot_message"
+    return "bot_id" not in message
 
 @app.event(
-    event="message", 
+    event="message",
     matchers=[no_bot_messages]
     # or matchers=[lambda message: message.get("subtype") != "bot_message"]
 )


### PR DESCRIPTION
## Summary

This PR updates the listener middleware example to filter out bot messages according to a `bot_id` value to match the changes of https://github.com/slackapi/bolt-js/pull/2610:

> In [classic Slack apps](https://api.slack.com/authentication/migration), the `bot_message` event is sent when a message is sent to a channel by an integration "bot". It is like a normal user message, except it has no associated user. With current [Slack apps](https://api.slack.com/authentication/quickstart), also known as granular bot permissions (GBP) apps, you can detect if a message was sent by a bot by the presence of the `bot_id` and `bot_profile` fields in the event payload.

🔗 https://api.slack.com/events/message/bot_message

### Testing

The updated examples can be used as a proof of concept!

### Category

* [x] Document pages under `/docs`

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
