### PR TITLE
ci: post regression notifications if scheduled tests do not succeed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
     name: Regression notifications
     runs-on: ubuntu-latest
     needs: build
-    if: failure() && github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch'
+    if: ${{ !success() && github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch' }}
     steps:
       - name: Send notifications of failing tests
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1


### PR DESCRIPTION
## Summary

This PR follows #1374 and #1375 to send regression notifications if scheduled tests do not succeed instead of just during failures. Fixes an issue where test timeout did not post a message.

### Testing

📺 Planning to add a few commits that confirm `!success` is the correct operation for both "cancelled" and "failure" states. Since these steps run when scheduled on "main" outside of this PR, these are both events we want to capture I believe.

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
