### PR TITLE
fix: make the function handler timeout 5 seconds

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -946,7 +946,9 @@ class App:
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
             primary_matcher = builtin_matchers.function_executed(callback_id=callback_id, base_logger=self._base_logger)
-            return self._register_listener(functions, primary_matcher, matchers, middleware, auto_acknowledge, acknowledgement_timeout=5)
+            return self._register_listener(
+                functions, primary_matcher, matchers, middleware, auto_acknowledge, acknowledgement_timeout=5
+            )
 
         return __call__
 

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -946,7 +946,7 @@ class App:
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
             primary_matcher = builtin_matchers.function_executed(callback_id=callback_id, base_logger=self._base_logger)
-            return self._register_listener(functions, primary_matcher, matchers, middleware, auto_acknowledge, 5)
+            return self._register_listener(functions, primary_matcher, matchers, middleware, auto_acknowledge, acknowledgement_timeout=5)
 
         return __call__
 

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -946,7 +946,7 @@ class App:
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
             primary_matcher = builtin_matchers.function_executed(callback_id=callback_id, base_logger=self._base_logger)
-            return self._register_listener(functions, primary_matcher, matchers, middleware, auto_acknowledge)
+            return self._register_listener(functions, primary_matcher, matchers, middleware, auto_acknowledge, 5)
 
         return __call__
 
@@ -1422,6 +1422,7 @@ class App:
         matchers: Optional[Sequence[Callable[..., bool]]],
         middleware: Optional[Sequence[Union[Callable, Middleware]]],
         auto_acknowledgement: bool = False,
+        acknowledgement_timeout: int = 3,
     ) -> Optional[Callable[..., Optional[BoltResponse]]]:
         value_to_return = None
         if not isinstance(functions, list):
@@ -1452,6 +1453,7 @@ class App:
                 matchers=listener_matchers,
                 middleware=listener_middleware,
                 auto_acknowledgement=auto_acknowledgement,
+                acknowledgement_timeout=acknowledgement_timeout,
                 base_logger=self._base_logger,
             )
         )

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -976,7 +976,9 @@ class AsyncApp:
             primary_matcher = builtin_matchers.function_executed(
                 callback_id=callback_id, base_logger=self._base_logger, asyncio=True
             )
-            return self._register_listener(functions, primary_matcher, matchers, middleware, auto_acknowledge, acknowledgement_timeout=5)
+            return self._register_listener(
+                functions, primary_matcher, matchers, middleware, auto_acknowledge, acknowledgement_timeout=5
+            )
 
         return __call__
 

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -976,7 +976,7 @@ class AsyncApp:
             primary_matcher = builtin_matchers.function_executed(
                 callback_id=callback_id, base_logger=self._base_logger, asyncio=True
             )
-            return self._register_listener(functions, primary_matcher, matchers, middleware, auto_acknowledge)
+            return self._register_listener(functions, primary_matcher, matchers, middleware, auto_acknowledge, 5)
 
         return __call__
 
@@ -1456,6 +1456,7 @@ class AsyncApp:
         matchers: Optional[Sequence[Callable[..., Awaitable[bool]]]],
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]],
         auto_acknowledgement: bool = False,
+        acknowledgement_timeout: int = 3,
     ) -> Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]:
         value_to_return = None
         if not isinstance(functions, list):
@@ -1491,6 +1492,7 @@ class AsyncApp:
                 matchers=listener_matchers,
                 middleware=listener_middleware,
                 auto_acknowledgement=auto_acknowledgement,
+                acknowledgement_timeout=acknowledgement_timeout,
                 base_logger=self._base_logger,
             )
         )

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -976,7 +976,7 @@ class AsyncApp:
             primary_matcher = builtin_matchers.function_executed(
                 callback_id=callback_id, base_logger=self._base_logger, asyncio=True
             )
-            return self._register_listener(functions, primary_matcher, matchers, middleware, auto_acknowledge, 5)
+            return self._register_listener(functions, primary_matcher, matchers, middleware, auto_acknowledge, acknowledgement_timeout=5)
 
         return __call__
 

--- a/slack_bolt/listener/async_listener.py
+++ b/slack_bolt/listener/async_listener.py
@@ -15,6 +15,7 @@ class AsyncListener(metaclass=ABCMeta):
     ack_function: Callable[..., Awaitable[BoltResponse]]
     lazy_functions: Sequence[Callable[..., Awaitable[None]]]
     auto_acknowledgement: bool
