### PR TITLE
fix(types): accept a sequence of suggested prompts in assistant context

### DIFF
--- a/slack_bolt/context/set_suggested_prompts/async_set_suggested_prompts.py
+++ b/slack_bolt/context/set_suggested_prompts/async_set_suggested_prompts.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Union, Optional
+from typing import Dict, List, Optional, Sequence, Union
 
 from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.web.async_slack_response import AsyncSlackResponse
@@ -21,7 +21,7 @@ class AsyncSetSuggestedPrompts:
 
     async def __call__(
         self,
-        prompts: List[Union[str, Dict[str, str]]],
+        prompts: Sequence[Union[str, Dict[str, str]]],
         title: Optional[str] = None,
     ) -> AsyncSlackResponse:
         prompts_arg: List[Dict[str, str]] = []

--- a/slack_bolt/context/set_suggested_prompts/set_suggested_prompts.py
+++ b/slack_bolt/context/set_suggested_prompts/set_suggested_prompts.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Union, Optional
+from typing import Dict, List, Optional, Sequence, Union
 
 from slack_sdk import WebClient
 from slack_sdk.web import SlackResponse
@@ -21,7 +21,7 @@ class SetSuggestedPrompts:
 
     def __call__(
         self,
-        prompts: List[Union[str, Dict[str, str]]],
+        prompts: Sequence[Union[str, Dict[str, str]]],
         title: Optional[str] = None,
     ) -> SlackResponse:
         prompts_arg: List[Dict[str, str]] = []

--- a/tests/slack_bolt/context/test_set_suggested_prompts.py
+++ b/tests/slack_bolt/context/test_set_suggested_prompts.py
@@ -1,0 +1,37 @@
+import pytest
+from slack_sdk import WebClient
+from slack_sdk.web import SlackResponse
+
+from slack_bolt.context.set_suggested_prompts import SetSuggestedPrompts
+from tests.mock_web_api_server import cleanup_mock_web_api_server, setup_mock_web_api_server
+
+
+class TestSetSuggestedPrompts:
+    def setup_method(self):
+        setup_mock_web_api_server(self)
+        valid_token = "xoxb-valid"
+        mock_api_server_base_url = "http://localhost:8888"
+        self.web_client = WebClient(token=valid_token, base_url=mock_api_server_base_url)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+
+    def test_set_suggested_prompts(self):
+        set_suggested_prompts = SetSuggestedPrompts(client=self.web_client, channel_id="C111", thread_ts="123.123")
+        response: SlackResponse = set_suggested_prompts(prompts=["One", "Two"])
+        assert response.status_code == 200
+
+    def test_set_suggested_prompts_objects(self):
+        set_suggested_prompts = SetSuggestedPrompts(client=self.web_client, channel_id="C111", thread_ts="123.123")
+        response: SlackResponse = set_suggested_prompts(
+            prompts=[
+                "One",
+                {"title": "Two", "message": "What's before addition?"},
+            ],
+        )
+        assert response.status_code == 200
+
+    def test_set_suggested_prompts_invalid(self):
+        set_suggested_prompts = SetSuggestedPrompts(client=self.web_client, channel_id="C111", thread_ts="123.123")
+        with pytest.raises(TypeError):
+            set_suggested_prompts()

--- a/tests/slack_bolt_async/context/test_async_set_suggested_prompts.py
+++ b/tests/slack_bolt_async/context/test_async_set_suggested_prompts.py
@@ -1,0 +1,45 @@
+import asyncio
+
+import pytest
+from slack_sdk.web.async_client import AsyncWebClient
+from slack_sdk.web.async_slack_response import AsyncSlackResponse
+
+from slack_bolt.context.set_suggested_prompts.async_set_suggested_prompts import AsyncSetSuggestedPrompts
+from tests.mock_web_api_server import cleanup_mock_web_api_server, setup_mock_web_api_server
+
+
+class TestAsyncSetSuggestedPrompts:
+    @pytest.fixture
+    def event_loop(self):
+        setup_mock_web_api_server(self)
+        valid_token = "xoxb-valid"
+        mock_api_server_base_url = "http://localhost:8888"
+        self.web_client = AsyncWebClient(token=valid_token, base_url=mock_api_server_base_url)
+
+        loop = asyncio.get_event_loop()
+        yield loop
+        loop.close()
+        cleanup_mock_web_api_server(self)
+
+    @pytest.mark.asyncio
+    async def test_set_suggested_prompts(self):
+        set_suggested_prompts = AsyncSetSuggestedPrompts(client=self.web_client, channel_id="C111", thread_ts="123.123")
+        response: AsyncSlackResponse = await set_suggested_prompts(prompts=["One", "Two"])
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_set_suggested_prompts_objects(self):
+        set_suggested_prompts = AsyncSetSuggestedPrompts(client=self.web_client, channel_id="C111", thread_ts="123.123")
+        response: AsyncSlackResponse = await set_suggested_prompts(
+            prompts=[
+                "One",
+                {"title": "Two", "message": "What's before addition?"},
+            ],
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_set_suggested_prompts_invalid(self):
+        set_suggested_prompts = AsyncSetSuggestedPrompts(client=self.web_client, channel_id="C111", thread_ts="123.123")
+        with pytest.raises(TypeError):
+            await set_suggested_prompts()


### PR DESCRIPTION
## Summary

This PR accepts a **sequence** of suggested prompts in the `assistant` context. Fixes an issue where **mypy** complained about invalid types:

```
listeners/assistant/assistant.py:50: error: Argument "prompts" to "__call__" of "SetSuggestedPrompts" has incompatible type "list[dict[str, str]]"; expected "list[str | dict[str, str]]"  [arg-type]
listeners/assistant/assistant.py:50: note: "list" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
listeners/assistant/assistant.py:50: note: Consider using "Sequence" instead, which is covariant
```

https://github.com/slack-samples/bolt-python-assistant-template/blob/ec9fb79117fb52bf3ccf0238d242af11ee50807f/listeners/assistant/assistant.py#L51

### Testing

This error should vanish when using this build without changing app functionalities!

```
$ mypy --python-executable=.venv/bin/python app.py
```

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
