### PR TITLE
feat: accept assistant.threads.setStatus method arguments from the assistant class

### DIFF
--- a/docs/reference/async_app.html
+++ b/docs/reference/async_app.html
@@ -5248,11 +5248,18 @@ async def run_ack_function(self, *, request: AsyncBoltRequest, response: BoltRes
         self.channel_id = channel_id
         self.thread_ts = thread_ts
 
-    async def __call__(self, status: str) -&gt; AsyncSlackResponse:
+    async def __call__(
+        self,
+        status: str,
+        loading_messages: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
         return await self.client.assistant_threads_setStatus(
-            status=status,
             channel_id=self.channel_id,
             thread_ts=self.thread_ts,
+            status=status,
+            loading_messages=loading_messages,
+            **kwargs,
         )</code></pre>
 </details>
 <div class="desc"></div>

--- a/docs/reference/context/set_status/async_set_status.html
+++ b/docs/reference/context/set_status/async_set_status.html
@@ -70,11 +70,18 @@ el.replaceWith(d);
         self.channel_id = channel_id
         self.thread_ts = thread_ts
 
-    async def __call__(self, status: str) -&gt; AsyncSlackResponse:
+    async def __call__(
+        self,
+        status: str,
+        loading_messages: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
         return await self.client.assistant_threads_setStatus(
-            status=status,
             channel_id=self.channel_id,
             thread_ts=self.thread_ts,
+            status=status,
+            loading_messages=loading_messages,
+            **kwargs,
         )</code></pre>
 </details>
 <div class="desc"></div>

--- a/docs/reference/context/set_status/index.html
+++ b/docs/reference/context/set_status/index.html
@@ -81,11 +81,18 @@ el.replaceWith(d);
         self.channel_id = channel_id
         self.thread_ts = thread_ts
 
-    def __call__(self, status: str) -&gt; SlackResponse:
+    def __call__(
+        self,
+        status: str,
+        loading_messages: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
         return self.client.assistant_threads_setStatus(
-            status=status,
             channel_id=self.channel_id,
             thread_ts=self.thread_ts,
+            status=status,
+            loading_messages=loading_messages,
+            **kwargs,
         )</code></pre>
 </details>
 <div class="desc"></div>

--- a/docs/reference/context/set_status/set_status.html
+++ b/docs/reference/context/set_status/set_status.html
@@ -70,11 +70,18 @@ el.replaceWith(d);
         self.channel_id = channel_id
         self.thread_ts = thread_ts
 
-    def __call__(self, status: str) -&gt; SlackResponse:
+    def __call__(
+        self,
+        status: str,
+        loading_messages: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
         return self.client.assistant_threads_setStatus(
-            status=status,
             channel_id=self.channel_id,
             thread_ts=self.thread_ts,
+            status=status,
+            loading_messages=loading_messages,
+            **kwargs,
         )</code></pre>
 </details>
 <div class="desc"></div>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -5786,11 +5786,18 @@ def run_ack_function(self, *, request: BoltRequest, response: BoltResponse) -&gt
         self.channel_id = channel_id
         self.thread_ts = thread_ts
 
-    def __call__(self, status: str) -&gt; SlackResponse:
+    def __call__(
+        self,
+        status: str,
+        loading_messages: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
         return self.client.assistant_threads_setStatus(
-            status=status,
             channel_id=self.channel_id,
             thread_ts=self.thread_ts,
+            status=status,
+            loading_messages=loading_messages,
+            **kwargs,
         )</code></pre>
 </details>
 <div class="desc"></div>

--- a/slack_bolt/context/set_status/async_set_status.py
+++ b/slack_bolt/context/set_status/async_set_status.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.web.async_slack_response import AsyncSlackResponse
 
@@ -17,9 +19,16 @@ class AsyncSetStatus:
         self.channel_id = channel_id
         self.thread_ts = thread_ts
 
-    async def __call__(self, status: str) -> AsyncSlackResponse:
+    async def __call__(
+        self,
+        status: str,
+        loading_messages: Optional[List[str]] = None,
+        **kwargs,
+    ) -> AsyncSlackResponse:
         return await self.client.assistant_threads_setStatus(
-            status=status,
             channel_id=self.channel_id,
             thread_ts=self.thread_ts,
+            status=status,
+            loading_messages=loading_messages,
+            **kwargs,
         )

--- a/slack_bolt/context/set_status/set_status.py
+++ b/slack_bolt/context/set_status/set_status.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from slack_sdk import WebClient
 from slack_sdk.web import SlackResponse
 
@@ -17,9 +19,16 @@ class SetStatus:
         self.channel_id = channel_id
         self.thread_ts = thread_ts
 
-    def __call__(self, status: str) -> SlackResponse:
+    def __call__(
+        self,
+        status: str,
+        loading_messages: Optional[List[str]] = None,
+        **kwargs,
+    ) -> SlackResponse:
         return self.client.assistant_threads_setStatus(
-            status=status,
             channel_id=self.channel_id,
             thread_ts=self.thread_ts,
+            status=status,
+            loading_messages=loading_messages,
+            **kwargs,
         )

--- a/tests/slack_bolt/context/test_set_status.py
+++ b/tests/slack_bolt/context/test_set_status.py
@@ -1,0 +1,38 @@
+import pytest
+from slack_sdk import WebClient
+from slack_sdk.web import SlackResponse
+
+from slack_bolt.context.set_status import SetStatus
+from tests.mock_web_api_server import cleanup_mock_web_api_server, setup_mock_web_api_server
+
+
+class TestSetStatus:
+    def setup_method(self):
+        setup_mock_web_api_server(self)
+        valid_token = "xoxb-valid"
+        mock_api_server_base_url = "http://localhost:8888"
+        self.web_client = WebClient(token=valid_token, base_url=mock_api_server_base_url)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+
+    def test_set_status(self):
+        set_status = SetStatus(client=self.web_client, channel_id="C111", thread_ts="123.123")
+        response: SlackResponse = set_status("Thinking...")
+        assert response.status_code == 200
+
+    def test_set_status_loading_messages(self):
+        set_status = SetStatus(client=self.web_client, channel_id="C111", thread_ts="123.123")
+        response: SlackResponse = set_status(
+            status="Thinking...",
+            loading_messages=[
+                "Sitting...",
+                "Waiting...",
+            ],
+        )
+        assert response.status_code == 200
+
+    def test_set_status_invalid(self):
+        set_status = SetStatus(client=self.web_client, channel_id="C111", thread_ts="123.123")
+        with pytest.raises(TypeError):
+            set_status()

--- a/tests/slack_bolt_async/context/test_async_set_status.py
+++ b/tests/slack_bolt_async/context/test_async_set_status.py
@@ -1,0 +1,45 @@
+import pytest
+from slack_sdk.web.async_client import AsyncWebClient
+from slack_sdk.web.async_slack_response import AsyncSlackResponse
+
+from slack_bolt.context.set_status.async_set_status import AsyncSetStatus
+from tests.mock_web_api_server import cleanup_mock_web_api_server_async, setup_mock_web_api_server_async
+from tests.utils import get_event_loop
+
+
+class TestAsyncSetStatus:
+    @pytest.fixture
+    def event_loop(self):
+        setup_mock_web_api_server_async(self)
+        valid_token = "xoxb-valid"
+        mock_api_server_base_url = "http://localhost:8888"
+        self.web_client = AsyncWebClient(token=valid_token, base_url=mock_api_server_base_url)
+
+        loop = get_event_loop()
+        yield loop
+        loop.close()
+        cleanup_mock_web_api_server_async(self)
+
+    @pytest.mark.asyncio
+    async def test_set_status(self):
+        set_status = AsyncSetStatus(client=self.web_client, channel_id="C111", thread_ts="123.123")
+        response: AsyncSlackResponse = await set_status("Thinking...")
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_set_status_loading_messages(self):
+        set_status = AsyncSetStatus(client=self.web_client, channel_id="C111", thread_ts="123.123")
+        response: AsyncSlackResponse = await set_status(
+            status="Thinking...",
+            loading_messages=[
+                "Sitting...",
+                "Waiting...",
+            ],
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_set_status_invalid(self):
+        set_status = AsyncSetStatus(client=self.web_client, channel_id="C111", thread_ts="123.123")
+        with pytest.raises(TypeError):
+            await set_status()


### PR DESCRIPTION
## Summary

This PR accepts `assistant.thread.setStatus` method arguments from the `Assistant` class to support additional arguments.

### Preview

The following is now supported when using the [`Assistant`](https://docs.slack.dev/tools/bolt-python/concepts/ai-apps) class:

```python
@assistant.user_message
def respond_in_assistant_thread(
    client: WebClient,
    context: BoltContext,
    logger: logging.Logger,
    payload: dict,
    say: Say,
    set_status: SetStatus,
):
    loading_messages = [
        "Teaching the hamsters to type faster…",
        "Untangling the internet cables…",
        "Consulting the office goldfish…",
        "Polishing up the response just for you…",
        "Convincing the AI to stop overthinking…",
    ]

    set_status(
        status="Bolt is typing",
        loading_messages=loading_messages,
    )
```

### Testing

Use the changes of this PR and this sample app: https://github.com/slack-samples/bolt-python-assistant-template/pull/12 🏁

- Planning to follow up soon with unit tests!

### Notes

Hoping to align a similar implementation for `bolt-js` too: https://github.com/slackapi/bolt-js/pull/2660 👾 

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