+    acknowledgement_timeout: int
 
     async def async_matches(
         self,
@@ -87,6 +88,7 @@ class AsyncCustomListener(AsyncListener):
     matchers: Sequence[AsyncListenerMatcher]
     middleware: Sequence[AsyncMiddleware]
     auto_acknowledgement: bool
+    acknowledgement_timeout: int
     arg_names: MutableSequence[str]
     logger: Logger
 
@@ -99,6 +101,7 @@ class AsyncCustomListener(AsyncListener):
         matchers: Sequence[AsyncListenerMatcher],
         middleware: Sequence[AsyncMiddleware],
         auto_acknowledgement: bool = False,
+        acknowledgement_timeout: int = 3,
         base_logger: Optional[Logger] = None,
     ):
         self.app_name = app_name
@@ -107,6 +110,7 @@ class AsyncCustomListener(AsyncListener):
         self.matchers = matchers
         self.middleware = middleware
         self.auto_acknowledgement = auto_acknowledgement
+        self.acknowledgement_timeout = acknowledgement_timeout
         self.arg_names = get_arg_names_of_callable(ack_function)
         self.logger = get_bolt_app_logger(app_name, self.ack_function, base_logger)
 

--- a/slack_bolt/listener/asyncio_runner.py
+++ b/slack_bolt/listener/asyncio_runner.py
@@ -149,7 +149,7 @@ class AsyncioListenerRunner:
                     self._start_lazy_function(lazy_func, request)
 
             # await for the completion of ack() in the async listener execution
-            while ack.response is None and time.time() - starting_time <= 3:
+            while ack.response is None and time.time() - starting_time <= listener.acknowledgement_timeout:
                 await asyncio.sleep(0.01)
 
             if response is None and ack.response is None:

--- a/slack_bolt/listener/custom_listener.py
+++ b/slack_bolt/listener/custom_listener.py
@@ -18,6 +18,7 @@ class CustomListener(Listener):
     matchers: Sequence[ListenerMatcher]
     middleware: Sequence[Middleware]
     auto_acknowledgement: bool
+    acknowledgement_timeout: int = 3
     arg_names: MutableSequence[str]
     logger: Logger
 
@@ -30,6 +31,7 @@ class CustomListener(Listener):
         matchers: Sequence[ListenerMatcher],
         middleware: Sequence[Middleware],
         auto_acknowledgement: bool = False,
+        acknowledgement_timeout: int = 3,
         base_logger: Optional[Logger] = None,
     ):
         self.app_name = app_name
@@ -38,6 +40,7 @@ class CustomListener(Listener):
         self.matchers = matchers
         self.middleware = middleware
         self.auto_acknowledgement = auto_acknowledgement
+        self.acknowledgement_timeout = acknowledgement_timeout
         self.arg_names = get_arg_names_of_callable(ack_function)
         self.logger = get_bolt_app_logger(app_name, self.ack_function, base_logger)
 

--- a/slack_bolt/listener/listener.py
+++ b/slack_bolt/listener/listener.py
@@ -13,6 +13,7 @@ class Listener(metaclass=ABCMeta):
     ack_function: Callable[..., BoltResponse]
     lazy_functions: Sequence[Callable[..., None]]
     auto_acknowledgement: bool
