### PR TITLE
build: install dependencies needed to autogenerate reference docs

### DIFF
--- a/scripts/generate_api_docs.sh
+++ b/scripts/generate_api_docs.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 # Generate API documents from the latest source code
 
-script_dir=`dirname $0`
-cd ${script_dir}/..
+set -e
+script_dir=$(dirname "$0")
+cd "${script_dir}/.."
 
+pip install -U pip
+pip install -U -r requirements/adapter.txt
+pip install -U -r requirements/async.txt
 pip install -U pdoc3
+pip install .
 rm -rf docs/reference
 
 pdoc slack_bolt --html -o docs/reference


### PR DESCRIPTION
## Summary

This PR adds `pip` installations to the "generate_api_docs.sh" script to make sure all required dependencies are installed in a virtual environment when generating reference - in particular the adapter and async reference!

### Testing

Use a new virtual environment to generate the docs:

```sh
$ python -m venv .venv
$ source .venv/bin/activate
$ ./scripts/generate_api_docs.sh  # Regenerate the docs!
$ ./scripts/uninstall_all.sh
$ ./scripts/generate_api_docs.sh  # Error without dependencies
```

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] Document pages under `/docs`
* [x] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
