### PR TITLE
build: require cheroot<11 with adapter test dependencies

### DIFF
--- a/requirements/adapter.txt
+++ b/requirements/adapter.txt
@@ -4,6 +4,7 @@
 boto3<=2
 bottle>=0.12,<1
 chalice>=1.28,<2;
+cheroot<11                              # https://github.com/slackapi/bolt-python/issues/1374
 CherryPy>=18,<19
 Django>=3,<6
 falcon>=2,<5; python_version<"3.11"


### PR DESCRIPTION
## Summary

This PR has a workaround for #1374 to use `cheroot<11` in adapter tests.

### Testing

Works on my machine and I hope CI now too. Huge kind thanks to @WilliamBergamin for helping me fix my test running setups! 🙏 ✨ 

### Notes

I don't believe we should close the linked issue with this, but was wanting to unblock CI for ongoing finding! 🔍 

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] Adapters in `slack_bolt.adapter`

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