+    acknowledgement_timeout: int = 3
 
     def matches(
         self,

--- a/slack_bolt/listener/thread_runner.py
+++ b/slack_bolt/listener/thread_runner.py
@@ -160,7 +160,9 @@ class ThreadListenerRunner:
                     self._start_lazy_function(lazy_func, request)
 
             # await for the completion of ack() in the async listener execution
-            while ack.response is None and time.time() - starting_time <= 3:
+            print(str(starting_time))
+            while ack.response is None and time.time() - starting_time <= listener.acknowledgement_timeout:
+                print("we are sleeping")
                 time.sleep(0.01)
 
             if response is None and ack.response is None:

--- a/slack_bolt/listener/thread_runner.py
+++ b/slack_bolt/listener/thread_runner.py
@@ -160,9 +160,7 @@ class ThreadListenerRunner:
                     self._start_lazy_function(lazy_func, request)
 
             # await for the completion of ack() in the async listener execution
-            print(str(starting_time))
             while ack.response is None and time.time() - starting_time <= listener.acknowledgement_timeout:
-                print("we are sleeping")
                 time.sleep(0.01)
 
             if response is None and ack.response is None:

--- a/tests/scenario_tests/test_function.py
+++ b/tests/scenario_tests/test_function.py
@@ -1,6 +1,7 @@
 import json
 import time
 import pytest
+from unittest.mock import Mock
 
 from slack_sdk.signature import SignatureVerifier
 from slack_sdk.web import WebClient
@@ -50,6 +51,10 @@ class TestFunction:
     def build_request_from_body(self, message_body: dict) -> BoltRequest:
         timestamp, body = str(int(time.time())), json.dumps(message_body)
         return BoltRequest(body=body, headers=self.build_headers(timestamp, body))
+
+    def setup_time_mocks(self, *, monkeypatch: pytest.MonkeyPatch, time_mock: Mock, sleep_mock: Mock):
+        monkeypatch.setattr(time, "time", time_mock)
+        monkeypatch.setattr(time, "sleep", sleep_mock)
 
     def test_valid_callback_id_success(self):
         app = App(
@@ -124,7 +129,7 @@ class TestFunction:
         assert response.status == 200
         assert_auth_test_count(self, 1)
 
-    def test_auto_acknowledge_false_without_acknowledging(self, caplog):
+    def test_auto_acknowledge_false_without_acknowledging(self, caplog, monkeypatch):
         app = App(
             client=self.web_client,
             signing_secret=self.signing_secret,
@@ -132,11 +137,39 @@ class TestFunction:
         app.function("reverse", auto_acknowledge=False)(just_no_ack)
 
         request = self.build_request_from_body(function_body)
+        self.setup_time_mocks(
+            monkeypatch=monkeypatch,
+            time_mock=Mock(side_effect=[current_time for current_time in range(100)]),
+            sleep_mock=Mock(),
+        )
         response = app.dispatch(request)
 
         assert response.status == 404
         assert_auth_test_count(self, 1)
         assert f"WARNING {just_no_ack.__name__} didn't call ack()" in caplog.text
+
+    def test_function_handler_timeout(self, monkeypatch):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        app.function("reverse", auto_acknowledge=False)(just_no_ack)
+        request = self.build_request_from_body(function_body)
+
+        sleep_mock = Mock()
+        self.setup_time_mocks(
+            monkeypatch=monkeypatch,
+            time_mock=Mock(side_effect=[current_time for current_time in range(100)]),
+            sleep_mock=sleep_mock,
+        )
+
+        response = app.dispatch(request)
+
+        assert response.status == 404
+        assert_auth_test_count(self, 1)
+        assert (
+            sleep_mock.call_count == 5
+        ), f"Expected handler to time out after calling time.sleep 5 times, but it was called {sleep_mock.call_count} times"
 
 
 function_body = {

--- a/tests/scenario_tests_async/test_function.py
+++ b/tests/scenario_tests_async/test_function.py
@@ -17,8 +17,10 @@ from tests.mock_web_api_server import (
 )
 from tests.utils import remove_os_env_temporarily, restore_os_env
 
+
 async def fake_sleep(seconds):
     pass
+
 
 class TestAsyncFunction:
     signing_secret = "secret"
@@ -144,7 +146,7 @@ class TestAsyncFunction:
         )
         app.function("reverse", auto_acknowledge=False)(just_no_ack)
         request = self.build_request_from_body(function_body)
-        
+
         self.setup_time_mocks(
             monkeypatch=monkeypatch,
             time_mock=Mock(side_effect=[current_time for current_time in range(100)]),


### PR DESCRIPTION
## Summary

The `function_executed` event is the only event with a timeout longer then 3 seconds, this PR aims to allow bolt to timeout function handlers after 5 seconds rather then 3. This will allow developer to call `ack` up to 5 seconds after they receive the `function_executed` event.

### Testing

1. Built this branch locally with the `scripts/build_pypi_package.sh` command
2. Follow [these steps](https://docs.slack.dev/tools/bolt-python/concepts/custom-steps) to set up an app with a custom step
3. Import the local build to the project
4. Configure the function to maually handle the auto acknowledge behavior and and let the handler sleep for more then 3 seconds
```python
@app.function("sample_custom_step", auto_acknowledge=False)
def sample_step_callback(ack: Ack, inputs: dict, fail: Fail, complete: Complete):
    try:
        message = inputs["message"]
        time.sleep(4.5)
        complete(
            outputs={
                "message": f":wave: You submitted the following message: \n\n>{message}"
            }
        )
        ack()
    except Exception as e:
        fail(f"Failed to handle a custom step request (error: {e})")
        raise e
    finally:
        ack()
```



### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
