### PR TITLE
docs: replace links from api.slack.com to docs.slack.dev redirects

### DIFF
--- a/.github/ISSUE_TEMPLATE/03_document.md
+++ b/.github/ISSUE_TEMPLATE/03_document.md
@@ -10,7 +10,7 @@ assignees: ''
 
 ### The page URLs
 
-* https://slack.dev/bolt-python/
+* https://docs.slack.dev/tools/bolt-python/
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ ngrok http 3000
 
 ## Running a Socket Mode app
 
-If you use [Socket Mode](https://api.slack.com/socket-mode) for running your app, `SocketModeHandler` is available for it.
+If you use [Socket Mode](https://docs.slack.dev/apis/events-api/using-socket-mode/) for running your app, `SocketModeHandler` is available for it.
 
 ```python
 import os
@@ -91,7 +91,7 @@ python app.py
 
 ## Listening for events
 
-Apps typically react to a collection of incoming events, which can correspond to [Events API events](https://api.slack.com/events-api), [actions](https://api.slack.com/interactivity/components), [shortcuts](https://api.slack.com/interactivity/shortcuts), [slash commands](https://api.slack.com/interactivity/slash-commands) or [options requests](https://api.slack.com/reference/block-kit/block-elements#external_select). For each type of
+Apps typically react to a collection of incoming events, which can correspond to [Events API events](https://docs.slack.dev/apis/events-api/), [actions](https://docs.slack.dev/block-kit/#making-things-interactive), [shortcuts](https://docs.slack.dev/interactivity/implementing-shortcuts/), [slash commands](https://docs.slack.dev/interactivity/implementing-slash-commands/) or [options requests](https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select). For each type of
 request, there's a method to build a listener function.
 
 ```python
@@ -138,12 +138,12 @@ Most of the app's functionality will be inside listener functions (the `fn` para
 | Argument  | Description  |
 | :---: | :--- |
 | `body` | Dictionary that contains the entire body of the request (superset of `payload`). Some accessory data is only available outside of the payload (such as `trigger_id` and `authorizations`).
-| `payload` | Contents of the incoming event. The payload structure depends on the listener. For example, for an Events API event, `payload` will be the [event type structure](https://api.slack.com/events-api#event_type_structure). For a block action, it will be the action from within the `actions` list. The `payload` dictionary is also accessible via the alias corresponding to the listener (`message`, `event`, `action`, `shortcut`, `view`, `command`, or `options`). For example, if you were building a `message()` listener, you could use the `payload` and `message` arguments interchangably. **An easy way to understand what's in a payload is to log it**. |
+| `payload` | Contents of the incoming event. The payload structure depends on the listener. For example, for an Events API event, `payload` will be the [event type structure](https://docs.slack.dev/apis/events-api/#event-type-structure). For a block action, it will be the action from within the `actions` list. The `payload` dictionary is also accessible via the alias corresponding to the listener (`message`, `event`, `action`, `shortcut`, `view`, `command`, or `options`). For example, if you were building a `message()` listener, you could use the `payload` and `message` arguments interchangably. **An easy way to understand what's in a payload is to log it**. |
 | `context` | Event context. This dictionary contains data about the event and app, such as the `botId`. Middleware can add additional context before the event is passed to listeners.
-| `ack` | Function that **must** be called to acknowledge that your app received the incoming event. `ack` exists for all actions, shortcuts, view submissions, slash command and options requests. `ack` returns a promise that resolves when complete. Read more in [Acknowledging events](https://tools.slack.dev/bolt-python/concepts/acknowledge).
+| `ack` | Function that **must** be called to acknowledge that your app received the incoming event. `ack` exists for all actions, shortcuts, view submissions, slash command and options requests. `ack` returns a promise that resolves when complete. Read more in [Acknowledging events](https://docs.slack.dev/tools/bolt-python/concepts/acknowledge/).
 | `respond` | Utility function that responds to incoming events **if** it contains a `response_url` (shortcuts, actions, and slash commands).
 | `say` | Utility function to send a message to the channel associated with the incoming event. This argument is only available when the listener is triggered for events that contain a `channel_id` (the most common being `message` events). `say` accepts simple strings (for plain-text messages) and dictionaries (for messages containing blocks).
-| `client` | Web API client that uses the token associated with the event. For single-workspace installations, the token is provided to the constructor. For multi-workspace installations, the token is returned by using [the OAuth library](https://tools.slack.dev/bolt-python/concepts/authenticating-oauth), or manually using the `authorize` function.
+| `client` | Web API client that uses the token associated with the event. For single-workspace installations, the token is provided to the constructor. For multi-workspace installations, the token is returned by using [the OAuth library](https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth/), or manually using the `authorize` function.
 | `logger` | The built-in [`logging.Logger`](https://docs.python.org/3/library/logging.html) instance you can use in middleware/listeners.
 | `complete` | Utility function used to signal the successful completion of a custom step execution. This tells Slack to proceed with the next steps in the workflow. This argument is only available with the `.function` and `.action` listener when handling custom workflow step executions.
 | `fail` | Utility function used to signal that a custom step failed to complete. This tells Slack to stop the workflow execution. This argument is only available with the `.function` and `.action` listener when handling custom workflow step executions.
@@ -192,7 +192,7 @@ Apps can be run the same way as the syncronous example above. If you'd prefer an
 
 ## Getting Help
 
-[The documentation](https://tools.slack.dev/bolt-python) has more information on basic and advanced concepts for Bolt for Python. Also, all the Python module documents of this library are available [here](https://tools.slack.dev/bolt-python/reference/).
+[The documentation](https://docs.slack.dev/tools/bolt-python/) has more information on basic and advanced concepts for Bolt for Python. Also, all the Python module documents of this library are available [here](https://docs.slack.dev/tools/bolt-python/reference/).
 
 If you otherwise get stuck, we're here to help. The following are the best ways to get assistance working through your issue:
 

--- a/docs/english/tutorial/custom-steps-workflow-builder-existing/custom-steps-workflow-builder-existing.md
+++ b/docs/english/tutorial/custom-steps-workflow-builder-existing/custom-steps-workflow-builder-existing.md
@@ -9,7 +9,7 @@ If you followed along with our [create a custom step for Workflow Builder: new a
 In this tutorial we will:
 - Start with an existing Bolt app
 - Add a custom **workflow step** in the [app settings](https://api.slack.com/apps)
-- Wire up the new step to a **function listener** in our project, using the [Bolt for Python](https://slack.dev/bolt-python/) framework
+- Wire up the new step to a **function listener** in our project, using the [Bolt for Python](https://docs.slack.dev/tools/bolt-python/) framework
 - See the step as a custom workflow step in Workflow Builder
 
 ## Prerequisites {#prereqs}

--- a/docs/reference/app/app.html
+++ b/docs/reference/app/app.html
@@ -117,10 +117,10 @@ el.replaceWith(d);
             if __name__ == &#34;__main__&#34;:
                 app.start(port=int(os.environ.get(&#34;PORT&#34;, 3000)))
 
-        Refer to https://slack.dev/bolt-python/tutorial/getting-started for details.
+        Refer to https://docs.slack.dev/tools/bolt-python/building-an-app for details.
 
         If you would like to build an OAuth app for enabling the app to run with multiple workspaces,
-        refer to https://slack.dev/bolt-python/concepts#authenticating-oauth to learn how to configure the app.
+        refer to https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth to learn how to configure the app.
 
         Args:
             logger: The custom logger that can be used in this app.
@@ -629,7 +629,7 @@ el.replaceWith(d);
             # Pass a function to this method
             app.middleware(middleware_func)
 
-        Refer to https://slack.dev/bolt-python/concepts#global-middleware for details.
+        Refer to https://docs.slack.dev/tools/bolt-python/concepts/global-middleware for details.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -675,7 +675,7 @@ el.replaceWith(d);
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new step from app listener.
 
@@ -693,7 +693,7 @@ el.replaceWith(d);
             # Pass Step to set up listeners
             app.step(ws)
 
-        Refer to https://api.slack.com/workflows/steps for details of steps from apps.
+        Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details of steps from apps.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -710,7 +710,7 @@ el.replaceWith(d);
         warnings.warn(
             (
                 &#34;Steps from apps for legacy workflows are now deprecated. &#34;
-                &#34;Use new custom steps: https://api.slack.com/automation/functions/custom-bolt&#34;
+                &#34;Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/&#34;
             ),
             category=DeprecationWarning,
         )
@@ -787,7 +787,7 @@ el.replaceWith(d);
             # Pass a function to this method
             app.event(&#34;team_join&#34;)(ask_for_introduction)
 
-        Refer to https://api.slack.com/apis/connections/events-api for details of Events API.
+        Refer to https://docs.slack.dev/apis/events-api/ for details of Events API.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -825,7 +825,7 @@ el.replaceWith(d);
             # Pass a function to this method
             app.message(&#34;:wave:&#34;)(say_hello)
 
-        Refer to https://api.slack.com/events/message for details of `message` events.
+        Refer to https://docs.slack.dev/reference/events/message/ for details of `message` events.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -936,7 +936,7 @@ el.replaceWith(d);
             # Pass a function to this method
             app.command(&#34;/echo&#34;)(repeat_text)
 
-        Refer to https://api.slack.com/interactivity/slash-commands for details of Slash Commands.
+        Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details of Slash Commands.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -983,7 +983,7 @@ el.replaceWith(d);
             # Pass a function to this method
             app.shortcut(&#34;open_modal&#34;)(open_modal)
 
-        Refer to https://api.slack.com/interactivity/shortcuts for details about Shortcuts.
+        Refer to https://docs.slack.dev/interactivity/implementing-shortcuts/ for details about Shortcuts.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1051,9 +1051,9 @@ el.replaceWith(d);
             # Pass a function to this method
             app.action(&#34;approve_button&#34;)(update_message)
 
-        * Refer to https://api.slack.com/reference/interaction-payloads/block-actions for actions in `blocks`.
-        * Refer to https://api.slack.com/legacy/message-buttons for actions in `attachments`.
-        * Refer to https://api.slack.com/dialogs for actions in dialogs.
+        * Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for actions in `blocks`.
+        * Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for actions in `attachments`.
+        * Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for actions in dialogs.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1079,7 +1079,7 @@ el.replaceWith(d);
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `block_actions` action listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/block-actions for details.
+        Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for details.
         &#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
@@ -1096,7 +1096,7 @@ el.replaceWith(d);
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `interactive_message` action listener.
-        Refer to https://api.slack.com/legacy/message-buttons for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1112,7 +1112,7 @@ el.replaceWith(d);
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `dialog_submission` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1128,7 +1128,7 @@ el.replaceWith(d);
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `dialog_cancellation` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1169,7 +1169,7 @@ el.replaceWith(d);
             # Pass a function to this method
             app.view(&#34;view_1&#34;)(handle_submission)
 
-        Refer to https://api.slack.com/reference/interaction-payloads/views for details of payloads.
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload for details of payloads.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1195,7 +1195,7 @@ el.replaceWith(d);
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `view_submission` listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/views#view_submission for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1211,7 +1211,7 @@ el.replaceWith(d);
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `view_closed` listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/views#view_closed for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1252,8 +1252,8 @@ el.replaceWith(d);
 
         Refer to the following documents for details:
 
-        * https://api.slack.com/reference/block-kit/block-elements#external_select
-        * https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+        * https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
+        * https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1293,7 +1293,7 @@ el.replaceWith(d);
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `dialog_suggestion` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1443,9 +1443,9 @@ def message_hello(message, say):
 if __name__ == "__main__":
     app.start(port=int(os.environ.get("PORT", 3000)))
 </code></pre>
-<p>Refer to <a href="https://slack.dev/bolt-python/tutorial/getting-started">https://slack.dev/bolt-python/tutorial/getting-started</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/bolt-python/building-an-app">https://docs.slack.dev/tools/bolt-python/building-an-app</a> for details.</p>
 <p>If you would like to build an OAuth app for enabling the app to run with multiple workspaces,
-refer to <a href="https://slack.dev/bolt-python/concepts#authenticating-oauth">https://slack.dev/bolt-python/concepts#authenticating-oauth</a> to learn how to configure the app.</p>
+refer to <a href="https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth">https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth</a> to learn how to configure the app.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>logger</code></strong></dt>
@@ -1637,9 +1637,9 @@ def process_before_response(self) -&gt; bool:
         # Pass a function to this method
         app.action(&#34;approve_button&#34;)(update_message)
 
-    * Refer to https://api.slack.com/reference/interaction-payloads/block-actions for actions in `blocks`.
-    * Refer to https://api.slack.com/legacy/message-buttons for actions in `attachments`.
-    * Refer to https://api.slack.com/dialogs for actions in dialogs.
+    * Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for actions in `blocks`.
+    * Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for actions in `attachments`.
+    * Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for actions in dialogs.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1668,9 +1668,9 @@ def update_message(ack):
 app.action("approve_button")(update_message)
 </code></pre>
 <ul>
-<li>Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-actions">https://api.slack.com/reference/interaction-payloads/block-actions</a> for actions in <code>blocks</code>.</li>
-<li>Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slack.com/legacy/message-buttons</a> for actions in <code>attachments</code>.</li>
-<li>Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for actions in dialogs.</li>
+<li>Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/">https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/</a> for actions in <code>blocks</code>.</li>
+<li>Refer to <a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/">https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/</a> for actions in <code>attachments</code>.</li>
+<li>Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for actions in dialogs.</li>
 </ul>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
@@ -1713,7 +1713,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `interactive_message` action listener.
-    Refer to https://api.slack.com/legacy/message-buttons for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1723,7 +1723,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>interactive_message</code> action listener.
-Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slack.com/legacy/message-buttons</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/">https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.app.App.block_action"><code class="name flex">
 <span>def <span class="ident">block_action</span></span>(<span>self,<br>constraints: str | Pattern | Dict[str, str | Pattern],<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="../middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -1740,7 +1740,7 @@ Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slac
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `block_actions` action listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/block-actions for details.
+    Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for details.
     &#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
@@ -1751,7 +1751,7 @@ Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slac
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>block_actions</code> action listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-actions">https://api.slack.com/reference/interaction-payloads/block-actions</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/">https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.app.App.block_suggestion"><code class="name flex">
 <span>def <span class="ident">block_suggestion</span></span>(<span>self,<br>action_id: str | Pattern,<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="../middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -1805,7 +1805,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-act
         # Pass a function to this method
         app.command(&#34;/echo&#34;)(repeat_text)
 
-    Refer to https://api.slack.com/interactivity/slash-commands for details of Slash Commands.
+    Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details of Slash Commands.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1836,7 +1836,7 @@ def repeat_text(ack, say, command):
 # Pass a function to this method
 app.command("/echo")(repeat_text)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/interactivity/slash-commands">https://api.slack.com/interactivity/slash-commands</a> for details of Slash Commands.</p>
+<p>Refer to <a href="https://docs.slack.dev/interactivity/implementing-slash-commands/">https://docs.slack.dev/interactivity/implementing-slash-commands/</a> for details of Slash Commands.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -1899,7 +1899,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `dialog_cancellation` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1909,7 +1909,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_cancellation</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.app.App.dialog_submission"><code class="name flex">
 <span>def <span class="ident">dialog_submission</span></span>(<span>self,<br>callback_id: str | Pattern,<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="../middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -1926,7 +1926,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `dialog_submission` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1936,7 +1936,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_submission</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.app.App.dialog_suggestion"><code class="name flex">
 <span>def <span class="ident">dialog_suggestion</span></span>(<span>self,<br>callback_id: str | Pattern,<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="../middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -1953,7 +1953,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `dialog_suggestion` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1963,7 +1963,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_suggestion</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.app.App.dispatch"><code class="name flex">
 <span>def <span class="ident">dispatch</span></span>(<span>self,<br>req: <a title="slack_bolt.request.request.BoltRequest" href="../request/request.html#slack_bolt.request.request.BoltRequest">BoltRequest</a>) ‑> <a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a></span>
@@ -2189,7 +2189,7 @@ when getting an unhandled error in Bolt app.</dd>
         # Pass a function to this method
         app.event(&#34;team_join&#34;)(ask_for_introduction)
 
-    Refer to https://api.slack.com/apis/connections/events-api for details of Events API.
+    Refer to https://docs.slack.dev/apis/events-api/ for details of Events API.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2221,7 +2221,7 @@ def ask_for_introduction(event, say):
 # Pass a function to this method
 app.event("team_join")(ask_for_introduction)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/apis/connections/events-api">https://api.slack.com/apis/connections/events-api</a> for details of Events API.</p>
+<p>Refer to <a href="https://docs.slack.dev/apis/events-api/">https://docs.slack.dev/apis/events-api/</a> for details of Events API.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2373,7 +2373,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
         # Pass a function to this method
         app.message(&#34;:wave:&#34;)(say_hello)
 
-    Refer to https://api.slack.com/events/message for details of `message` events.
+    Refer to https://docs.slack.dev/reference/events/message/ for details of `message` events.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2424,7 +2424,7 @@ def say_hello(message, say):
 # Pass a function to this method
 app.message(":wave:")(say_hello)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/events/message">https://api.slack.com/events/message</a> for details of <code>message</code> events.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/events/message/">https://docs.slack.dev/reference/events/message/</a> for details of <code>message</code> events.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2484,7 +2484,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
         # Pass a function to this method
         app.middleware(middleware_func)
 
-    Refer to https://slack.dev/bolt-python/concepts#global-middleware for details.
+    Refer to https://docs.slack.dev/tools/bolt-python/concepts/global-middleware for details.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2522,7 +2522,7 @@ def middleware_func(logger, body, next):
 # Pass a function to this method
 app.middleware(middleware_func)
 </code></pre>
-<p>Refer to <a href="https://slack.dev/bolt-python/concepts#global-middleware">https://slack.dev/bolt-python/concepts#global-middleware</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/bolt-python/concepts/global-middleware">https://docs.slack.dev/tools/bolt-python/concepts/global-middleware</a> for details.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2567,8 +2567,8 @@ app.middleware(middleware_func)
 
     Refer to the following documents for details:
 
-    * https://api.slack.com/reference/block-kit/block-elements#external_select
-    * https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+    * https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
+    * https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2608,8 +2608,8 @@ app.options("menu_selection")(show_menu_options)
 </code></pre>
 <p>Refer to the following documents for details:</p>
 <ul>
-<li><a href="https://api.slack.com/reference/block-kit/block-elements#external_select">https://api.slack.com/reference/block-kit/block-elements#external_select</a></li>
-<li><a href="https://api.slack.com/reference/block-kit/block-elements#external_multi_select">https://api.slack.com/reference/block-kit/block-elements#external_multi_select</a></li>
+<li><a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select</a></li>
+<li><a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select</a></li>
 </ul>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
@@ -2655,7 +2655,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
         # Pass a function to this method
         app.shortcut(&#34;open_modal&#34;)(open_modal)
 
-    Refer to https://api.slack.com/interactivity/shortcuts for details about Shortcuts.
+    Refer to https://docs.slack.dev/interactivity/implementing-shortcuts/ for details about Shortcuts.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2692,7 +2692,7 @@ def open_modal(ack, body, client):
 # Pass a function to this method
 app.shortcut("open_modal")(open_modal)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/interactivity/shortcuts">https://api.slack.com/interactivity/shortcuts</a> for details about Shortcuts.</p>
+<p>Refer to <a href="https://docs.slack.dev/interactivity/implementing-shortcuts/">https://docs.slack.dev/interactivity/implementing-shortcuts/</a> for details about Shortcuts.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2778,7 +2778,7 @@ For production, consider using a production-ready WSGI server such as Gunicorn.<
     &#34;&#34;&#34;
     Deprecated:
         Steps from apps for legacy workflows are now deprecated.
-        Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
     Registers a new step from app listener.
 
@@ -2796,7 +2796,7 @@ For production, consider using a production-ready WSGI server such as Gunicorn.<
         # Pass Step to set up listeners
         app.step(ws)
 
-    Refer to https://api.slack.com/workflows/steps for details of steps from apps.
+    Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details of steps from apps.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2813,7 +2813,7 @@ For production, consider using a production-ready WSGI server such as Gunicorn.<
     warnings.warn(
         (
             &#34;Steps from apps for legacy workflows are now deprecated. &#34;
-            &#34;Use new custom steps: https://api.slack.com/automation/functions/custom-bolt&#34;
+            &#34;Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/&#34;
         ),
         category=DeprecationWarning,
     )
@@ -2835,7 +2835,7 @@ For production, consider using a production-ready WSGI server such as Gunicorn.<
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>Registers a new step from app listener.</p>
 <p>Unlike others, this method doesn't behave as a decorator.
 If you want to register a step from app by a decorator, use <code>WorkflowStepBuilder</code>'s methods.</p>
@@ -2850,7 +2850,7 @@ ws = WorkflowStep(
 # Pass Step to set up listeners
 app.step(ws)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/workflows/steps">https://api.slack.com/workflows/steps</a> for details of steps from apps.</p>
+<p>Refer to <a href="https://docs.slack.dev/legacy/legacy-steps-from-apps/">https://docs.slack.dev/legacy/legacy-steps-from-apps/</a> for details of steps from apps.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <p>For further information about WorkflowStep specific function arguments
 such as <code>configure</code>, <code>update</code>, <code>complete</code>, and <code>fail</code>,
@@ -2921,7 +2921,7 @@ refer to <code><a title="slack_bolt.workflows.step.utilities" href="../workflows
         # Pass a function to this method
         app.view(&#34;view_1&#34;)(handle_submission)
 
-    Refer to https://api.slack.com/reference/interaction-payloads/views for details of payloads.
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload for details of payloads.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2962,7 +2962,7 @@ def handle_submission(ack, body, client, view):
 # Pass a function to this method
 app.view("view_1")(handle_submission)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/reference/interaction-payloads/views">https://api.slack.com/reference/interaction-payloads/views</a> for details of payloads.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload</a> for details of payloads.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2991,7 +2991,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `view_closed` listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/views#view_closed for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -3001,7 +3001,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>view_closed</code> listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#view_closed">https://api.slack.com/reference/interaction-payloads/views#view_closed</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.app.App.view_submission"><code class="name flex">
 <span>def <span class="ident">view_submission</span></span>(<span>self,<br>constraints: str | Pattern,<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="../middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -3018,7 +3018,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#vie
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `view_submission` listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/views#view_submission for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -3028,7 +3028,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#vie
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>view_submission</code> listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#view_submission">https://api.slack.com/reference/interaction-payloads/views#view_submission</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission</a> for details.</p></div>
 </dd>
 </dl>
 </dd>

--- a/docs/reference/app/async_app.html
+++ b/docs/reference/app/async_app.html
@@ -114,10 +114,10 @@ el.replaceWith(d);
             if __name__ == &#34;__main__&#34;:
                 app.start(port=int(os.environ.get(&#34;PORT&#34;, 3000)))
 
-        Refer to https://slack.dev/bolt-python/concepts#async for details.
+        Refer to https://docs.slack.dev/tools/bolt-python/concepts/async for details.
 
         If you would like to build an OAuth app for enabling the app to run with multiple workspaces,
-        refer to https://slack.dev/bolt-python/concepts#authenticating-oauth to learn how to configure the app.
+        refer to https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth to learn how to configure the app.
 
         Args:
             logger: The custom logger that can be used in this app.
@@ -687,7 +687,7 @@ el.replaceWith(d);
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new step from app listener.
 
@@ -705,7 +705,7 @@ el.replaceWith(d);
             # Pass Step to set up listeners
             app.step(ws)
 
-        Refer to https://api.slack.com/workflows/steps for details of steps from apps.
+        Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details of steps from apps.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
         For further information about AsyncWorkflowStep specific function arguments
@@ -721,7 +721,7 @@ el.replaceWith(d);
         warnings.warn(
             (
                 &#34;Steps from apps for legacy workflows are now deprecated. &#34;
-                &#34;Use new custom steps: https://api.slack.com/automation/functions/custom-bolt&#34;
+                &#34;Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/&#34;
             ),
             category=DeprecationWarning,
         )
@@ -803,7 +803,7 @@ el.replaceWith(d);
             # Pass a function to this method
             app.event(&#34;team_join&#34;)(ask_for_introduction)
 
-        Refer to https://api.slack.com/apis/connections/events-api for details of Events API.
+        Refer to https://docs.slack.dev/apis/events-api/ for details of Events API.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -841,7 +841,7 @@ el.replaceWith(d);
             # Pass a function to this method
             app.message(&#34;:wave:&#34;)(say_hello)
 
-        Refer to https://api.slack.com/events/message for details of `message` events.
+        Refer to https://docs.slack.dev/reference/events/message/ for details of `message` events.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -956,7 +956,7 @@ el.replaceWith(d);
             # Pass a function to this method
             app.command(&#34;/echo&#34;)(repeat_text)
 
-        Refer to https://api.slack.com/interactivity/slash-commands for details of Slash Commands.
+        Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details of Slash Commands.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -1003,7 +1003,7 @@ el.replaceWith(d);
             # Pass a function to this method
             app.shortcut(&#34;open_modal&#34;)(open_modal)
 
-        Refer to https://api.slack.com/interactivity/shortcuts for details about Shortcuts.
+        Refer to https://docs.slack.dev/interactivity/implementing-shortcuts/ for details about Shortcuts.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -1071,9 +1071,9 @@ el.replaceWith(d);
             # Pass a function to this method
             app.action(&#34;approve_button&#34;)(update_message)
 
-        * Refer to https://api.slack.com/reference/interaction-payloads/block-actions for actions in `blocks`.
-        * Refer to https://api.slack.com/legacy/message-buttons for actions in `attachments`.
-        * Refer to https://api.slack.com/dialogs for actions in dialogs.
+        * Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for actions in `blocks`.
+        * Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for actions in `attachments`.
+        * Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for actions in dialogs.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -1099,7 +1099,7 @@ el.replaceWith(d);
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         &#34;&#34;&#34;Registers a new `block_actions` action listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/block-actions for details.
+        Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for details.
         &#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
@@ -1116,7 +1116,7 @@ el.replaceWith(d);
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         &#34;&#34;&#34;Registers a new `interactive_message` action listener.
-        Refer to https://api.slack.com/legacy/message-buttons for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1132,7 +1132,7 @@ el.replaceWith(d);
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         &#34;&#34;&#34;Registers a new `dialog_submission` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1148,7 +1148,7 @@ el.replaceWith(d);
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         &#34;&#34;&#34;Registers a new `dialog_submission` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1189,7 +1189,7 @@ el.replaceWith(d);
             # Pass a function to this method
             app.view(&#34;view_1&#34;)(handle_submission)
 
-        Refer to https://api.slack.com/reference/interaction-payloads/views for details of payloads.
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload for details of payloads.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -1215,7 +1215,7 @@ el.replaceWith(d);
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         &#34;&#34;&#34;Registers a new `view_submission` listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/views#view_submission for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1231,7 +1231,7 @@ el.replaceWith(d);
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         &#34;&#34;&#34;Registers a new `view_closed` listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/views#view_closed for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1272,8 +1272,8 @@ el.replaceWith(d);
 
         Refer to the following documents for details:
 
-        * https://api.slack.com/reference/block-kit/block-elements#external_select
-        * https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+        * https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
+        * https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -1313,7 +1313,7 @@ el.replaceWith(d);
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         &#34;&#34;&#34;Registers a new `dialog_suggestion` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1473,9 +1473,9 @@ async def message_hello(message, say):  # async function
 if __name__ == "__main__":
     app.start(port=int(os.environ.get("PORT", 3000)))
 </code></pre>
-<p>Refer to <a href="https://slack.dev/bolt-python/concepts#async">https://slack.dev/bolt-python/concepts#async</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/bolt-python/concepts/async">https://docs.slack.dev/tools/bolt-python/concepts/async</a> for details.</p>
 <p>If you would like to build an OAuth app for enabling the app to run with multiple workspaces,
-refer to <a href="https://slack.dev/bolt-python/concepts#authenticating-oauth">https://slack.dev/bolt-python/concepts#authenticating-oauth</a> to learn how to configure the app.</p>
+refer to <a href="https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth">https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth</a> to learn how to configure the app.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>logger</code></strong></dt>
@@ -1669,9 +1669,9 @@ def process_before_response(self) -&gt; bool:
         # Pass a function to this method
         app.action(&#34;approve_button&#34;)(update_message)
 
-    * Refer to https://api.slack.com/reference/interaction-payloads/block-actions for actions in `blocks`.
-    * Refer to https://api.slack.com/legacy/message-buttons for actions in `attachments`.
-    * Refer to https://api.slack.com/dialogs for actions in dialogs.
+    * Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for actions in `blocks`.
+    * Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for actions in `attachments`.
+    * Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for actions in dialogs.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -1700,9 +1700,9 @@ async def update_message(ack):
 app.action("approve_button")(update_message)
 </code></pre>
 <ul>
-<li>Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-actions">https://api.slack.com/reference/interaction-payloads/block-actions</a> for actions in <code>blocks</code>.</li>
-<li>Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slack.com/legacy/message-buttons</a> for actions in <code>attachments</code>.</li>
-<li>Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for actions in dialogs.</li>
+<li>Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/">https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/</a> for actions in <code>blocks</code>.</li>
+<li>Refer to <a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/">https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/</a> for actions in <code>attachments</code>.</li>
+<li>Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for actions in dialogs.</li>
 </ul>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="../kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
@@ -1873,7 +1873,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
     &#34;&#34;&#34;Registers a new `interactive_message` action listener.
-    Refer to https://api.slack.com/legacy/message-buttons for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1883,7 +1883,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>interactive_message</code> action listener.
-Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slack.com/legacy/message-buttons</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/">https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.async_app.AsyncApp.block_action"><code class="name flex">
 <span>def <span class="ident">block_action</span></span>(<span>self,<br>constraints: str | Pattern | Dict[str, str | Pattern],<br>matchers: Sequence[Callable[..., Awaitable[bool]]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.async_middleware.AsyncMiddleware" href="../middleware/async_middleware.html#slack_bolt.middleware.async_middleware.AsyncMiddleware">AsyncMiddleware</a>] | None = None) ‑> Callable[..., Callable[..., Awaitable[<a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None]] | None]</span>
@@ -1900,7 +1900,7 @@ Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slac
     middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
     &#34;&#34;&#34;Registers a new `block_actions` action listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/block-actions for details.
+    Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for details.
     &#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
@@ -1911,7 +1911,7 @@ Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slac
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>block_actions</code> action listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-actions">https://api.slack.com/reference/interaction-payloads/block-actions</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/">https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.async_app.AsyncApp.block_suggestion"><code class="name flex">
 <span>def <span class="ident">block_suggestion</span></span>(<span>self,<br>action_id: str | Pattern,<br>matchers: Sequence[Callable[..., Awaitable[bool]]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.async_middleware.AsyncMiddleware" href="../middleware/async_middleware.html#slack_bolt.middleware.async_middleware.AsyncMiddleware">AsyncMiddleware</a>] | None = None) ‑> Callable[..., Callable[..., Awaitable[<a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None]] | None]</span>
@@ -1965,7 +1965,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-act
         # Pass a function to this method
         app.command(&#34;/echo&#34;)(repeat_text)
 
-    Refer to https://api.slack.com/interactivity/slash-commands for details of Slash Commands.
+    Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details of Slash Commands.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -1996,7 +1996,7 @@ async def repeat_text(ack, say, command):
 # Pass a function to this method
 app.command("/echo")(repeat_text)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/interactivity/slash-commands">https://api.slack.com/interactivity/slash-commands</a> for details of Slash Commands.</p>
+<p>Refer to <a href="https://docs.slack.dev/interactivity/implementing-slash-commands/">https://docs.slack.dev/interactivity/implementing-slash-commands/</a> for details of Slash Commands.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="../kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2059,7 +2059,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
     &#34;&#34;&#34;Registers a new `dialog_submission` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -2069,7 +2069,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_submission</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.async_app.AsyncApp.dialog_submission"><code class="name flex">
 <span>def <span class="ident">dialog_submission</span></span>(<span>self,<br>callback_id: str | Pattern,<br>matchers: Sequence[Callable[..., Awaitable[bool]]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.async_middleware.AsyncMiddleware" href="../middleware/async_middleware.html#slack_bolt.middleware.async_middleware.AsyncMiddleware">AsyncMiddleware</a>] | None = None) ‑> Callable[..., Callable[..., Awaitable[<a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None]] | None]</span>
@@ -2086,7 +2086,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
     &#34;&#34;&#34;Registers a new `dialog_submission` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -2096,7 +2096,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_submission</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.async_app.AsyncApp.dialog_suggestion"><code class="name flex">
 <span>def <span class="ident">dialog_suggestion</span></span>(<span>self,<br>callback_id: str | Pattern,<br>matchers: Sequence[Callable[..., Awaitable[bool]]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.async_middleware.AsyncMiddleware" href="../middleware/async_middleware.html#slack_bolt.middleware.async_middleware.AsyncMiddleware">AsyncMiddleware</a>] | None = None) ‑> Callable[..., Callable[..., Awaitable[<a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None]] | None]</span>
@@ -2113,7 +2113,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
     &#34;&#34;&#34;Registers a new `dialog_suggestion` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -2123,7 +2123,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_suggestion</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.async_app.AsyncApp.enable_token_revocation_listeners"><code class="name flex">
 <span>def <span class="ident">enable_token_revocation_listeners</span></span>(<span>self) ‑> None</span>
@@ -2229,7 +2229,7 @@ when getting an unhandled error in Bolt app.</dd>
         # Pass a function to this method
         app.event(&#34;team_join&#34;)(ask_for_introduction)
 
-    Refer to https://api.slack.com/apis/connections/events-api for details of Events API.
+    Refer to https://docs.slack.dev/apis/events-api/ for details of Events API.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -2261,7 +2261,7 @@ async def ask_for_introduction(event, say):
 # Pass a function to this method
 app.event("team_join")(ask_for_introduction)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/apis/connections/events-api">https://api.slack.com/apis/connections/events-api</a> for details of Events API.</p>
+<p>Refer to <a href="https://docs.slack.dev/apis/events-api/">https://docs.slack.dev/apis/events-api/</a> for details of Events API.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="../kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2414,7 +2414,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
         # Pass a function to this method
         app.message(&#34;:wave:&#34;)(say_hello)
 
-    Refer to https://api.slack.com/events/message for details of `message` events.
+    Refer to https://docs.slack.dev/reference/events/message/ for details of `message` events.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -2468,7 +2468,7 @@ async def say_hello(message, say):
 # Pass a function to this method
 app.message(":wave:")(say_hello)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/events/message">https://api.slack.com/events/message</a> for details of <code>message</code> events.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/events/message/">https://docs.slack.dev/reference/events/message/</a> for details of <code>message</code> events.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="../kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2608,8 +2608,8 @@ app.middleware(middleware_func)
 
     Refer to the following documents for details:
 
-    * https://api.slack.com/reference/block-kit/block-elements#external_select
-    * https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+    * https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
+    * https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -2649,8 +2649,8 @@ app.options("menu_selection")(show_menu_options)
 </code></pre>
 <p>Refer to the following documents for details:</p>
 <ul>
-<li><a href="https://api.slack.com/reference/block-kit/block-elements#external_select">https://api.slack.com/reference/block-kit/block-elements#external_select</a></li>
-<li><a href="https://api.slack.com/reference/block-kit/block-elements#external_multi_select">https://api.slack.com/reference/block-kit/block-elements#external_multi_select</a></li>
+<li><a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select</a></li>
+<li><a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select</a></li>
 </ul>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="../kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
@@ -2739,7 +2739,7 @@ Refer to <a href="https://docs.aiohttp.org/">https://docs.aiohttp.org/</a> for m
         # Pass a function to this method
         app.shortcut(&#34;open_modal&#34;)(open_modal)
 
-    Refer to https://api.slack.com/interactivity/shortcuts for details about Shortcuts.
+    Refer to https://docs.slack.dev/interactivity/implementing-shortcuts/ for details about Shortcuts.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -2776,7 +2776,7 @@ async def open_modal(ack, body, client):
 # Pass a function to this method
 app.shortcut("open_modal")(open_modal)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/interactivity/shortcuts">https://api.slack.com/interactivity/shortcuts</a> for details about Shortcuts.</p>
+<p>Refer to <a href="https://docs.slack.dev/interactivity/implementing-shortcuts/">https://docs.slack.dev/interactivity/implementing-shortcuts/</a> for details about Shortcuts.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="../kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2839,7 +2839,7 @@ Refer to <a href="https://docs.aiohttp.org/">https://docs.aiohttp.org/</a> for m
     &#34;&#34;&#34;
     Deprecated:
         Steps from apps for legacy workflows are now deprecated.
-        Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
     Registers a new step from app listener.
 
@@ -2857,7 +2857,7 @@ Refer to <a href="https://docs.aiohttp.org/">https://docs.aiohttp.org/</a> for m
         # Pass Step to set up listeners
         app.step(ws)
 
-    Refer to https://api.slack.com/workflows/steps for details of steps from apps.
+    Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details of steps from apps.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
     For further information about AsyncWorkflowStep specific function arguments
@@ -2873,7 +2873,7 @@ Refer to <a href="https://docs.aiohttp.org/">https://docs.aiohttp.org/</a> for m
     warnings.warn(
         (
             &#34;Steps from apps for legacy workflows are now deprecated. &#34;
-            &#34;Use new custom steps: https://api.slack.com/automation/functions/custom-bolt&#34;
+            &#34;Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/&#34;
         ),
         category=DeprecationWarning,
     )
@@ -2895,7 +2895,7 @@ Refer to <a href="https://docs.aiohttp.org/">https://docs.aiohttp.org/</a> for m
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>Registers a new step from app listener.</p>
 <p>Unlike others, this method doesn't behave as a decorator.
 If you want to register a step from app by a decorator, use <code>AsyncWorkflowStepBuilder</code>'s methods.</p>
@@ -2910,7 +2910,7 @@ ws = AsyncWorkflowStep(
 # Pass Step to set up listeners
 app.step(ws)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/workflows/steps">https://api.slack.com/workflows/steps</a> for details of steps from apps.</p>
+<p>Refer to <a href="https://docs.slack.dev/legacy/legacy-steps-from-apps/">https://docs.slack.dev/legacy/legacy-steps-from-apps/</a> for details of steps from apps.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="../kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.
 For further information about AsyncWorkflowStep specific function arguments
 such as <code>configure</code>, <code>update</code>, <code>complete</code>, and <code>fail</code>,
@@ -2978,7 +2978,7 @@ refer to the <code>async</code> prefixed ones in <code><a title="slack_bolt.work
         # Pass a function to this method
         app.view(&#34;view_1&#34;)(handle_submission)
 
-    Refer to https://api.slack.com/reference/interaction-payloads/views for details of payloads.
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload for details of payloads.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -3019,7 +3019,7 @@ async def handle_submission(ack, body, client, view):
 # Pass a function to this method
 app.view("view_1")(handle_submission)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/reference/interaction-payloads/views">https://api.slack.com/reference/interaction-payloads/views</a> for details of payloads.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload</a> for details of payloads.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="../kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -3048,7 +3048,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
     &#34;&#34;&#34;Registers a new `view_closed` listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/views#view_closed for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -3058,7 +3058,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>view_closed</code> listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#view_closed">https://api.slack.com/reference/interaction-payloads/views#view_closed</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.async_app.AsyncApp.view_submission"><code class="name flex">
 <span>def <span class="ident">view_submission</span></span>(<span>self,<br>constraints: str | Pattern,<br>matchers: Sequence[Callable[..., Awaitable[bool]]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.async_middleware.AsyncMiddleware" href="../middleware/async_middleware.html#slack_bolt.middleware.async_middleware.AsyncMiddleware">AsyncMiddleware</a>] | None = None) ‑> Callable[..., Callable[..., Awaitable[<a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None]] | None]</span>
@@ -3075,7 +3075,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#vie
     middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
     &#34;&#34;&#34;Registers a new `view_submission` listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/views#view_submission for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -3085,7 +3085,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#vie
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>view_submission</code> listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#view_submission">https://api.slack.com/reference/interaction-payloads/views#view_submission</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.async_app.AsyncApp.web_app"><code class="name flex">
 <span>def <span class="ident">web_app</span></span>(<span>self, path: str = '/slack/events', port: int = 3000) ‑> aiohttp.web_app.Application</span>

--- a/docs/reference/app/index.html
+++ b/docs/reference/app/index.html
@@ -136,10 +136,10 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
             if __name__ == &#34;__main__&#34;:
                 app.start(port=int(os.environ.get(&#34;PORT&#34;, 3000)))
 
-        Refer to https://slack.dev/bolt-python/tutorial/getting-started for details.
+        Refer to https://docs.slack.dev/tools/bolt-python/building-an-app for details.
 
         If you would like to build an OAuth app for enabling the app to run with multiple workspaces,
-        refer to https://slack.dev/bolt-python/concepts#authenticating-oauth to learn how to configure the app.
+        refer to https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth to learn how to configure the app.
 
         Args:
             logger: The custom logger that can be used in this app.
@@ -648,7 +648,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
             # Pass a function to this method
             app.middleware(middleware_func)
 
-        Refer to https://slack.dev/bolt-python/concepts#global-middleware for details.
+        Refer to https://docs.slack.dev/tools/bolt-python/concepts/global-middleware for details.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -694,7 +694,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new step from app listener.
 
@@ -712,7 +712,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
             # Pass Step to set up listeners
             app.step(ws)
 
-        Refer to https://api.slack.com/workflows/steps for details of steps from apps.
+        Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details of steps from apps.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -729,7 +729,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
         warnings.warn(
             (
                 &#34;Steps from apps for legacy workflows are now deprecated. &#34;
-                &#34;Use new custom steps: https://api.slack.com/automation/functions/custom-bolt&#34;
+                &#34;Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/&#34;
             ),
             category=DeprecationWarning,
         )
@@ -806,7 +806,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
             # Pass a function to this method
             app.event(&#34;team_join&#34;)(ask_for_introduction)
 
-        Refer to https://api.slack.com/apis/connections/events-api for details of Events API.
+        Refer to https://docs.slack.dev/apis/events-api/ for details of Events API.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -844,7 +844,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
             # Pass a function to this method
             app.message(&#34;:wave:&#34;)(say_hello)
 
-        Refer to https://api.slack.com/events/message for details of `message` events.
+        Refer to https://docs.slack.dev/reference/events/message/ for details of `message` events.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -955,7 +955,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
             # Pass a function to this method
             app.command(&#34;/echo&#34;)(repeat_text)
 
-        Refer to https://api.slack.com/interactivity/slash-commands for details of Slash Commands.
+        Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details of Slash Commands.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1002,7 +1002,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
             # Pass a function to this method
             app.shortcut(&#34;open_modal&#34;)(open_modal)
 
-        Refer to https://api.slack.com/interactivity/shortcuts for details about Shortcuts.
+        Refer to https://docs.slack.dev/interactivity/implementing-shortcuts/ for details about Shortcuts.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1070,9 +1070,9 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
             # Pass a function to this method
             app.action(&#34;approve_button&#34;)(update_message)
 
-        * Refer to https://api.slack.com/reference/interaction-payloads/block-actions for actions in `blocks`.
-        * Refer to https://api.slack.com/legacy/message-buttons for actions in `attachments`.
-        * Refer to https://api.slack.com/dialogs for actions in dialogs.
+        * Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for actions in `blocks`.
+        * Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for actions in `attachments`.
+        * Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for actions in dialogs.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1098,7 +1098,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `block_actions` action listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/block-actions for details.
+        Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for details.
         &#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
@@ -1115,7 +1115,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `interactive_message` action listener.
-        Refer to https://api.slack.com/legacy/message-buttons for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1131,7 +1131,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `dialog_submission` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1147,7 +1147,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `dialog_cancellation` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1188,7 +1188,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
             # Pass a function to this method
             app.view(&#34;view_1&#34;)(handle_submission)
 
-        Refer to https://api.slack.com/reference/interaction-payloads/views for details of payloads.
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload for details of payloads.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1214,7 +1214,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `view_submission` listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/views#view_submission for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1230,7 +1230,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `view_closed` listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/views#view_closed for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1271,8 +1271,8 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
 
         Refer to the following documents for details:
 
-        * https://api.slack.com/reference/block-kit/block-elements#external_select
-        * https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+        * https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
+        * https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1312,7 +1312,7 @@ you can use <code><a title="slack_bolt.app.async_app" href="async_app.html">slac
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `dialog_suggestion` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1462,9 +1462,9 @@ def message_hello(message, say):
 if __name__ == "__main__":
     app.start(port=int(os.environ.get("PORT", 3000)))
 </code></pre>
-<p>Refer to <a href="https://slack.dev/bolt-python/tutorial/getting-started">https://slack.dev/bolt-python/tutorial/getting-started</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/bolt-python/building-an-app">https://docs.slack.dev/tools/bolt-python/building-an-app</a> for details.</p>
 <p>If you would like to build an OAuth app for enabling the app to run with multiple workspaces,
-refer to <a href="https://slack.dev/bolt-python/concepts#authenticating-oauth">https://slack.dev/bolt-python/concepts#authenticating-oauth</a> to learn how to configure the app.</p>
+refer to <a href="https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth">https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth</a> to learn how to configure the app.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>logger</code></strong></dt>
@@ -1656,9 +1656,9 @@ def process_before_response(self) -&gt; bool:
         # Pass a function to this method
         app.action(&#34;approve_button&#34;)(update_message)
 
-    * Refer to https://api.slack.com/reference/interaction-payloads/block-actions for actions in `blocks`.
-    * Refer to https://api.slack.com/legacy/message-buttons for actions in `attachments`.
-    * Refer to https://api.slack.com/dialogs for actions in dialogs.
+    * Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for actions in `blocks`.
+    * Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for actions in `attachments`.
+    * Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for actions in dialogs.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1687,9 +1687,9 @@ def update_message(ack):
 app.action("approve_button")(update_message)
 </code></pre>
 <ul>
-<li>Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-actions">https://api.slack.com/reference/interaction-payloads/block-actions</a> for actions in <code>blocks</code>.</li>
-<li>Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slack.com/legacy/message-buttons</a> for actions in <code>attachments</code>.</li>
-<li>Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for actions in dialogs.</li>
+<li>Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/">https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/</a> for actions in <code>blocks</code>.</li>
+<li>Refer to <a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/">https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/</a> for actions in <code>attachments</code>.</li>
+<li>Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for actions in dialogs.</li>
 </ul>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
@@ -1732,7 +1732,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `interactive_message` action listener.
-    Refer to https://api.slack.com/legacy/message-buttons for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1742,7 +1742,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>interactive_message</code> action listener.
-Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slack.com/legacy/message-buttons</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/">https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.App.block_action"><code class="name flex">
 <span>def <span class="ident">block_action</span></span>(<span>self,<br>constraints: str | Pattern | Dict[str, str | Pattern],<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="../middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -1759,7 +1759,7 @@ Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slac
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `block_actions` action listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/block-actions for details.
+    Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for details.
     &#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
@@ -1770,7 +1770,7 @@ Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slac
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>block_actions</code> action listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-actions">https://api.slack.com/reference/interaction-payloads/block-actions</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/">https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.App.block_suggestion"><code class="name flex">
 <span>def <span class="ident">block_suggestion</span></span>(<span>self,<br>action_id: str | Pattern,<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="../middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -1824,7 +1824,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-act
         # Pass a function to this method
         app.command(&#34;/echo&#34;)(repeat_text)
 
-    Refer to https://api.slack.com/interactivity/slash-commands for details of Slash Commands.
+    Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details of Slash Commands.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1855,7 +1855,7 @@ def repeat_text(ack, say, command):
 # Pass a function to this method
 app.command("/echo")(repeat_text)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/interactivity/slash-commands">https://api.slack.com/interactivity/slash-commands</a> for details of Slash Commands.</p>
+<p>Refer to <a href="https://docs.slack.dev/interactivity/implementing-slash-commands/">https://docs.slack.dev/interactivity/implementing-slash-commands/</a> for details of Slash Commands.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -1918,7 +1918,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `dialog_cancellation` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1928,7 +1928,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_cancellation</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.App.dialog_submission"><code class="name flex">
 <span>def <span class="ident">dialog_submission</span></span>(<span>self,<br>callback_id: str | Pattern,<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="../middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -1945,7 +1945,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `dialog_submission` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1955,7 +1955,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_submission</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.App.dialog_suggestion"><code class="name flex">
 <span>def <span class="ident">dialog_suggestion</span></span>(<span>self,<br>callback_id: str | Pattern,<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="../middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -1972,7 +1972,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `dialog_suggestion` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1982,7 +1982,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_suggestion</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.App.dispatch"><code class="name flex">
 <span>def <span class="ident">dispatch</span></span>(<span>self,<br>req: <a title="slack_bolt.request.request.BoltRequest" href="../request/request.html#slack_bolt.request.request.BoltRequest">BoltRequest</a>) ‑> <a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a></span>
@@ -2208,7 +2208,7 @@ when getting an unhandled error in Bolt app.</dd>
         # Pass a function to this method
         app.event(&#34;team_join&#34;)(ask_for_introduction)
 
-    Refer to https://api.slack.com/apis/connections/events-api for details of Events API.
+    Refer to https://docs.slack.dev/apis/events-api/ for details of Events API.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2240,7 +2240,7 @@ def ask_for_introduction(event, say):
 # Pass a function to this method
 app.event("team_join")(ask_for_introduction)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/apis/connections/events-api">https://api.slack.com/apis/connections/events-api</a> for details of Events API.</p>
+<p>Refer to <a href="https://docs.slack.dev/apis/events-api/">https://docs.slack.dev/apis/events-api/</a> for details of Events API.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2392,7 +2392,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
         # Pass a function to this method
         app.message(&#34;:wave:&#34;)(say_hello)
 
-    Refer to https://api.slack.com/events/message for details of `message` events.
+    Refer to https://docs.slack.dev/reference/events/message/ for details of `message` events.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2443,7 +2443,7 @@ def say_hello(message, say):
 # Pass a function to this method
 app.message(":wave:")(say_hello)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/events/message">https://api.slack.com/events/message</a> for details of <code>message</code> events.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/events/message/">https://docs.slack.dev/reference/events/message/</a> for details of <code>message</code> events.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2503,7 +2503,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
         # Pass a function to this method
         app.middleware(middleware_func)
 
-    Refer to https://slack.dev/bolt-python/concepts#global-middleware for details.
+    Refer to https://docs.slack.dev/tools/bolt-python/concepts/global-middleware for details.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2541,7 +2541,7 @@ def middleware_func(logger, body, next):
 # Pass a function to this method
 app.middleware(middleware_func)
 </code></pre>
-<p>Refer to <a href="https://slack.dev/bolt-python/concepts#global-middleware">https://slack.dev/bolt-python/concepts#global-middleware</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/bolt-python/concepts/global-middleware">https://docs.slack.dev/tools/bolt-python/concepts/global-middleware</a> for details.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2586,8 +2586,8 @@ app.middleware(middleware_func)
 
     Refer to the following documents for details:
 
-    * https://api.slack.com/reference/block-kit/block-elements#external_select
-    * https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+    * https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
+    * https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2627,8 +2627,8 @@ app.options("menu_selection")(show_menu_options)
 </code></pre>
 <p>Refer to the following documents for details:</p>
 <ul>
-<li><a href="https://api.slack.com/reference/block-kit/block-elements#external_select">https://api.slack.com/reference/block-kit/block-elements#external_select</a></li>
-<li><a href="https://api.slack.com/reference/block-kit/block-elements#external_multi_select">https://api.slack.com/reference/block-kit/block-elements#external_multi_select</a></li>
+<li><a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select</a></li>
+<li><a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select</a></li>
 </ul>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
@@ -2674,7 +2674,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
         # Pass a function to this method
         app.shortcut(&#34;open_modal&#34;)(open_modal)
 
-    Refer to https://api.slack.com/interactivity/shortcuts for details about Shortcuts.
+    Refer to https://docs.slack.dev/interactivity/implementing-shortcuts/ for details about Shortcuts.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2711,7 +2711,7 @@ def open_modal(ack, body, client):
 # Pass a function to this method
 app.shortcut("open_modal")(open_modal)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/interactivity/shortcuts">https://api.slack.com/interactivity/shortcuts</a> for details about Shortcuts.</p>
+<p>Refer to <a href="https://docs.slack.dev/interactivity/implementing-shortcuts/">https://docs.slack.dev/interactivity/implementing-shortcuts/</a> for details about Shortcuts.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2797,7 +2797,7 @@ For production, consider using a production-ready WSGI server such as Gunicorn.<
     &#34;&#34;&#34;
     Deprecated:
         Steps from apps for legacy workflows are now deprecated.
-        Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
     Registers a new step from app listener.
 
@@ -2815,7 +2815,7 @@ For production, consider using a production-ready WSGI server such as Gunicorn.<
         # Pass Step to set up listeners
         app.step(ws)
 
-    Refer to https://api.slack.com/workflows/steps for details of steps from apps.
+    Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details of steps from apps.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2832,7 +2832,7 @@ For production, consider using a production-ready WSGI server such as Gunicorn.<
     warnings.warn(
         (
             &#34;Steps from apps for legacy workflows are now deprecated. &#34;
-            &#34;Use new custom steps: https://api.slack.com/automation/functions/custom-bolt&#34;
+            &#34;Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/&#34;
         ),
         category=DeprecationWarning,
     )
@@ -2854,7 +2854,7 @@ For production, consider using a production-ready WSGI server such as Gunicorn.<
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>Registers a new step from app listener.</p>
 <p>Unlike others, this method doesn't behave as a decorator.
 If you want to register a step from app by a decorator, use <code>WorkflowStepBuilder</code>'s methods.</p>
@@ -2869,7 +2869,7 @@ ws = WorkflowStep(
 # Pass Step to set up listeners
 app.step(ws)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/workflows/steps">https://api.slack.com/workflows/steps</a> for details of steps from apps.</p>
+<p>Refer to <a href="https://docs.slack.dev/legacy/legacy-steps-from-apps/">https://docs.slack.dev/legacy/legacy-steps-from-apps/</a> for details of steps from apps.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <p>For further information about WorkflowStep specific function arguments
 such as <code>configure</code>, <code>update</code>, <code>complete</code>, and <code>fail</code>,
@@ -2940,7 +2940,7 @@ refer to <code><a title="slack_bolt.workflows.step.utilities" href="../workflows
         # Pass a function to this method
         app.view(&#34;view_1&#34;)(handle_submission)
 
-    Refer to https://api.slack.com/reference/interaction-payloads/views for details of payloads.
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload for details of payloads.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2981,7 +2981,7 @@ def handle_submission(ack, body, client, view):
 # Pass a function to this method
 app.view("view_1")(handle_submission)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/reference/interaction-payloads/views">https://api.slack.com/reference/interaction-payloads/views</a> for details of payloads.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload</a> for details of payloads.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="../kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -3010,7 +3010,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `view_closed` listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/views#view_closed for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -3020,7 +3020,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>view_closed</code> listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#view_closed">https://api.slack.com/reference/interaction-payloads/views#view_closed</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.app.App.view_submission"><code class="name flex">
 <span>def <span class="ident">view_submission</span></span>(<span>self,<br>constraints: str | Pattern,<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="../middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="../response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -3037,7 +3037,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#vie
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `view_submission` listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/views#view_submission for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -3047,7 +3047,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#vie
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>view_submission</code> listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#view_submission">https://api.slack.com/reference/interaction-payloads/views#view_submission</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission</a> for details.</p></div>
 </dd>
 </dl>
 </dd>

--- a/docs/reference/async_app.html
+++ b/docs/reference/async_app.html
@@ -205,10 +205,10 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
             if __name__ == &#34;__main__&#34;:
                 app.start(port=int(os.environ.get(&#34;PORT&#34;, 3000)))
 
-        Refer to https://slack.dev/bolt-python/concepts#async for details.
+        Refer to https://docs.slack.dev/tools/bolt-python/concepts/async for details.
 
         If you would like to build an OAuth app for enabling the app to run with multiple workspaces,
-        refer to https://slack.dev/bolt-python/concepts#authenticating-oauth to learn how to configure the app.
+        refer to https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth to learn how to configure the app.
 
         Args:
             logger: The custom logger that can be used in this app.
@@ -778,7 +778,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new step from app listener.
 
@@ -796,7 +796,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
             # Pass Step to set up listeners
             app.step(ws)
 
-        Refer to https://api.slack.com/workflows/steps for details of steps from apps.
+        Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details of steps from apps.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
         For further information about AsyncWorkflowStep specific function arguments
@@ -812,7 +812,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
         warnings.warn(
             (
                 &#34;Steps from apps for legacy workflows are now deprecated. &#34;
-                &#34;Use new custom steps: https://api.slack.com/automation/functions/custom-bolt&#34;
+                &#34;Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/&#34;
             ),
             category=DeprecationWarning,
         )
@@ -894,7 +894,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
             # Pass a function to this method
             app.event(&#34;team_join&#34;)(ask_for_introduction)
 
-        Refer to https://api.slack.com/apis/connections/events-api for details of Events API.
+        Refer to https://docs.slack.dev/apis/events-api/ for details of Events API.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -932,7 +932,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
             # Pass a function to this method
             app.message(&#34;:wave:&#34;)(say_hello)
 
-        Refer to https://api.slack.com/events/message for details of `message` events.
+        Refer to https://docs.slack.dev/reference/events/message/ for details of `message` events.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -1047,7 +1047,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
             # Pass a function to this method
             app.command(&#34;/echo&#34;)(repeat_text)
 
-        Refer to https://api.slack.com/interactivity/slash-commands for details of Slash Commands.
+        Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details of Slash Commands.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -1094,7 +1094,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
             # Pass a function to this method
             app.shortcut(&#34;open_modal&#34;)(open_modal)
 
-        Refer to https://api.slack.com/interactivity/shortcuts for details about Shortcuts.
+        Refer to https://docs.slack.dev/interactivity/implementing-shortcuts/ for details about Shortcuts.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -1162,9 +1162,9 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
             # Pass a function to this method
             app.action(&#34;approve_button&#34;)(update_message)
 
-        * Refer to https://api.slack.com/reference/interaction-payloads/block-actions for actions in `blocks`.
-        * Refer to https://api.slack.com/legacy/message-buttons for actions in `attachments`.
-        * Refer to https://api.slack.com/dialogs for actions in dialogs.
+        * Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for actions in `blocks`.
+        * Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for actions in `attachments`.
+        * Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for actions in dialogs.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -1190,7 +1190,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         &#34;&#34;&#34;Registers a new `block_actions` action listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/block-actions for details.
+        Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for details.
         &#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
@@ -1207,7 +1207,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         &#34;&#34;&#34;Registers a new `interactive_message` action listener.
-        Refer to https://api.slack.com/legacy/message-buttons for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1223,7 +1223,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         &#34;&#34;&#34;Registers a new `dialog_submission` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1239,7 +1239,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         &#34;&#34;&#34;Registers a new `dialog_submission` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1280,7 +1280,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
             # Pass a function to this method
             app.view(&#34;view_1&#34;)(handle_submission)
 
-        Refer to https://api.slack.com/reference/interaction-payloads/views for details of payloads.
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload for details of payloads.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -1306,7 +1306,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         &#34;&#34;&#34;Registers a new `view_submission` listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/views#view_submission for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1322,7 +1322,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         &#34;&#34;&#34;Registers a new `view_closed` listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/views#view_closed for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1363,8 +1363,8 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
 
         Refer to the following documents for details:
 
-        * https://api.slack.com/reference/block-kit/block-elements#external_select
-        * https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+        * https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
+        * https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -1404,7 +1404,7 @@ Apps can be run the same way as the synchronous example above. If you'd prefer a
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         &#34;&#34;&#34;Registers a new `dialog_suggestion` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1564,9 +1564,9 @@ async def message_hello(message, say):  # async function
 if __name__ == "__main__":
     app.start(port=int(os.environ.get("PORT", 3000)))
 </code></pre>
-<p>Refer to <a href="https://slack.dev/bolt-python/concepts#async">https://slack.dev/bolt-python/concepts#async</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/bolt-python/concepts/async">https://docs.slack.dev/tools/bolt-python/concepts/async</a> for details.</p>
 <p>If you would like to build an OAuth app for enabling the app to run with multiple workspaces,
-refer to <a href="https://slack.dev/bolt-python/concepts#authenticating-oauth">https://slack.dev/bolt-python/concepts#authenticating-oauth</a> to learn how to configure the app.</p>
+refer to <a href="https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth">https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth</a> to learn how to configure the app.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>logger</code></strong></dt>
@@ -1760,9 +1760,9 @@ def process_before_response(self) -&gt; bool:
         # Pass a function to this method
         app.action(&#34;approve_button&#34;)(update_message)
 
-    * Refer to https://api.slack.com/reference/interaction-payloads/block-actions for actions in `blocks`.
-    * Refer to https://api.slack.com/legacy/message-buttons for actions in `attachments`.
-    * Refer to https://api.slack.com/dialogs for actions in dialogs.
+    * Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for actions in `blocks`.
+    * Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for actions in `attachments`.
+    * Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for actions in dialogs.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -1791,9 +1791,9 @@ async def update_message(ack):
 app.action("approve_button")(update_message)
 </code></pre>
 <ul>
-<li>Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-actions">https://api.slack.com/reference/interaction-payloads/block-actions</a> for actions in <code>blocks</code>.</li>
-<li>Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slack.com/legacy/message-buttons</a> for actions in <code>attachments</code>.</li>
-<li>Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for actions in dialogs.</li>
+<li>Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/">https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/</a> for actions in <code>blocks</code>.</li>
+<li>Refer to <a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/">https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/</a> for actions in <code>attachments</code>.</li>
+<li>Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for actions in dialogs.</li>
 </ul>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
@@ -1964,7 +1964,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
     &#34;&#34;&#34;Registers a new `interactive_message` action listener.
-    Refer to https://api.slack.com/legacy/message-buttons for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1974,7 +1974,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>interactive_message</code> action listener.
-Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slack.com/legacy/message-buttons</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/">https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.async_app.AsyncApp.block_action"><code class="name flex">
 <span>def <span class="ident">block_action</span></span>(<span>self,<br>constraints: str | Pattern | Dict[str, str | Pattern],<br>matchers: Sequence[Callable[..., Awaitable[bool]]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.async_middleware.AsyncMiddleware" href="middleware/async_middleware.html#slack_bolt.middleware.async_middleware.AsyncMiddleware">AsyncMiddleware</a>] | None = None) ‑> Callable[..., Callable[..., Awaitable[<a title="slack_bolt.response.response.BoltResponse" href="response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None]] | None]</span>
@@ -1991,7 +1991,7 @@ Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slac
     middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
     &#34;&#34;&#34;Registers a new `block_actions` action listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/block-actions for details.
+    Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for details.
     &#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
@@ -2002,7 +2002,7 @@ Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slac
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>block_actions</code> action listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-actions">https://api.slack.com/reference/interaction-payloads/block-actions</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/">https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.async_app.AsyncApp.block_suggestion"><code class="name flex">
 <span>def <span class="ident">block_suggestion</span></span>(<span>self,<br>action_id: str | Pattern,<br>matchers: Sequence[Callable[..., Awaitable[bool]]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.async_middleware.AsyncMiddleware" href="middleware/async_middleware.html#slack_bolt.middleware.async_middleware.AsyncMiddleware">AsyncMiddleware</a>] | None = None) ‑> Callable[..., Callable[..., Awaitable[<a title="slack_bolt.response.response.BoltResponse" href="response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None]] | None]</span>
@@ -2056,7 +2056,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-act
         # Pass a function to this method
         app.command(&#34;/echo&#34;)(repeat_text)
 
-    Refer to https://api.slack.com/interactivity/slash-commands for details of Slash Commands.
+    Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details of Slash Commands.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -2087,7 +2087,7 @@ async def repeat_text(ack, say, command):
 # Pass a function to this method
 app.command("/echo")(repeat_text)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/interactivity/slash-commands">https://api.slack.com/interactivity/slash-commands</a> for details of Slash Commands.</p>
+<p>Refer to <a href="https://docs.slack.dev/interactivity/implementing-slash-commands/">https://docs.slack.dev/interactivity/implementing-slash-commands/</a> for details of Slash Commands.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2150,7 +2150,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
     &#34;&#34;&#34;Registers a new `dialog_submission` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -2160,7 +2160,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_submission</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.async_app.AsyncApp.dialog_submission"><code class="name flex">
 <span>def <span class="ident">dialog_submission</span></span>(<span>self,<br>callback_id: str | Pattern,<br>matchers: Sequence[Callable[..., Awaitable[bool]]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.async_middleware.AsyncMiddleware" href="middleware/async_middleware.html#slack_bolt.middleware.async_middleware.AsyncMiddleware">AsyncMiddleware</a>] | None = None) ‑> Callable[..., Callable[..., Awaitable[<a title="slack_bolt.response.response.BoltResponse" href="response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None]] | None]</span>
@@ -2177,7 +2177,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
     &#34;&#34;&#34;Registers a new `dialog_submission` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -2187,7 +2187,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_submission</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.async_app.AsyncApp.dialog_suggestion"><code class="name flex">
 <span>def <span class="ident">dialog_suggestion</span></span>(<span>self,<br>callback_id: str | Pattern,<br>matchers: Sequence[Callable[..., Awaitable[bool]]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.async_middleware.AsyncMiddleware" href="middleware/async_middleware.html#slack_bolt.middleware.async_middleware.AsyncMiddleware">AsyncMiddleware</a>] | None = None) ‑> Callable[..., Callable[..., Awaitable[<a title="slack_bolt.response.response.BoltResponse" href="response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None]] | None]</span>
@@ -2204,7 +2204,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
     &#34;&#34;&#34;Registers a new `dialog_suggestion` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -2214,7 +2214,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_suggestion</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.async_app.AsyncApp.enable_token_revocation_listeners"><code class="name flex">
 <span>def <span class="ident">enable_token_revocation_listeners</span></span>(<span>self) ‑> None</span>
@@ -2320,7 +2320,7 @@ when getting an unhandled error in Bolt app.</dd>
         # Pass a function to this method
         app.event(&#34;team_join&#34;)(ask_for_introduction)
 
-    Refer to https://api.slack.com/apis/connections/events-api for details of Events API.
+    Refer to https://docs.slack.dev/apis/events-api/ for details of Events API.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -2352,7 +2352,7 @@ async def ask_for_introduction(event, say):
 # Pass a function to this method
 app.event("team_join")(ask_for_introduction)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/apis/connections/events-api">https://api.slack.com/apis/connections/events-api</a> for details of Events API.</p>
+<p>Refer to <a href="https://docs.slack.dev/apis/events-api/">https://docs.slack.dev/apis/events-api/</a> for details of Events API.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2505,7 +2505,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
         # Pass a function to this method
         app.message(&#34;:wave:&#34;)(say_hello)
 
-    Refer to https://api.slack.com/events/message for details of `message` events.
+    Refer to https://docs.slack.dev/reference/events/message/ for details of `message` events.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -2559,7 +2559,7 @@ async def say_hello(message, say):
 # Pass a function to this method
 app.message(":wave:")(say_hello)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/events/message">https://api.slack.com/events/message</a> for details of <code>message</code> events.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/events/message/">https://docs.slack.dev/reference/events/message/</a> for details of <code>message</code> events.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2699,8 +2699,8 @@ app.middleware(middleware_func)
 
     Refer to the following documents for details:
 
-    * https://api.slack.com/reference/block-kit/block-elements#external_select
-    * https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+    * https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
+    * https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -2740,8 +2740,8 @@ app.options("menu_selection")(show_menu_options)
 </code></pre>
 <p>Refer to the following documents for details:</p>
 <ul>
-<li><a href="https://api.slack.com/reference/block-kit/block-elements#external_select">https://api.slack.com/reference/block-kit/block-elements#external_select</a></li>
-<li><a href="https://api.slack.com/reference/block-kit/block-elements#external_multi_select">https://api.slack.com/reference/block-kit/block-elements#external_multi_select</a></li>
+<li><a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select</a></li>
+<li><a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select</a></li>
 </ul>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
@@ -2830,7 +2830,7 @@ Refer to <a href="https://docs.aiohttp.org/">https://docs.aiohttp.org/</a> for m
         # Pass a function to this method
         app.shortcut(&#34;open_modal&#34;)(open_modal)
 
-    Refer to https://api.slack.com/interactivity/shortcuts for details about Shortcuts.
+    Refer to https://docs.slack.dev/interactivity/implementing-shortcuts/ for details about Shortcuts.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -2867,7 +2867,7 @@ async def open_modal(ack, body, client):
 # Pass a function to this method
 app.shortcut("open_modal")(open_modal)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/interactivity/shortcuts">https://api.slack.com/interactivity/shortcuts</a> for details about Shortcuts.</p>
+<p>Refer to <a href="https://docs.slack.dev/interactivity/implementing-shortcuts/">https://docs.slack.dev/interactivity/implementing-shortcuts/</a> for details about Shortcuts.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2930,7 +2930,7 @@ Refer to <a href="https://docs.aiohttp.org/">https://docs.aiohttp.org/</a> for m
     &#34;&#34;&#34;
     Deprecated:
         Steps from apps for legacy workflows are now deprecated.
-        Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
     Registers a new step from app listener.
 
@@ -2948,7 +2948,7 @@ Refer to <a href="https://docs.aiohttp.org/">https://docs.aiohttp.org/</a> for m
         # Pass Step to set up listeners
         app.step(ws)
 
-    Refer to https://api.slack.com/workflows/steps for details of steps from apps.
+    Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details of steps from apps.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
     For further information about AsyncWorkflowStep specific function arguments
@@ -2964,7 +2964,7 @@ Refer to <a href="https://docs.aiohttp.org/">https://docs.aiohttp.org/</a> for m
     warnings.warn(
         (
             &#34;Steps from apps for legacy workflows are now deprecated. &#34;
-            &#34;Use new custom steps: https://api.slack.com/automation/functions/custom-bolt&#34;
+            &#34;Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/&#34;
         ),
         category=DeprecationWarning,
     )
@@ -2986,7 +2986,7 @@ Refer to <a href="https://docs.aiohttp.org/">https://docs.aiohttp.org/</a> for m
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>Registers a new step from app listener.</p>
 <p>Unlike others, this method doesn't behave as a decorator.
 If you want to register a step from app by a decorator, use <code>AsyncWorkflowStepBuilder</code>'s methods.</p>
@@ -3001,7 +3001,7 @@ ws = AsyncWorkflowStep(
 # Pass Step to set up listeners
 app.step(ws)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/workflows/steps">https://api.slack.com/workflows/steps</a> for details of steps from apps.</p>
+<p>Refer to <a href="https://docs.slack.dev/legacy/legacy-steps-from-apps/">https://docs.slack.dev/legacy/legacy-steps-from-apps/</a> for details of steps from apps.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.
 For further information about AsyncWorkflowStep specific function arguments
 such as <code>configure</code>, <code>update</code>, <code>complete</code>, and <code>fail</code>,
@@ -3069,7 +3069,7 @@ refer to the <code>async</code> prefixed ones in <code><a title="slack_bolt.work
         # Pass a function to this method
         app.view(&#34;view_1&#34;)(handle_submission)
 
-    Refer to https://api.slack.com/reference/interaction-payloads/views for details of payloads.
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload for details of payloads.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`&#39;s API document.
 
@@ -3110,7 +3110,7 @@ async def handle_submission(ack, body, client, view):
 # Pass a function to this method
 app.view("view_1")(handle_submission)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/reference/interaction-payloads/views">https://api.slack.com/reference/interaction-payloads/views</a> for details of payloads.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload</a> for details of payloads.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.async_args" href="kwargs_injection/async_args.html">slack_bolt.kwargs_injection.async_args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -3139,7 +3139,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
     &#34;&#34;&#34;Registers a new `view_closed` listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/views#view_closed for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -3149,7 +3149,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>view_closed</code> listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#view_closed">https://api.slack.com/reference/interaction-payloads/views#view_closed</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.async_app.AsyncApp.view_submission"><code class="name flex">
 <span>def <span class="ident">view_submission</span></span>(<span>self,<br>constraints: str | Pattern,<br>matchers: Sequence[Callable[..., Awaitable[bool]]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.async_middleware.AsyncMiddleware" href="middleware/async_middleware.html#slack_bolt.middleware.async_middleware.AsyncMiddleware">AsyncMiddleware</a>] | None = None) ‑> Callable[..., Callable[..., Awaitable[<a title="slack_bolt.response.response.BoltResponse" href="response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None]] | None]</span>
@@ -3166,7 +3166,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#vie
     middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
     &#34;&#34;&#34;Registers a new `view_submission` listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/views#view_submission for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -3176,7 +3176,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#vie
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>view_submission</code> listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#view_submission">https://api.slack.com/reference/interaction-payloads/views#view_submission</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.async_app.AsyncApp.web_app"><code class="name flex">
 <span>def <span class="ident">web_app</span></span>(<span>self, path: str = '/slack/events', port: int = 3000) ‑> aiohttp.web_app.Application</span>

--- a/docs/reference/authorization/index.html
+++ b/docs/reference/authorization/index.html
@@ -39,7 +39,7 @@ el.replaceWith(d);
 <section id="section-intro">
 <p>Authorization is the process of determining which Slack credentials should be available
 while processing an incoming Slack event.</p>
-<p>Refer to <a href="https://slack.dev/bolt-python/concepts#authorization">https://slack.dev/bolt-python/concepts#authorization</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/bolt-python/concepts/authorization">https://docs.slack.dev/tools/bolt-python/concepts/authorization</a> for details.</p>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>

--- a/docs/reference/context/assistant/thread_context_store/file/index.html
+++ b/docs/reference/context/assistant/thread_context_store/file/index.html
@@ -48,7 +48,7 @@ el.replaceWith(d);
 <dl>
 <dt id="slack_bolt.context.assistant.thread_context_store.file.FileAssistantThreadContextStore"><code class="flex name class">
 <span>class <span class="ident">FileAssistantThreadContextStore</span></span>
-<span>(</span><span>base_dir: str = '/Users/wbergamin/.bolt-app-assistant-thread-contexts')</span>
+<span>(</span><span>base_dir: str = '/Users/eden.zimbelman/.bolt-app-assistant-thread-contexts')</span>
 </code></dt>
 <dd>
 <details class="source">

--- a/docs/reference/context/index.html
+++ b/docs/reference/context/index.html
@@ -40,7 +40,7 @@ el.replaceWith(d);
 <p>All listeners have access to a context dictionary, which can be used to enrich events with additional information.
 Bolt automatically attaches information that is included in the incoming event,
 like <code>user_id</code>, <code>team_id</code>, <code>channel_id</code>, and <code>enterprise_id</code>.</p>
-<p>Refer to <a href="https://slack.dev/bolt-python/concepts#context">https://slack.dev/bolt-python/concepts#context</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/bolt-python/concepts/context">https://docs.slack.dev/tools/bolt-python/concepts/context</a> for details.</p>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -36,9 +36,9 @@ el.replaceWith(d);
 <h1 class="title">Package <code>slack_bolt</code></h1>
 </header>
 <section id="section-intro">
-<p>A Python framework to build Slack apps in a flash with the latest platform features.Read the <a href="https://slack.dev/bolt-python/tutorial/getting-started">getting started guide</a> and look at our <a href="https://github.com/slackapi/bolt-python/tree/main/examples">code examples</a> to learn how to build apps using Bolt.</p>
+<p>A Python framework to build Slack apps in a flash with the latest platform features.Read the <a href="https://docs.slack.dev/tools/bolt-python/building-an-app">getting started guide</a> and look at our <a href="https://github.com/slackapi/bolt-python/tree/main/examples">code examples</a> to learn how to build apps using Bolt.</p>
 <ul>
-<li>Website: <a href="https://slack.dev/bolt-python/">https://slack.dev/bolt-python/</a></li>
+<li>Website: <a href="https://docs.slack.dev/tools/bolt-python/">https://docs.slack.dev/tools/bolt-python/</a></li>
 <li>GitHub repository: <a href="https://github.com/slackapi/bolt-python">https://github.com/slackapi/bolt-python</a></li>
 <li>The class representing a Bolt app: <code><a title="slack_bolt.app.app" href="app/app.html">slack_bolt.app.app</a></code></li>
 </ul>
@@ -257,10 +257,10 @@ if the execution chain should continue running the following middleware …</p><
             if __name__ == &#34;__main__&#34;:
                 app.start(port=int(os.environ.get(&#34;PORT&#34;, 3000)))
 
-        Refer to https://slack.dev/bolt-python/tutorial/getting-started for details.
+        Refer to https://docs.slack.dev/tools/bolt-python/building-an-app for details.
 
         If you would like to build an OAuth app for enabling the app to run with multiple workspaces,
-        refer to https://slack.dev/bolt-python/concepts#authenticating-oauth to learn how to configure the app.
+        refer to https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth to learn how to configure the app.
 
         Args:
             logger: The custom logger that can be used in this app.
@@ -769,7 +769,7 @@ if the execution chain should continue running the following middleware …</p><
             # Pass a function to this method
             app.middleware(middleware_func)
 
-        Refer to https://slack.dev/bolt-python/concepts#global-middleware for details.
+        Refer to https://docs.slack.dev/tools/bolt-python/concepts/global-middleware for details.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -815,7 +815,7 @@ if the execution chain should continue running the following middleware …</p><
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new step from app listener.
 
@@ -833,7 +833,7 @@ if the execution chain should continue running the following middleware …</p><
             # Pass Step to set up listeners
             app.step(ws)
 
-        Refer to https://api.slack.com/workflows/steps for details of steps from apps.
+        Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details of steps from apps.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -850,7 +850,7 @@ if the execution chain should continue running the following middleware …</p><
         warnings.warn(
             (
                 &#34;Steps from apps for legacy workflows are now deprecated. &#34;
-                &#34;Use new custom steps: https://api.slack.com/automation/functions/custom-bolt&#34;
+                &#34;Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/&#34;
             ),
             category=DeprecationWarning,
         )
@@ -927,7 +927,7 @@ if the execution chain should continue running the following middleware …</p><
             # Pass a function to this method
             app.event(&#34;team_join&#34;)(ask_for_introduction)
 
-        Refer to https://api.slack.com/apis/connections/events-api for details of Events API.
+        Refer to https://docs.slack.dev/apis/events-api/ for details of Events API.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -965,7 +965,7 @@ if the execution chain should continue running the following middleware …</p><
             # Pass a function to this method
             app.message(&#34;:wave:&#34;)(say_hello)
 
-        Refer to https://api.slack.com/events/message for details of `message` events.
+        Refer to https://docs.slack.dev/reference/events/message/ for details of `message` events.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1076,7 +1076,7 @@ if the execution chain should continue running the following middleware …</p><
             # Pass a function to this method
             app.command(&#34;/echo&#34;)(repeat_text)
 
-        Refer to https://api.slack.com/interactivity/slash-commands for details of Slash Commands.
+        Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details of Slash Commands.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1123,7 +1123,7 @@ if the execution chain should continue running the following middleware …</p><
             # Pass a function to this method
             app.shortcut(&#34;open_modal&#34;)(open_modal)
 
-        Refer to https://api.slack.com/interactivity/shortcuts for details about Shortcuts.
+        Refer to https://docs.slack.dev/interactivity/implementing-shortcuts/ for details about Shortcuts.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1191,9 +1191,9 @@ if the execution chain should continue running the following middleware …</p><
             # Pass a function to this method
             app.action(&#34;approve_button&#34;)(update_message)
 
-        * Refer to https://api.slack.com/reference/interaction-payloads/block-actions for actions in `blocks`.
-        * Refer to https://api.slack.com/legacy/message-buttons for actions in `attachments`.
-        * Refer to https://api.slack.com/dialogs for actions in dialogs.
+        * Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for actions in `blocks`.
+        * Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for actions in `attachments`.
+        * Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for actions in dialogs.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1219,7 +1219,7 @@ if the execution chain should continue running the following middleware …</p><
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `block_actions` action listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/block-actions for details.
+        Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for details.
         &#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
@@ -1236,7 +1236,7 @@ if the execution chain should continue running the following middleware …</p><
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `interactive_message` action listener.
-        Refer to https://api.slack.com/legacy/message-buttons for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1252,7 +1252,7 @@ if the execution chain should continue running the following middleware …</p><
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `dialog_submission` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1268,7 +1268,7 @@ if the execution chain should continue running the following middleware …</p><
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `dialog_cancellation` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1309,7 +1309,7 @@ if the execution chain should continue running the following middleware …</p><
             # Pass a function to this method
             app.view(&#34;view_1&#34;)(handle_submission)
 
-        Refer to https://api.slack.com/reference/interaction-payloads/views for details of payloads.
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload for details of payloads.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1335,7 +1335,7 @@ if the execution chain should continue running the following middleware …</p><
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `view_submission` listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/views#view_submission for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1351,7 +1351,7 @@ if the execution chain should continue running the following middleware …</p><
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `view_closed` listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/views#view_closed for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1392,8 +1392,8 @@ if the execution chain should continue running the following middleware …</p><
 
         Refer to the following documents for details:
 
-        * https://api.slack.com/reference/block-kit/block-elements#external_select
-        * https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+        * https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
+        * https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1433,7 +1433,7 @@ if the execution chain should continue running the following middleware …</p><
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         &#34;&#34;&#34;Registers a new `dialog_suggestion` listener.
-        Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1583,9 +1583,9 @@ def message_hello(message, say):
 if __name__ == "__main__":
     app.start(port=int(os.environ.get("PORT", 3000)))
 </code></pre>
-<p>Refer to <a href="https://slack.dev/bolt-python/tutorial/getting-started">https://slack.dev/bolt-python/tutorial/getting-started</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/bolt-python/building-an-app">https://docs.slack.dev/tools/bolt-python/building-an-app</a> for details.</p>
 <p>If you would like to build an OAuth app for enabling the app to run with multiple workspaces,
-refer to <a href="https://slack.dev/bolt-python/concepts#authenticating-oauth">https://slack.dev/bolt-python/concepts#authenticating-oauth</a> to learn how to configure the app.</p>
+refer to <a href="https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth">https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth</a> to learn how to configure the app.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>logger</code></strong></dt>
@@ -1777,9 +1777,9 @@ def process_before_response(self) -&gt; bool:
         # Pass a function to this method
         app.action(&#34;approve_button&#34;)(update_message)
 
-    * Refer to https://api.slack.com/reference/interaction-payloads/block-actions for actions in `blocks`.
-    * Refer to https://api.slack.com/legacy/message-buttons for actions in `attachments`.
-    * Refer to https://api.slack.com/dialogs for actions in dialogs.
+    * Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for actions in `blocks`.
+    * Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for actions in `attachments`.
+    * Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for actions in dialogs.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1808,9 +1808,9 @@ def update_message(ack):
 app.action("approve_button")(update_message)
 </code></pre>
 <ul>
-<li>Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-actions">https://api.slack.com/reference/interaction-payloads/block-actions</a> for actions in <code>blocks</code>.</li>
-<li>Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slack.com/legacy/message-buttons</a> for actions in <code>attachments</code>.</li>
-<li>Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for actions in dialogs.</li>
+<li>Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/">https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/</a> for actions in <code>blocks</code>.</li>
+<li>Refer to <a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/">https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/</a> for actions in <code>attachments</code>.</li>
+<li>Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for actions in dialogs.</li>
 </ul>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
@@ -1853,7 +1853,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `interactive_message` action listener.
-    Refer to https://api.slack.com/legacy/message-buttons for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1863,7 +1863,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>interactive_message</code> action listener.
-Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slack.com/legacy/message-buttons</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/">https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.App.block_action"><code class="name flex">
 <span>def <span class="ident">block_action</span></span>(<span>self,<br>constraints: str | Pattern | Dict[str, str | Pattern],<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -1880,7 +1880,7 @@ Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slac
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `block_actions` action listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/block-actions for details.
+    Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for details.
     &#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
@@ -1891,7 +1891,7 @@ Refer to <a href="https://api.slack.com/legacy/message-buttons">https://api.slac
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>block_actions</code> action listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-actions">https://api.slack.com/reference/interaction-payloads/block-actions</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/">https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.App.block_suggestion"><code class="name flex">
 <span>def <span class="ident">block_suggestion</span></span>(<span>self,<br>action_id: str | Pattern,<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -1945,7 +1945,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/block-act
         # Pass a function to this method
         app.command(&#34;/echo&#34;)(repeat_text)
 
-    Refer to https://api.slack.com/interactivity/slash-commands for details of Slash Commands.
+    Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details of Slash Commands.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -1976,7 +1976,7 @@ def repeat_text(ack, say, command):
 # Pass a function to this method
 app.command("/echo")(repeat_text)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/interactivity/slash-commands">https://api.slack.com/interactivity/slash-commands</a> for details of Slash Commands.</p>
+<p>Refer to <a href="https://docs.slack.dev/interactivity/implementing-slash-commands/">https://docs.slack.dev/interactivity/implementing-slash-commands/</a> for details of Slash Commands.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2039,7 +2039,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `dialog_cancellation` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -2049,7 +2049,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_cancellation</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.App.dialog_submission"><code class="name flex">
 <span>def <span class="ident">dialog_submission</span></span>(<span>self,<br>callback_id: str | Pattern,<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -2066,7 +2066,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `dialog_submission` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -2076,7 +2076,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_submission</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.App.dialog_suggestion"><code class="name flex">
 <span>def <span class="ident">dialog_suggestion</span></span>(<span>self,<br>callback_id: str | Pattern,<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -2093,7 +2093,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `dialog_suggestion` listener.
-    Refer to https://api.slack.com/dialogs for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -2103,7 +2103,7 @@ Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>dialog_suggestion</code> listener.
-Refer to <a href="https://api.slack.com/dialogs">https://api.slack.com/dialogs</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-dialogs/">https://docs.slack.dev/legacy/legacy-dialogs/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.App.dispatch"><code class="name flex">
 <span>def <span class="ident">dispatch</span></span>(<span>self,<br>req: <a title="slack_bolt.request.request.BoltRequest" href="request/request.html#slack_bolt.request.request.BoltRequest">BoltRequest</a>) ‑> <a title="slack_bolt.response.response.BoltResponse" href="response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a></span>
@@ -2329,7 +2329,7 @@ when getting an unhandled error in Bolt app.</dd>
         # Pass a function to this method
         app.event(&#34;team_join&#34;)(ask_for_introduction)
 
-    Refer to https://api.slack.com/apis/connections/events-api for details of Events API.
+    Refer to https://docs.slack.dev/apis/events-api/ for details of Events API.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2361,7 +2361,7 @@ def ask_for_introduction(event, say):
 # Pass a function to this method
 app.event("team_join")(ask_for_introduction)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/apis/connections/events-api">https://api.slack.com/apis/connections/events-api</a> for details of Events API.</p>
+<p>Refer to <a href="https://docs.slack.dev/apis/events-api/">https://docs.slack.dev/apis/events-api/</a> for details of Events API.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2513,7 +2513,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
         # Pass a function to this method
         app.message(&#34;:wave:&#34;)(say_hello)
 
-    Refer to https://api.slack.com/events/message for details of `message` events.
+    Refer to https://docs.slack.dev/reference/events/message/ for details of `message` events.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2564,7 +2564,7 @@ def say_hello(message, say):
 # Pass a function to this method
 app.message(":wave:")(say_hello)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/events/message">https://api.slack.com/events/message</a> for details of <code>message</code> events.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/events/message/">https://docs.slack.dev/reference/events/message/</a> for details of <code>message</code> events.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2624,7 +2624,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
         # Pass a function to this method
         app.middleware(middleware_func)
 
-    Refer to https://slack.dev/bolt-python/concepts#global-middleware for details.
+    Refer to https://docs.slack.dev/tools/bolt-python/concepts/global-middleware for details.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2662,7 +2662,7 @@ def middleware_func(logger, body, next):
 # Pass a function to this method
 app.middleware(middleware_func)
 </code></pre>
-<p>Refer to <a href="https://slack.dev/bolt-python/concepts#global-middleware">https://slack.dev/bolt-python/concepts#global-middleware</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/bolt-python/concepts/global-middleware">https://docs.slack.dev/tools/bolt-python/concepts/global-middleware</a> for details.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2707,8 +2707,8 @@ app.middleware(middleware_func)
 
     Refer to the following documents for details:
 
-    * https://api.slack.com/reference/block-kit/block-elements#external_select
-    * https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+    * https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
+    * https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2748,8 +2748,8 @@ app.options("menu_selection")(show_menu_options)
 </code></pre>
 <p>Refer to the following documents for details:</p>
 <ul>
-<li><a href="https://api.slack.com/reference/block-kit/block-elements#external_select">https://api.slack.com/reference/block-kit/block-elements#external_select</a></li>
-<li><a href="https://api.slack.com/reference/block-kit/block-elements#external_multi_select">https://api.slack.com/reference/block-kit/block-elements#external_multi_select</a></li>
+<li><a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select</a></li>
+<li><a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select</a></li>
 </ul>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
@@ -2795,7 +2795,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
         # Pass a function to this method
         app.shortcut(&#34;open_modal&#34;)(open_modal)
 
-    Refer to https://api.slack.com/interactivity/shortcuts for details about Shortcuts.
+    Refer to https://docs.slack.dev/interactivity/implementing-shortcuts/ for details about Shortcuts.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2832,7 +2832,7 @@ def open_modal(ack, body, client):
 # Pass a function to this method
 app.shortcut("open_modal")(open_modal)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/interactivity/shortcuts">https://api.slack.com/interactivity/shortcuts</a> for details about Shortcuts.</p>
+<p>Refer to <a href="https://docs.slack.dev/interactivity/implementing-shortcuts/">https://docs.slack.dev/interactivity/implementing-shortcuts/</a> for details about Shortcuts.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -2918,7 +2918,7 @@ For production, consider using a production-ready WSGI server such as Gunicorn.<
     &#34;&#34;&#34;
     Deprecated:
         Steps from apps for legacy workflows are now deprecated.
-        Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
     Registers a new step from app listener.
 
@@ -2936,7 +2936,7 @@ For production, consider using a production-ready WSGI server such as Gunicorn.<
         # Pass Step to set up listeners
         app.step(ws)
 
-    Refer to https://api.slack.com/workflows/steps for details of steps from apps.
+    Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details of steps from apps.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -2953,7 +2953,7 @@ For production, consider using a production-ready WSGI server such as Gunicorn.<
     warnings.warn(
         (
             &#34;Steps from apps for legacy workflows are now deprecated. &#34;
-            &#34;Use new custom steps: https://api.slack.com/automation/functions/custom-bolt&#34;
+            &#34;Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/&#34;
         ),
         category=DeprecationWarning,
     )
@@ -2975,7 +2975,7 @@ For production, consider using a production-ready WSGI server such as Gunicorn.<
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>Registers a new step from app listener.</p>
 <p>Unlike others, this method doesn't behave as a decorator.
 If you want to register a step from app by a decorator, use <code>WorkflowStepBuilder</code>'s methods.</p>
@@ -2990,7 +2990,7 @@ ws = WorkflowStep(
 # Pass Step to set up listeners
 app.step(ws)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/workflows/steps">https://api.slack.com/workflows/steps</a> for details of steps from apps.</p>
+<p>Refer to <a href="https://docs.slack.dev/legacy/legacy-steps-from-apps/">https://docs.slack.dev/legacy/legacy-steps-from-apps/</a> for details of steps from apps.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <p>For further information about WorkflowStep specific function arguments
 such as <code>configure</code>, <code>update</code>, <code>complete</code>, and <code>fail</code>,
@@ -3061,7 +3061,7 @@ refer to <code><a title="slack_bolt.workflows.step.utilities" href="workflows/st
         # Pass a function to this method
         app.view(&#34;view_1&#34;)(handle_submission)
 
-    Refer to https://api.slack.com/reference/interaction-payloads/views for details of payloads.
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload for details of payloads.
 
     To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`&#39;s API document.
 
@@ -3102,7 +3102,7 @@ def handle_submission(ack, body, client, view):
 # Pass a function to this method
 app.view("view_1")(handle_submission)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/reference/interaction-payloads/views">https://api.slack.com/reference/interaction-payloads/views</a> for details of payloads.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload</a> for details of payloads.</p>
 <p>To learn available arguments for middleware/listeners, see <code><a title="slack_bolt.kwargs_injection.args" href="kwargs_injection/args.html">slack_bolt.kwargs_injection.args</a></code>'s API document.</p>
 <h2 id="args">Args</h2>
 <dl>
@@ -3131,7 +3131,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `view_closed` listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/views#view_closed for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -3141,7 +3141,7 @@ Only when all the middleware call <code>next()</code> method, the listener funct
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>view_closed</code> listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#view_closed">https://api.slack.com/reference/interaction-payloads/views#view_closed</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.App.view_submission"><code class="name flex">
 <span>def <span class="ident">view_submission</span></span>(<span>self,<br>constraints: str | Pattern,<br>matchers: Sequence[Callable[..., bool]] | None = None,<br>middleware: Sequence[Callable | <a title="slack_bolt.middleware.middleware.Middleware" href="middleware/middleware.html#slack_bolt.middleware.middleware.Middleware">Middleware</a>] | None = None) ‑> Callable[..., Callable[..., <a title="slack_bolt.response.response.BoltResponse" href="response/response.html#slack_bolt.response.response.BoltResponse">BoltResponse</a> | None] | None]</span>
@@ -3158,7 +3158,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#vie
     middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
 ) -&gt; Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
     &#34;&#34;&#34;Registers a new `view_submission` listener.
-    Refer to https://api.slack.com/reference/interaction-payloads/views#view_submission for details.&#34;&#34;&#34;
+    Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for details.&#34;&#34;&#34;
 
     def __call__(*args, **kwargs):
         functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -3168,7 +3168,7 @@ Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#vie
     return __call__</code></pre>
 </details>
 <div class="desc"><p>Registers a new <code>view_submission</code> listener.
-Refer to <a href="https://api.slack.com/reference/interaction-payloads/views#view_submission">https://api.slack.com/reference/interaction-payloads/views#view_submission</a> for details.</p></div>
+Refer to <a href="https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission">https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission</a> for details.</p></div>
 </dd>
 </dl>
 </dd>
@@ -5225,7 +5225,7 @@ def set_title(self) -&gt; Optional[SetTitle]:
 </dd>
 <dt id="slack_bolt.FileAssistantThreadContextStore"><code class="flex name class">
 <span>class <span class="ident">FileAssistantThreadContextStore</span></span>
-<span>(</span><span>base_dir: str = '/Users/wbergamin/.bolt-app-assistant-thread-contexts')</span>
+<span>(</span><span>base_dir: str = '/Users/eden.zimbelman/.bolt-app-assistant-thread-contexts')</span>
 </code></dt>
 <dd>
 <details class="source">

--- a/docs/reference/lazy_listener/index.html
+++ b/docs/reference/lazy_listener/index.html
@@ -56,7 +56,7 @@ app.command("/start-process")(
     lazy=[run_long_process]
 )
 </code></pre>
-<p>Refer to <a href="https://slack.dev/bolt-python/concepts#lazy-listeners">https://slack.dev/bolt-python/concepts#lazy-listeners</a> for more details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/bolt-python/concepts/lazy-listeners">https://docs.slack.dev/tools/bolt-python/concepts/lazy-listeners</a> for more details.</p>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>

--- a/docs/reference/listener_matcher/builtins.html
+++ b/docs/reference/listener_matcher/builtins.html
@@ -80,7 +80,7 @@ el.replaceWith(d);
             return dialog_submission(constraints[&#34;callback_id&#34;], asyncio)
         if action_type == &#34;dialog_cancellation&#34;:
             return dialog_cancellation(constraints[&#34;callback_id&#34;], asyncio)
-        # https://api.slack.com/workflows/steps
+        # https://docs.slack.dev/legacy/legacy-steps-from-apps/
         if action_type == &#34;workflow_step_edit&#34;:
             return workflow_step_edit(constraints[&#34;callback_id&#34;], asyncio)
 

--- a/docs/reference/logger/messages.html
+++ b/docs/reference/logger/messages.html
@@ -303,7 +303,7 @@ el.replaceWith(d);
         &#34;Bolt has enabled the file-based InstallationStore/OAuthStateStore for you. &#34;
         &#34;Note that these file-based stores are for local development. &#34;
         &#34;If you&#39;d like to use a different data store, set the oauth_settings argument in the App constructor. &#34;
-        &#34;Please refer to https://slack.dev/bolt-python/concepts#authenticating-oauth for more details.&#34;
+        &#34;Please refer to https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth for more details.&#34;
     )</code></pre>
 </details>
 <div class="desc"></div>

--- a/docs/reference/middleware/async_builtins.html
+++ b/docs/reference/middleware/async_builtins.html
@@ -205,7 +205,7 @@ el.replaceWith(d);
     &#34;&#34;&#34;Verifies an incoming request by checking the validity of
     `x-slack-signature`, `x-slack-request-timestamp`, and its body data.
 
-    Refer to https://api.slack.com/authentication/verifying-requests-from-slack for details.
+    Refer to https://docs.slack.dev/authentication/verifying-requests-from-slack/ for details.
     &#34;&#34;&#34;
 
     async def async_process(
@@ -232,10 +232,10 @@ el.replaceWith(d);
 </details>
 <div class="desc"><p>Verifies an incoming request by checking the validity of
 <code>x-slack-signature</code>, <code>x-slack-request-timestamp</code>, and its body data.</p>
-<p>Refer to <a href="https://api.slack.com/authentication/verifying-requests-from-slack">https://api.slack.com/authentication/verifying-requests-from-slack</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/">https://docs.slack.dev/authentication/verifying-requests-from-slack/</a> for details.</p>
 <p>Verifies an incoming request by checking the validity of
 <code>x-slack-signature</code>, <code>x-slack-request-timestamp</code>, and its body data.</p>
-<p>Refer to <a href="https://api.slack.com/authentication/verifying-requests-from-slack">https://api.slack.com/authentication/verifying-requests-from-slack</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/">https://docs.slack.dev/authentication/verifying-requests-from-slack/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>signing_secret</code></strong></dt>
@@ -293,12 +293,12 @@ el.replaceWith(d);
 </details>
 <div class="desc"><p>A middleware can process request data before other middleware and listener functions.</p>
 <p>Handles <code>ssl_check</code> requests.
-Refer to <a href="https://api.slack.com/interactivity/slash-commands">https://api.slack.com/interactivity/slash-commands</a> for details.</p>
+Refer to <a href="https://docs.slack.dev/interactivity/implementing-slash-commands/">https://docs.slack.dev/interactivity/implementing-slash-commands/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>verification_token</code></strong></dt>
 <dd>The verification token to check
-(optional as it's already deprecated - <a href="https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation">https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation</a>)</dd>
+(optional as it's already deprecated - <a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation">https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation</a>)</dd>
 <dt><strong><code>base_logger</code></strong></dt>
 <dd>The base logger</dd>
 </dl></div>
@@ -352,7 +352,7 @@ Refer to <a href="https://api.slack.com/interactivity/slash-commands">https://ap
 </details>
 <div class="desc"><p>A middleware can process request data before other middleware and listener functions.</p>
 <p>Handles url_verification requests.</p>
-<p>Refer to <a href="https://api.slack.com/events/url_verification">https://api.slack.com/events/url_verification</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/events/url_verification/">https://docs.slack.dev/reference/events/url_verification/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>base_logger</code></strong></dt>

--- a/docs/reference/middleware/index.html
+++ b/docs/reference/middleware/index.html
@@ -639,7 +639,7 @@ def simple_middleware(req, resp, next_):
         &#34;&#34;&#34;Verifies an incoming request by checking the validity of
         `x-slack-signature`, `x-slack-request-timestamp`, and its body data.
 
-        Refer to https://api.slack.com/authentication/verifying-requests-from-slack for details.
+        Refer to https://docs.slack.dev/authentication/verifying-requests-from-slack/ for details.
 
         Args:
             signing_secret: The signing secret
@@ -688,7 +688,7 @@ def simple_middleware(req, resp, next_):
 <div class="desc"><p>A middleware can process request data before other middleware and listener functions.</p>
 <p>Verifies an incoming request by checking the validity of
 <code>x-slack-signature</code>, <code>x-slack-request-timestamp</code>, and its body data.</p>
-<p>Refer to <a href="https://api.slack.com/authentication/verifying-requests-from-slack">https://api.slack.com/authentication/verifying-requests-from-slack</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/">https://docs.slack.dev/authentication/verifying-requests-from-slack/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>signing_secret</code></strong></dt>
@@ -834,11 +834,11 @@ def simple_middleware(req, resp, next_):
         base_logger: Optional[Logger] = None,
     ):
         &#34;&#34;&#34;Handles `ssl_check` requests.
-        Refer to https://api.slack.com/interactivity/slash-commands for details.
+        Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details.
 
         Args:
             verification_token: The verification token to check
-                (optional as it&#39;s already deprecated - https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation)
+                (optional as it&#39;s already deprecated - https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation)
             base_logger: The base logger
         &#34;&#34;&#34;  # noqa: E501
         self.verification_token = verification_token
@@ -880,12 +880,12 @@ def simple_middleware(req, resp, next_):
 </details>
 <div class="desc"><p>A middleware can process request data before other middleware and listener functions.</p>
 <p>Handles <code><a title="slack_bolt.middleware.ssl_check" href="ssl_check/index.html">slack_bolt.middleware.ssl_check</a></code> requests.
-Refer to <a href="https://api.slack.com/interactivity/slash-commands">https://api.slack.com/interactivity/slash-commands</a> for details.</p>
+Refer to <a href="https://docs.slack.dev/interactivity/implementing-slash-commands/">https://docs.slack.dev/interactivity/implementing-slash-commands/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>verification_token</code></strong></dt>
 <dd>The verification token to check
-(optional as it's already deprecated - <a href="https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation">https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation</a>)</dd>
+(optional as it's already deprecated - <a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation">https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation</a>)</dd>
 <dt><strong><code>base_logger</code></strong></dt>
 <dd>The base logger</dd>
 </dl></div>
@@ -931,7 +931,7 @@ Refer to <a href="https://api.slack.com/interactivity/slash-commands">https://ap
     def __init__(self, base_logger: Optional[Logger] = None):
         &#34;&#34;&#34;Handles url_verification requests.
 
-        Refer to https://api.slack.com/events/url_verification for details.
+        Refer to https://docs.slack.dev/reference/events/url_verification/ for details.
 
         Args:
             base_logger: The base logger
@@ -965,7 +965,7 @@ Refer to <a href="https://api.slack.com/interactivity/slash-commands">https://ap
 </details>
 <div class="desc"><p>A middleware can process request data before other middleware and listener functions.</p>
 <p>Handles url_verification requests.</p>
-<p>Refer to <a href="https://api.slack.com/events/url_verification">https://api.slack.com/events/url_verification</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/events/url_verification/">https://docs.slack.dev/reference/events/url_verification/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>base_logger</code></strong></dt>

--- a/docs/reference/middleware/request_verification/async_request_verification.html
+++ b/docs/reference/middleware/request_verification/async_request_verification.html
@@ -59,7 +59,7 @@ el.replaceWith(d);
     &#34;&#34;&#34;Verifies an incoming request by checking the validity of
     `x-slack-signature`, `x-slack-request-timestamp`, and its body data.
 
-    Refer to https://api.slack.com/authentication/verifying-requests-from-slack for details.
+    Refer to https://docs.slack.dev/authentication/verifying-requests-from-slack/ for details.
     &#34;&#34;&#34;
 
     async def async_process(
@@ -86,10 +86,10 @@ el.replaceWith(d);
 </details>
 <div class="desc"><p>Verifies an incoming request by checking the validity of
 <code>x-slack-signature</code>, <code>x-slack-request-timestamp</code>, and its body data.</p>
-<p>Refer to <a href="https://api.slack.com/authentication/verifying-requests-from-slack">https://api.slack.com/authentication/verifying-requests-from-slack</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/">https://docs.slack.dev/authentication/verifying-requests-from-slack/</a> for details.</p>
 <p>Verifies an incoming request by checking the validity of
 <code>x-slack-signature</code>, <code>x-slack-request-timestamp</code>, and its body data.</p>
-<p>Refer to <a href="https://api.slack.com/authentication/verifying-requests-from-slack">https://api.slack.com/authentication/verifying-requests-from-slack</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/">https://docs.slack.dev/authentication/verifying-requests-from-slack/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>signing_secret</code></strong></dt>

--- a/docs/reference/middleware/request_verification/index.html
+++ b/docs/reference/middleware/request_verification/index.html
@@ -71,7 +71,7 @@ el.replaceWith(d);
         &#34;&#34;&#34;Verifies an incoming request by checking the validity of
         `x-slack-signature`, `x-slack-request-timestamp`, and its body data.
 
-        Refer to https://api.slack.com/authentication/verifying-requests-from-slack for details.
+        Refer to https://docs.slack.dev/authentication/verifying-requests-from-slack/ for details.
 
         Args:
             signing_secret: The signing secret
@@ -120,7 +120,7 @@ el.replaceWith(d);
 <div class="desc"><p>A middleware can process request data before other middleware and listener functions.</p>
 <p>Verifies an incoming request by checking the validity of
 <code>x-slack-signature</code>, <code>x-slack-request-timestamp</code>, and its body data.</p>
-<p>Refer to <a href="https://api.slack.com/authentication/verifying-requests-from-slack">https://api.slack.com/authentication/verifying-requests-from-slack</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/">https://docs.slack.dev/authentication/verifying-requests-from-slack/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>signing_secret</code></strong></dt>

--- a/docs/reference/middleware/request_verification/request_verification.html
+++ b/docs/reference/middleware/request_verification/request_verification.html
@@ -60,7 +60,7 @@ el.replaceWith(d);
         &#34;&#34;&#34;Verifies an incoming request by checking the validity of
         `x-slack-signature`, `x-slack-request-timestamp`, and its body data.
 
-        Refer to https://api.slack.com/authentication/verifying-requests-from-slack for details.
+        Refer to https://docs.slack.dev/authentication/verifying-requests-from-slack/ for details.
 
         Args:
             signing_secret: The signing secret
@@ -109,7 +109,7 @@ el.replaceWith(d);
 <div class="desc"><p>A middleware can process request data before other middleware and listener functions.</p>
 <p>Verifies an incoming request by checking the validity of
 <code>x-slack-signature</code>, <code>x-slack-request-timestamp</code>, and its body data.</p>
-<p>Refer to <a href="https://api.slack.com/authentication/verifying-requests-from-slack">https://api.slack.com/authentication/verifying-requests-from-slack</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/">https://docs.slack.dev/authentication/verifying-requests-from-slack/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>signing_secret</code></strong></dt>

--- a/docs/reference/middleware/ssl_check/async_ssl_check.html
+++ b/docs/reference/middleware/ssl_check/async_ssl_check.html
@@ -75,12 +75,12 @@ el.replaceWith(d);
 </details>
 <div class="desc"><p>A middleware can process request data before other middleware and listener functions.</p>
 <p>Handles <code>ssl_check</code> requests.
-Refer to <a href="https://api.slack.com/interactivity/slash-commands">https://api.slack.com/interactivity/slash-commands</a> for details.</p>
+Refer to <a href="https://docs.slack.dev/interactivity/implementing-slash-commands/">https://docs.slack.dev/interactivity/implementing-slash-commands/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>verification_token</code></strong></dt>
 <dd>The verification token to check
-(optional as it's already deprecated - <a href="https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation">https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation</a>)</dd>
+(optional as it's already deprecated - <a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation">https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation</a>)</dd>
 <dt><strong><code>base_logger</code></strong></dt>
 <dd>The base logger</dd>
 </dl></div>

--- a/docs/reference/middleware/ssl_check/index.html
+++ b/docs/reference/middleware/ssl_check/index.html
@@ -76,11 +76,11 @@ el.replaceWith(d);
         base_logger: Optional[Logger] = None,
     ):
         &#34;&#34;&#34;Handles `ssl_check` requests.
-        Refer to https://api.slack.com/interactivity/slash-commands for details.
+        Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details.
 
         Args:
             verification_token: The verification token to check
-                (optional as it&#39;s already deprecated - https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation)
+                (optional as it&#39;s already deprecated - https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation)
             base_logger: The base logger
         &#34;&#34;&#34;  # noqa: E501
         self.verification_token = verification_token
@@ -122,12 +122,12 @@ el.replaceWith(d);
 </details>
 <div class="desc"><p>A middleware can process request data before other middleware and listener functions.</p>
 <p>Handles <code><a title="slack_bolt.middleware.ssl_check.ssl_check" href="ssl_check.html">slack_bolt.middleware.ssl_check.ssl_check</a></code> requests.
-Refer to <a href="https://api.slack.com/interactivity/slash-commands">https://api.slack.com/interactivity/slash-commands</a> for details.</p>
+Refer to <a href="https://docs.slack.dev/interactivity/implementing-slash-commands/">https://docs.slack.dev/interactivity/implementing-slash-commands/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>verification_token</code></strong></dt>
 <dd>The verification token to check
-(optional as it's already deprecated - <a href="https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation">https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation</a>)</dd>
+(optional as it's already deprecated - <a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation">https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation</a>)</dd>
 <dt><strong><code>base_logger</code></strong></dt>
 <dd>The base logger</dd>
 </dl></div>

--- a/docs/reference/middleware/ssl_check/ssl_check.html
+++ b/docs/reference/middleware/ssl_check/ssl_check.html
@@ -65,11 +65,11 @@ el.replaceWith(d);
         base_logger: Optional[Logger] = None,
     ):
         &#34;&#34;&#34;Handles `ssl_check` requests.
-        Refer to https://api.slack.com/interactivity/slash-commands for details.
+        Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details.
 
         Args:
             verification_token: The verification token to check
-                (optional as it&#39;s already deprecated - https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation)
+                (optional as it&#39;s already deprecated - https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation)
             base_logger: The base logger
         &#34;&#34;&#34;  # noqa: E501
         self.verification_token = verification_token
@@ -111,12 +111,12 @@ el.replaceWith(d);
 </details>
 <div class="desc"><p>A middleware can process request data before other middleware and listener functions.</p>
 <p>Handles <code>ssl_check</code> requests.
-Refer to <a href="https://api.slack.com/interactivity/slash-commands">https://api.slack.com/interactivity/slash-commands</a> for details.</p>
+Refer to <a href="https://docs.slack.dev/interactivity/implementing-slash-commands/">https://docs.slack.dev/interactivity/implementing-slash-commands/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>verification_token</code></strong></dt>
 <dd>The verification token to check
-(optional as it's already deprecated - <a href="https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation">https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation</a>)</dd>
+(optional as it's already deprecated - <a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation">https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation</a>)</dd>
 <dt><strong><code>base_logger</code></strong></dt>
 <dd>The base logger</dd>
 </dl></div>

--- a/docs/reference/middleware/url_verification/async_url_verification.html
+++ b/docs/reference/middleware/url_verification/async_url_verification.html
@@ -73,7 +73,7 @@ el.replaceWith(d);
 </details>
 <div class="desc"><p>A middleware can process request data before other middleware and listener functions.</p>
 <p>Handles url_verification requests.</p>
-<p>Refer to <a href="https://api.slack.com/events/url_verification">https://api.slack.com/events/url_verification</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/events/url_verification/">https://docs.slack.dev/reference/events/url_verification/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>base_logger</code></strong></dt>

--- a/docs/reference/middleware/url_verification/index.html
+++ b/docs/reference/middleware/url_verification/index.html
@@ -70,7 +70,7 @@ el.replaceWith(d);
     def __init__(self, base_logger: Optional[Logger] = None):
         &#34;&#34;&#34;Handles url_verification requests.
 
-        Refer to https://api.slack.com/events/url_verification for details.
+        Refer to https://docs.slack.dev/reference/events/url_verification/ for details.
 
         Args:
             base_logger: The base logger
@@ -104,7 +104,7 @@ el.replaceWith(d);
 </details>
 <div class="desc"><p>A middleware can process request data before other middleware and listener functions.</p>
 <p>Handles url_verification requests.</p>
-<p>Refer to <a href="https://api.slack.com/events/url_verification">https://api.slack.com/events/url_verification</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/events/url_verification/">https://docs.slack.dev/reference/events/url_verification/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>base_logger</code></strong></dt>

--- a/docs/reference/middleware/url_verification/url_verification.html
+++ b/docs/reference/middleware/url_verification/url_verification.html
@@ -59,7 +59,7 @@ el.replaceWith(d);
     def __init__(self, base_logger: Optional[Logger] = None):
         &#34;&#34;&#34;Handles url_verification requests.
 
-        Refer to https://api.slack.com/events/url_verification for details.
+        Refer to https://docs.slack.dev/reference/events/url_verification/ for details.
 
         Args:
             base_logger: The base logger
@@ -93,7 +93,7 @@ el.replaceWith(d);
 </details>
 <div class="desc"><p>A middleware can process request data before other middleware and listener functions.</p>
 <p>Handles url_verification requests.</p>
-<p>Refer to <a href="https://api.slack.com/events/url_verification">https://api.slack.com/events/url_verification</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/reference/events/url_verification/">https://docs.slack.dev/reference/events/url_verification/</a> for details.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>base_logger</code></strong></dt>

--- a/docs/reference/oauth/index.html
+++ b/docs/reference/oauth/index.html
@@ -37,7 +37,7 @@ el.replaceWith(d);
 </header>
 <section id="section-intro">
 <p>Slack OAuth flow support for building an app that is installable in any workspaces.</p>
-<p>Refer to <a href="https://slack.dev/bolt-python/concepts#authenticating-oauth">https://slack.dev/bolt-python/concepts#authenticating-oauth</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth">https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth</a> for details.</p>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>

--- a/docs/reference/request/index.html
+++ b/docs/reference/request/index.html
@@ -37,7 +37,7 @@ el.replaceWith(d);
 </header>
 <section id="section-intro">
 <p>Incoming request from Slack through either HTTP request or Socket Mode connection.</p>
-<p>Refer to <a href="https://api.slack.com/apis/connections">https://api.slack.com/apis/connections</a> for the two types of connections.
+<p>Refer to <a href="https://docs.slack.dev/apis/events-api/">https://docs.slack.dev/apis/events-api/</a> for the two types of connections.
 This interface encapsulates the difference between the two.</p>
 </section>
 <section>

--- a/docs/reference/response/index.html
+++ b/docs/reference/response/index.html
@@ -39,7 +39,7 @@ el.replaceWith(d);
 <p>This interface represents Bolt's synchronous response to Slack.</p>
 <p>In Socket Mode, the response data can be transformed to a WebSocket message. In the HTTP endpoint mode,
 the response data becomes an HTTP response data.</p>
-<p>Refer to <a href="https://api.slack.com/apis/connections">https://api.slack.com/apis/connections</a> for the two types of connections.</p>
+<p>Refer to <a href="https://docs.slack.dev/apis/events-api/">https://docs.slack.dev/apis/events-api/</a> for the two types of connections.</p>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>

--- a/docs/reference/workflows/index.html
+++ b/docs/reference/workflows/index.html
@@ -43,7 +43,7 @@ el.replaceWith(d);
 <li><code><a title="slack_bolt.workflows.step.utilities" href="step/utilities/index.html">slack_bolt.workflows.step.utilities</a></code></li>
 <li><code><a title="slack_bolt.workflows.step.async_step" href="step/async_step.html">slack_bolt.workflows.step.async_step</a></code> (if you use asyncio-based <code>AsyncApp</code>)</li>
 </ul>
-<p>Refer to <a href="https://api.slack.com/workflows/steps">https://api.slack.com/workflows/steps</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/legacy/legacy-steps-from-apps/">https://docs.slack.dev/legacy/legacy-steps-from-apps/</a> for details.</p>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>

--- a/docs/reference/workflows/step/async_step.html
+++ b/docs/reference/workflows/step/async_step.html
@@ -78,7 +78,7 @@ el.replaceWith(d);
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Args:
             callback_id: The callback_id for this step from app
@@ -124,7 +124,7 @@ el.replaceWith(d);
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
         &#34;&#34;&#34;
         return AsyncWorkflowStepBuilder(callback_id, base_logger=base_logger)
 
@@ -200,7 +200,7 @@ el.replaceWith(d);
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>callback_id</code></strong></dt>
@@ -252,7 +252,7 @@ When it's a list, the first one is responsible for ack() while the rest are lazy
 <dd>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p></div>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p></div>
 </dd>
 </dl>
 </dd>
@@ -267,7 +267,7 @@ Use new custom steps: <a href="https://api.slack.com/automation/functions/custom
 </summary>
 <pre><code class="python">class AsyncWorkflowStepBuilder:
     &#34;&#34;&#34;Steps from apps
-    Refer to https://api.slack.com/workflows/steps for details.
+    Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details.
     &#34;&#34;&#34;
 
     callback_id: Union[str, Pattern]
@@ -285,7 +285,7 @@ Use new custom steps: <a href="https://api.slack.com/automation/functions/custom
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         This builder is supposed to be used as decorator.
 
@@ -327,7 +327,7 @@ Use new custom steps: <a href="https://api.slack.com/automation/functions/custom
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new edit listener with details.
 
@@ -380,7 +380,7 @@ Use new custom steps: <a href="https://api.slack.com/automation/functions/custom
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new save listener with details.
 
@@ -433,7 +433,7 @@ Use new custom steps: <a href="https://api.slack.com/automation/functions/custom
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new execute listener with details.
 
@@ -480,7 +480,7 @@ Use new custom steps: <a href="https://api.slack.com/automation/functions/custom
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Constructs a WorkflowStep object. This method may raise an exception
         if the builder doesn&#39;t have enough configurations to build the object.
@@ -555,10 +555,10 @@ Use new custom steps: <a href="https://api.slack.com/automation/functions/custom
         return _middleware</code></pre>
 </details>
 <div class="desc"><p>Steps from apps
-Refer to <a href="https://api.slack.com/workflows/steps">https://api.slack.com/workflows/steps</a> for details.</p>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-steps-from-apps/">https://docs.slack.dev/legacy/legacy-steps-from-apps/</a> for details.</p>
 <h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>This builder is supposed to be used as decorator.</p>
 <pre><code>my_step = AsyncWorkflowStep.builder("my_step")
 @my_step.edit
@@ -659,7 +659,7 @@ def to_listener_middleware(
     &#34;&#34;&#34;
     Deprecated:
         Steps from apps for legacy workflows are now deprecated.
-        Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
     Constructs a WorkflowStep object. This method may raise an exception
     if the builder doesn&#39;t have enough configurations to build the object.
@@ -685,7 +685,7 @@ def to_listener_middleware(
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>Constructs a WorkflowStep object. This method may raise an exception
 if the builder doesn't have enough configurations to build the object.</p>
 <h2 id="returns">Returns</h2>
@@ -709,7 +709,7 @@ if the builder doesn't have enough configurations to build the object.</p>
     &#34;&#34;&#34;
     Deprecated:
         Steps from apps for legacy workflows are now deprecated.
-        Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
     Registers a new edit listener with details.
 
@@ -754,7 +754,7 @@ if the builder doesn't have enough configurations to build the object.</p>
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>Registers a new edit listener with details.</p>
 <p>You can use this method as decorator as well.</p>
 <pre><code>@my_step.edit
@@ -799,7 +799,7 @@ refer to the <code>async</code> prefixed ones in <code><a title="slack_bolt.work
     &#34;&#34;&#34;
     Deprecated:
         Steps from apps for legacy workflows are now deprecated.
-        Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
     Registers a new execute listener with details.
 
@@ -844,7 +844,7 @@ refer to the <code>async</code> prefixed ones in <code><a title="slack_bolt.work
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>Registers a new execute listener with details.</p>
 <p>You can use this method as decorator as well.</p>
 <pre><code>@my_step.execute
@@ -889,7 +889,7 @@ refer to the <code>async</code> prefixed ones in <code><a title="slack_bolt.work
     &#34;&#34;&#34;
     Deprecated:
         Steps from apps for legacy workflows are now deprecated.
-        Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
     Registers a new save listener with details.
 
@@ -934,7 +934,7 @@ refer to the <code>async</code> prefixed ones in <code><a title="slack_bolt.work
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>Registers a new save listener with details.</p>
 <p>You can use this method as decorator as well.</p>
 <pre><code>@my_step.save

--- a/docs/reference/workflows/step/index.html
+++ b/docs/reference/workflows/step/index.html
@@ -174,7 +174,7 @@ Refer to <a href="https://api.slack.com/methods/workflows.stepCompleted">https:/
         )
         app.step(ws)
 
-    Refer to https://api.slack.com/workflows/steps for details.
+    Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details.
     &#34;&#34;&#34;
 
     def __init__(self, *, callback_id: str, client: WebClient, body: dict):
@@ -219,7 +219,7 @@ ws = WorkflowStep(
 )
 app.step(ws)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/workflows/steps">https://api.slack.com/workflows/steps</a> for details.</p></div>
+<p>Refer to <a href="https://docs.slack.dev/legacy/legacy-steps-from-apps/">https://docs.slack.dev/legacy/legacy-steps-from-apps/</a> for details.</p></div>
 </dd>
 <dt id="slack_bolt.workflows.step.Fail"><code class="flex name class">
 <span>class <span class="ident">Fail</span></span>
@@ -411,7 +411,7 @@ Refer to <a href="https://api.slack.com/methods/workflows.updateStep">https://ap
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Args:
             callback_id: The callback_id for this step from app
@@ -453,7 +453,7 @@ Refer to <a href="https://api.slack.com/methods/workflows.updateStep">https://ap
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
         &#34;&#34;&#34;
         return WorkflowStepBuilder(
             callback_id,
@@ -546,7 +546,7 @@ Refer to <a href="https://api.slack.com/methods/workflows.updateStep">https://ap
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>callback_id</code></strong></dt>
@@ -598,7 +598,7 @@ When it's a list, the first one is responsible for ack() while the rest are lazy
 <dd>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p></div>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p></div>
 </dd>
 </dl>
 </dd>

--- a/docs/reference/workflows/step/step.html
+++ b/docs/reference/workflows/step/step.html
@@ -78,7 +78,7 @@ el.replaceWith(d);
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Args:
             callback_id: The callback_id for this step from app
@@ -120,7 +120,7 @@ el.replaceWith(d);
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
         &#34;&#34;&#34;
         return WorkflowStepBuilder(
             callback_id,
@@ -213,7 +213,7 @@ el.replaceWith(d);
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>callback_id</code></strong></dt>
@@ -265,7 +265,7 @@ When it's a list, the first one is responsible for ack() while the rest are lazy
 <dd>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p></div>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p></div>
 </dd>
 </dl>
 </dd>
@@ -280,7 +280,7 @@ Use new custom steps: <a href="https://api.slack.com/automation/functions/custom
 </summary>
 <pre><code class="python">class WorkflowStepBuilder:
     &#34;&#34;&#34;Steps from apps
-    Refer to https://api.slack.com/workflows/steps for details.
+    Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details.
     &#34;&#34;&#34;
 
     callback_id: Union[str, Pattern]
@@ -298,7 +298,7 @@ Use new custom steps: <a href="https://api.slack.com/automation/functions/custom
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         This builder is supposed to be used as decorator.
 
@@ -340,7 +340,7 @@ Use new custom steps: <a href="https://api.slack.com/automation/functions/custom
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new edit listener with details.
 
@@ -394,7 +394,7 @@ Use new custom steps: <a href="https://api.slack.com/automation/functions/custom
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new save listener with details.
 
@@ -447,7 +447,7 @@ Use new custom steps: <a href="https://api.slack.com/automation/functions/custom
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new execute listener with details.
 
@@ -494,7 +494,7 @@ Use new custom steps: <a href="https://api.slack.com/automation/functions/custom
         &#34;&#34;&#34;
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Constructs a WorkflowStep object. This method may raise an exception
         if the builder doesn&#39;t have enough configurations to build the object.
@@ -584,10 +584,10 @@ Use new custom steps: <a href="https://api.slack.com/automation/functions/custom
         return _middleware</code></pre>
 </details>
 <div class="desc"><p>Steps from apps
-Refer to <a href="https://api.slack.com/workflows/steps">https://api.slack.com/workflows/steps</a> for details.</p>
+Refer to <a href="https://docs.slack.dev/legacy/legacy-steps-from-apps/">https://docs.slack.dev/legacy/legacy-steps-from-apps/</a> for details.</p>
 <h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>This builder is supposed to be used as decorator.</p>
 <pre><code>my_step = WorkflowStep.builder("my_step")
 @my_step.edit
@@ -703,7 +703,7 @@ def to_listener_middleware(
     &#34;&#34;&#34;
     Deprecated:
         Steps from apps for legacy workflows are now deprecated.
-        Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
     Constructs a WorkflowStep object. This method may raise an exception
     if the builder doesn&#39;t have enough configurations to build the object.
@@ -729,7 +729,7 @@ def to_listener_middleware(
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>Constructs a WorkflowStep object. This method may raise an exception
 if the builder doesn't have enough configurations to build the object.</p>
 <h2 id="returns">Returns</h2>
@@ -753,7 +753,7 @@ if the builder doesn't have enough configurations to build the object.</p>
     &#34;&#34;&#34;
     Deprecated:
         Steps from apps for legacy workflows are now deprecated.
-        Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
     Registers a new edit listener with details.
 
@@ -799,7 +799,7 @@ if the builder doesn't have enough configurations to build the object.</p>
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>Registers a new edit listener with details.</p>
 <p>You can use this method as decorator as well.</p>
 <pre><code>@my_step.edit
@@ -844,7 +844,7 @@ refer to <code><a title="slack_bolt.workflows.step.utilities" href="utilities/in
     &#34;&#34;&#34;
     Deprecated:
         Steps from apps for legacy workflows are now deprecated.
-        Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
     Registers a new execute listener with details.
 
@@ -889,7 +889,7 @@ refer to <code><a title="slack_bolt.workflows.step.utilities" href="utilities/in
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>Registers a new execute listener with details.</p>
 <p>You can use this method as decorator as well.</p>
 <pre><code>@my_step.execute
@@ -934,7 +934,7 @@ refer to <code><a title="slack_bolt.workflows.step.utilities" href="utilities/in
     &#34;&#34;&#34;
     Deprecated:
         Steps from apps for legacy workflows are now deprecated.
-        Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+        Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
     Registers a new save listener with details.
 
@@ -979,7 +979,7 @@ refer to <code><a title="slack_bolt.workflows.step.utilities" href="utilities/in
 </details>
 <div class="desc"><h2 id="deprecated">Deprecated</h2>
 <p>Steps from apps for legacy workflows are now deprecated.
-Use new custom steps: <a href="https://api.slack.com/automation/functions/custom-bolt">https://api.slack.com/automation/functions/custom-bolt</a></p>
+Use new custom steps: <a href="https://docs.slack.dev/workflows/workflow-steps/">https://docs.slack.dev/workflows/workflow-steps/</a></p>
 <p>Registers a new save listener with details.</p>
 <p>You can use this method as decorator as well.</p>
 <pre><code>@my_step.save

--- a/docs/reference/workflows/step/utilities/async_configure.html
+++ b/docs/reference/workflows/step/utilities/async_configure.html
@@ -83,7 +83,7 @@ el.replaceWith(d);
         )
         app.step(ws)
 
-    Refer to https://api.slack.com/workflows/steps for details.
+    Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details.
     &#34;&#34;&#34;
 
     def __init__(self, *, callback_id: str, client: AsyncWebClient, body: dict):
@@ -131,7 +131,7 @@ ws = AsyncWorkflowStep(
 )
 app.step(ws)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/workflows/steps">https://api.slack.com/workflows/steps</a> for details.</p></div>
+<p>Refer to <a href="https://docs.slack.dev/legacy/legacy-steps-from-apps/">https://docs.slack.dev/legacy/legacy-steps-from-apps/</a> for details.</p></div>
 </dd>
 </dl>
 </section>

--- a/docs/reference/workflows/step/utilities/configure.html
+++ b/docs/reference/workflows/step/utilities/configure.html
@@ -83,7 +83,7 @@ el.replaceWith(d);
         )
         app.step(ws)
 
-    Refer to https://api.slack.com/workflows/steps for details.
+    Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details.
     &#34;&#34;&#34;
 
     def __init__(self, *, callback_id: str, client: WebClient, body: dict):
@@ -128,7 +128,7 @@ ws = WorkflowStep(
 )
 app.step(ws)
 </code></pre>
-<p>Refer to <a href="https://api.slack.com/workflows/steps">https://api.slack.com/workflows/steps</a> for details.</p></div>
+<p>Refer to <a href="https://docs.slack.dev/legacy/legacy-steps-from-apps/">https://docs.slack.dev/legacy/legacy-steps-from-apps/</a> for details.</p></div>
 </dd>
 </dl>
 </section>

--- a/examples/aws_lambda/README.md
+++ b/examples/aws_lambda/README.md
@@ -32,16 +32,16 @@ Instructions on how to set up and deploy each example are provided below.
       `lazy_aws_lambda_config.yaml`
   - Optionally enter a description for the role, such as "Bolt Python basic
       role"
-3. Ensure you have created an app on api.slack.com/apps as per the [Getting
-   Started Guide](https://slack.dev/bolt-python/tutorial/getting-started).
+3. Ensure you have created an app on api.slack.com/apps as per the
+   [Building an App](https://docs.slack.dev/tools/bolt-python/building-an-app) guide.
    Ensure you have installed it to a workspace.
 4. Ensure you have exported your Slack Bot Token and Slack Signing Secret for your
    apps as the environment variables `SLACK_BOT_TOKEN` and
-   `SLACK_SIGNING_SECRET`, respectively, as per the [Getting
-   Started Guide](https://slack.dev/bolt-python/tutorial/getting-started).
+   `SLACK_SIGNING_SECRET`, respectively, as per the
+   [Building an App](https://docs.slack.dev/tools/bolt-python/building-an-app) guide.
 5. You may want to create a dedicated virtual environment for this example app, as
-   per the "Setting up your project" section of the [Getting
-   Started Guide](https://slack.dev/bolt-python/tutorial/getting-started).
+   per the "Setting up your project" section of the
+   [Building an App](https://docs.slack.dev/tools/bolt-python/building-an-app) guide.
 6. Let's deploy the Lambda! Run `./deploy_lazy.sh`. By default it deploys to the
    us-east-1 region in AWS - you can change this at the top of `lazy_aws_lambda_config.yaml` if you wish.
 7. Load up AWS Lambda inside the AWS Console - make sure you are in the correct
@@ -150,7 +150,7 @@ Let’s create a user role that will use the custom policy we created as well as
     3. "Create Role"
 
 ### Create Slack App and Load your Lambda to AWS
-Ensure you have created an app on [api.slack.com/apps](https://api.slack.com/apps) as per the [Getting Started Guide](https://slack.dev/bolt-python/tutorial/getting-started). You do not need to ensure you have installed it to a workspace, as the OAuth flow will provide your app the ability to be installed by anyone.
+Ensure you have created an app on [api.slack.com/apps](https://api.slack.com/apps) as per the [Building an App](https://docs.slack.dev/tools/bolt-python/building-an-app) guide. You do not need to ensure you have installed it to a workspace, as the OAuth flow will provide your app the ability to be installed by anyone.
 
 1. Remember those S3 buckets we made? You will need the names of these buckets again in the next step.
 2. You need many environment variables exported! Specifically the following from api.slack.com/apps

--- a/examples/django/README.md
+++ b/examples/django/README.md
@@ -4,7 +4,7 @@ This example demonstrates how you can use Bolt for Python in your Django applica
 
 ### `simple_app` - Single-workspace App Example
 
-If you want to run a simple app like the one you've tried in the [Getting Started Guide](https://slack.dev/bolt-python/tutorial/getting-started), this is the right one for you. By default, this Django project runs this application. If you want to switch to OAuth flow supported one, modify `myslackapp/urls.py`.
+If you want to run a simple app like the one you've tried in the [Building an App](https://docs.slack.dev/tools/bolt-python/building-an-app) guide, this is the right one for you. By default, this Django project runs this application. If you want to switch to OAuth flow supported one, modify `myslackapp/urls.py`.
 
 To run this app, all you need to do are:
 
@@ -31,7 +31,7 @@ python manage.py migrate
 python manage.py runserver 0.0.0.0:3000
 ```
 
-As you did at [Getting Started Guide](https://slack.dev/bolt-python/tutorial/getting-started), configure ngrok or something similar to serve a public endpoint. Lastly,
+As you did at [Building an App](https://docs.slack.dev/tools/bolt-python/building-an-app) guide, configure ngrok or something similar to serve a public endpoint. Lastly,
 
 * Go back to the Slack app configuration page
 * Go to "Event Subscriptions"
@@ -54,7 +54,7 @@ To run this app, all you need to do are:
 * Create a new Slack app configuration at https://api.slack.com/apps?new_app=1
 * Go to "OAuth & Permissions"
   * Add `app_mentions:read`, `chat:write` in Scopes > Bot Token Scopes
-* Follow the instructions [here](https://slack.dev/bolt-python/concepts#authenticating-oauth) for configuring OAuth flow supported Slack apps
+* Follow the instructions [here](https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth) for configuring OAuth flow supported Slack apps
 
 You can start your Django application this way:
 
@@ -73,7 +73,7 @@ python manage.py migrate
 python manage.py runserver 0.0.0.0:3000
 ```
 
-As you did at [Getting Started Guide](https://slack.dev/bolt-python/tutorial/getting-started), configure ngrok or something similar to serve a public endpoint. Lastly,
+As you did at [Building an App](https://docs.slack.dev/tools/bolt-python/building-an-app) guide, configure ngrok or something similar to serve a public endpoint. Lastly,
 
 * Go back to the Slack app configuration page
 * Go to "Event Subscriptions"

--- a/examples/getting_started/README.md
+++ b/examples/getting_started/README.md
@@ -1,5 +1,5 @@
 # Getting Started with ⚡️ Bolt for Python
-> Slack app example from 📚 [Getting started with Bolt for Python][1]
+> Slack app example from 📚 [Building an App with Bolt for Python][1]
 
 ## Overview
 
@@ -42,6 +42,6 @@ ngrok http 3000
 python3 app.py
 ```
 
-[1]: https://slack.dev/bolt-python/tutorial/getting-started
-[2]: https://slack.dev/bolt-python/
-[3]: https://slack.dev/bolt-python/tutorial/getting-started#setting-up-events
+[1]: https://docs.slack.dev/tools/bolt-python/building-an-app
+[2]: https://docs.slack.dev/tools/bolt-python/
+[3]: https://docs.slack.dev/tools/bolt-python/building-an-app#setting-up-events

--- a/examples/message_events.py
+++ b/examples/message_events.py
@@ -32,7 +32,7 @@ def extract_subtype(body: dict, context: BoltContext, next: Callable):
     next()
 
 
-# https://api.slack.com/events/message
+# https://docs.slack.dev/reference/events/message/
 # Newly posted messages only
 # or @app.event("message")
 @app.event({"type": "message", "subtype": None})
@@ -55,8 +55,8 @@ def detect_deletion(say: Say, body: dict):
     say(f"You've deleted a message: {text}")
 
 
-# https://api.slack.com/events/message/file_share
-# https://api.slack.com/events/message/bot_message
+# https://docs.slack.dev/reference/events/message/file_share
+# https://docs.slack.dev/reference/events/message/bot_message
 @app.event(
     event={"type": "message", "subtype": re.compile("(me_message)|(file_share)")},
     middleware=[extract_subtype],

--- a/examples/readme_app.py
+++ b/examples/readme_app.py
@@ -16,13 +16,13 @@ def log_request(logger, body, next):
     return next()
 
 
-# Events API: https://api.slack.com/events-api
+# Events API: https://docs.slack.dev/apis/events-api/
 @app.event("app_mention")
 def event_test(say):
     say("What's up?")
 
 
-# Interactivity: https://api.slack.com/interactivity
+# Interactivity: https://docs.slack.dev/interactivity/
 @app.shortcut("callback-id-here")
 # @app.command("/hello-bolt-python")
 def open_modal(ack, client, logger, body):

--- a/examples/readme_async_app.py
+++ b/examples/readme_async_app.py
@@ -28,13 +28,13 @@ async def log_request(logger, body, next):
     return await next()
 
 
-# Events API: https://api.slack.com/events-api
+# Events API: https://docs.slack.dev/apis/events-api/
 @app.event("app_mention")
 async def event_test(say):
     await say("What's up?")
 
 
-# Interactivity: https://api.slack.com/interactivity
+# Interactivity: https://docs.slack.dev/interactivity/
 @app.shortcut("callback-id-here")
 # @app.command("/hello-bolt-python")
 async def open_modal(ack, client, logger, body):

--- a/examples/workflow_steps/async_steps_from_apps.py
+++ b/examples/workflow_steps/async_steps_from_apps.py
@@ -11,7 +11,7 @@ from slack_bolt.workflows.step.async_step import (
 
 ################################################################################
 # Steps from apps for legacy workflows are now deprecated.                     #
-# Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
+# Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/       #
 ################################################################################
 
 logging.basicConfig(level=logging.DEBUG)

--- a/examples/workflow_steps/async_steps_from_apps_decorator.py
+++ b/examples/workflow_steps/async_steps_from_apps_decorator.py
@@ -13,7 +13,7 @@ from slack_bolt.workflows.step.async_step import (
 
 ################################################################################
 # Steps from apps for legacy workflows are now deprecated.                     #
-# Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
+# Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/       #
 ################################################################################
 
 logging.basicConfig(level=logging.DEBUG)

--- a/examples/workflow_steps/async_steps_from_apps_primitive.py
+++ b/examples/workflow_steps/async_steps_from_apps_primitive.py
@@ -5,7 +5,7 @@ from slack_bolt.async_app import AsyncApp, AsyncAck
 
 ################################################################################
 # Steps from apps for legacy workflows are now deprecated.                     #
-# Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
+# Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/       #
 ################################################################################
 
 logging.basicConfig(level=logging.DEBUG)

--- a/examples/workflow_steps/steps_from_apps.py
+++ b/examples/workflow_steps/steps_from_apps.py
@@ -8,7 +8,7 @@ from slack_bolt.workflows.step import Configure, Update, Complete, Fail
 
 ################################################################################
 # Steps from apps for legacy workflows are now deprecated.                     #
-# Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
+# Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/       #
 ################################################################################
 
 logging.basicConfig(level=logging.DEBUG)

--- a/examples/workflow_steps/steps_from_apps_decorator.py
+++ b/examples/workflow_steps/steps_from_apps_decorator.py
@@ -9,7 +9,7 @@ from slack_bolt.workflows.step import Configure, Update, Complete, Fail, Workflo
 
 ################################################################################
 # Steps from apps for legacy workflows are now deprecated.                     #
-# Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
+# Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/       #
 ################################################################################
 
 logging.basicConfig(level=logging.DEBUG)

--- a/examples/workflow_steps/steps_from_apps_primitive.py
+++ b/examples/workflow_steps/steps_from_apps_primitive.py
@@ -7,7 +7,7 @@ from slack_bolt import App, Ack
 
 ################################################################################
 # Steps from apps for legacy workflows are now deprecated.                     #
-# Use new custom steps: https://api.slack.com/automation/functions/custom-bolt #
+# Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/       #
 ################################################################################
 
 logging.basicConfig(level=logging.DEBUG)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = ["slack_sdk>=3.35.0,<4"]
 
 
 [project.urls]
-Documentation = "https://slack.dev/bolt-python"
+Documentation = "https://docs.slack.dev/tools/bolt-python/"
 
 [tool.setuptools.packages.find]
 include = ["slack_bolt*"]

--- a/slack_bolt/__init__.py
+++ b/slack_bolt/__init__.py
@@ -1,7 +1,7 @@
 """
-A Python framework to build Slack apps in a flash with the latest platform features.Read the [getting started guide](https://slack.dev/bolt-python/tutorial/getting-started) and look at our [code examples](https://github.com/slackapi/bolt-python/tree/main/examples) to learn how to build apps using Bolt.
+A Python framework to build Slack apps in a flash with the latest platform features.Read the [getting started guide](https://docs.slack.dev/tools/bolt-python/building-an-app) and look at our [code examples](https://github.com/slackapi/bolt-python/tree/main/examples) to learn how to build apps using Bolt.
 
-* Website: https://slack.dev/bolt-python/
+* Website: https://docs.slack.dev/tools/bolt-python/
 * GitHub repository: https://github.com/slackapi/bolt-python
 * The class representing a Bolt app: `slack_bolt.app.app`
 """  # noqa: E501

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -1237,7 +1237,9 @@ class App:
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `view_submission` listener.
-        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for details."""
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for
+        details.
+        """
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -159,10 +159,10 @@ class App:
             if __name__ == "__main__":
                 app.start(port=int(os.environ.get("PORT", 3000)))
 
-        Refer to https://slack.dev/bolt-python/tutorial/getting-started for details.
+        Refer to https://docs.slack.dev/tools/bolt-python/building-an-app for details.
 
         If you would like to build an OAuth app for enabling the app to run with multiple workspaces,
-        refer to https://slack.dev/bolt-python/concepts#authenticating-oauth to learn how to configure the app.
+        refer to https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth to learn how to configure the app.
 
         Args:
             logger: The custom logger that can be used in this app.
@@ -671,7 +671,7 @@ class App:
             # Pass a function to this method
             app.middleware(middleware_func)
 
-        Refer to https://slack.dev/bolt-python/concepts#global-middleware for details.
+        Refer to https://docs.slack.dev/tools/bolt-python/concepts/global-middleware for details.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`'s API document.
 
@@ -717,7 +717,7 @@ class App:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new step from app listener.
 
@@ -735,7 +735,7 @@ class App:
             # Pass Step to set up listeners
             app.step(ws)
 
-        Refer to https://api.slack.com/workflows/steps for details of steps from apps.
+        Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details of steps from apps.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`'s API document.
 
@@ -752,7 +752,7 @@ class App:
         warnings.warn(
             (
                 "Steps from apps for legacy workflows are now deprecated. "
-                "Use new custom steps: https://api.slack.com/automation/functions/custom-bolt"
+                "Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/"
             ),
             category=DeprecationWarning,
         )
@@ -829,7 +829,7 @@ class App:
             # Pass a function to this method
             app.event("team_join")(ask_for_introduction)
 
-        Refer to https://api.slack.com/apis/connections/events-api for details of Events API.
+        Refer to https://docs.slack.dev/apis/events-api/ for details of Events API.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`'s API document.
 
@@ -867,7 +867,7 @@ class App:
             # Pass a function to this method
             app.message(":wave:")(say_hello)
 
-        Refer to https://api.slack.com/events/message for details of `message` events.
+        Refer to https://docs.slack.dev/reference/events/message/ for details of `message` events.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`'s API document.
 
@@ -978,7 +978,7 @@ class App:
             # Pass a function to this method
             app.command("/echo")(repeat_text)
 
-        Refer to https://api.slack.com/interactivity/slash-commands for details of Slash Commands.
+        Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details of Slash Commands.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`'s API document.
 
@@ -1025,7 +1025,7 @@ class App:
             # Pass a function to this method
             app.shortcut("open_modal")(open_modal)
 
-        Refer to https://api.slack.com/interactivity/shortcuts for details about Shortcuts.
+        Refer to https://docs.slack.dev/interactivity/implementing-shortcuts/ for details about Shortcuts.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`'s API document.
 
@@ -1093,9 +1093,9 @@ class App:
             # Pass a function to this method
             app.action("approve_button")(update_message)
 
-        * Refer to https://api.slack.com/reference/interaction-payloads/block-actions for actions in `blocks`.
-        * Refer to https://api.slack.com/legacy/message-buttons for actions in `attachments`.
-        * Refer to https://api.slack.com/dialogs for actions in dialogs.
+        * Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for actions in `blocks`.
+        * Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for actions in `attachments`.
+        * Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for actions in dialogs.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`'s API document.
 
@@ -1121,7 +1121,7 @@ class App:
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `block_actions` action listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/block-actions for details.
+        Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for details.
         """
 
         def __call__(*args, **kwargs):
@@ -1138,7 +1138,7 @@ class App:
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `interactive_message` action listener.
-        Refer to https://api.slack.com/legacy/message-buttons for details."""
+        Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for details."""
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1154,7 +1154,7 @@ class App:
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `dialog_submission` listener.
-        Refer to https://api.slack.com/dialogs for details."""
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details."""
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1170,7 +1170,7 @@ class App:
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `dialog_cancellation` listener.
-        Refer to https://api.slack.com/dialogs for details."""
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details."""
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1211,7 +1211,7 @@ class App:
             # Pass a function to this method
             app.view("view_1")(handle_submission)
 
-        Refer to https://api.slack.com/reference/interaction-payloads/views for details of payloads.
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload for details of payloads.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`'s API document.
 
@@ -1237,7 +1237,7 @@ class App:
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `view_submission` listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/views#view_submission for details."""
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for details."""
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1253,7 +1253,7 @@ class App:
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `view_closed` listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/views#view_closed for details."""
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed for details."""
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1294,8 +1294,8 @@ class App:
 
         Refer to the following documents for details:
 
-        * https://api.slack.com/reference/block-kit/block-elements#external_select
-        * https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+        * https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
+        * https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.args`'s API document.
 
@@ -1335,7 +1335,7 @@ class App:
         middleware: Optional[Sequence[Union[Callable, Middleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Optional[BoltResponse]]]]:
         """Registers a new `dialog_suggestion` listener.
-        Refer to https://api.slack.com/dialogs for details."""
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details."""
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -1266,7 +1266,9 @@ class AsyncApp:
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `view_submission` listener.
-        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for details."""
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for
+        details.
+        """
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -165,10 +165,10 @@ class AsyncApp:
             if __name__ == "__main__":
                 app.start(port=int(os.environ.get("PORT", 3000)))
 
-        Refer to https://slack.dev/bolt-python/concepts#async for details.
+        Refer to https://docs.slack.dev/tools/bolt-python/concepts/async for details.
 
         If you would like to build an OAuth app for enabling the app to run with multiple workspaces,
-        refer to https://slack.dev/bolt-python/concepts#authenticating-oauth to learn how to configure the app.
+        refer to https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth to learn how to configure the app.
 
         Args:
             logger: The custom logger that can be used in this app.
@@ -738,7 +738,7 @@ class AsyncApp:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new step from app listener.
 
@@ -756,7 +756,7 @@ class AsyncApp:
             # Pass Step to set up listeners
             app.step(ws)
 
-        Refer to https://api.slack.com/workflows/steps for details of steps from apps.
+        Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details of steps from apps.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`'s API document.
         For further information about AsyncWorkflowStep specific function arguments
@@ -772,7 +772,7 @@ class AsyncApp:
         warnings.warn(
             (
                 "Steps from apps for legacy workflows are now deprecated. "
-                "Use new custom steps: https://api.slack.com/automation/functions/custom-bolt"
+                "Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/"
             ),
             category=DeprecationWarning,
         )
@@ -854,7 +854,7 @@ class AsyncApp:
             # Pass a function to this method
             app.event("team_join")(ask_for_introduction)
 
-        Refer to https://api.slack.com/apis/connections/events-api for details of Events API.
+        Refer to https://docs.slack.dev/apis/events-api/ for details of Events API.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`'s API document.
 
@@ -892,7 +892,7 @@ class AsyncApp:
             # Pass a function to this method
             app.message(":wave:")(say_hello)
 
-        Refer to https://api.slack.com/events/message for details of `message` events.
+        Refer to https://docs.slack.dev/reference/events/message/ for details of `message` events.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`'s API document.
 
@@ -1007,7 +1007,7 @@ class AsyncApp:
             # Pass a function to this method
             app.command("/echo")(repeat_text)
 
-        Refer to https://api.slack.com/interactivity/slash-commands for details of Slash Commands.
+        Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details of Slash Commands.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`'s API document.
 
@@ -1054,7 +1054,7 @@ class AsyncApp:
             # Pass a function to this method
             app.shortcut("open_modal")(open_modal)
 
-        Refer to https://api.slack.com/interactivity/shortcuts for details about Shortcuts.
+        Refer to https://docs.slack.dev/interactivity/implementing-shortcuts/ for details about Shortcuts.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`'s API document.
 
@@ -1122,9 +1122,9 @@ class AsyncApp:
             # Pass a function to this method
             app.action("approve_button")(update_message)
 
-        * Refer to https://api.slack.com/reference/interaction-payloads/block-actions for actions in `blocks`.
-        * Refer to https://api.slack.com/legacy/message-buttons for actions in `attachments`.
-        * Refer to https://api.slack.com/dialogs for actions in dialogs.
+        * Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for actions in `blocks`.
+        * Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for actions in `attachments`.
+        * Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for actions in dialogs.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`'s API document.
 
@@ -1150,7 +1150,7 @@ class AsyncApp:
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `block_actions` action listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/block-actions for details.
+        Refer to https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/ for details.
         """
 
         def __call__(*args, **kwargs):
@@ -1167,7 +1167,7 @@ class AsyncApp:
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `interactive_message` action listener.
-        Refer to https://api.slack.com/legacy/message-buttons for details."""
+        Refer to https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/ for details."""
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1183,7 +1183,7 @@ class AsyncApp:
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `dialog_submission` listener.
-        Refer to https://api.slack.com/dialogs for details."""
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details."""
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1199,7 +1199,7 @@ class AsyncApp:
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `dialog_submission` listener.
-        Refer to https://api.slack.com/dialogs for details."""
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details."""
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1240,7 +1240,7 @@ class AsyncApp:
             # Pass a function to this method
             app.view("view_1")(handle_submission)
 
-        Refer to https://api.slack.com/reference/interaction-payloads/views for details of payloads.
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload for details of payloads.
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`'s API document.
 
@@ -1266,7 +1266,7 @@ class AsyncApp:
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `view_submission` listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/views#view_submission for details."""
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission for details."""
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1282,7 +1282,7 @@ class AsyncApp:
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `view_closed` listener.
-        Refer to https://api.slack.com/reference/interaction-payloads/views#view_closed for details."""
+        Refer to https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed for details."""
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)
@@ -1323,8 +1323,8 @@ class AsyncApp:
 
         Refer to the following documents for details:
 
-        * https://api.slack.com/reference/block-kit/block-elements#external_select
-        * https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+        * https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
+        * https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
         To learn available arguments for middleware/listeners, see `slack_bolt.kwargs_injection.async_args`'s API document.
 
@@ -1364,7 +1364,7 @@ class AsyncApp:
         middleware: Optional[Sequence[Union[Callable, AsyncMiddleware]]] = None,
     ) -> Callable[..., Optional[Callable[..., Awaitable[Optional[BoltResponse]]]]]:
         """Registers a new `dialog_suggestion` listener.
-        Refer to https://api.slack.com/dialogs for details."""
+        Refer to https://docs.slack.dev/legacy/legacy-dialogs/ for details."""
 
         def __call__(*args, **kwargs):
             functions = self._to_listener_functions(kwargs) if kwargs else list(args)

--- a/slack_bolt/authorization/__init__.py
+++ b/slack_bolt/authorization/__init__.py
@@ -1,7 +1,7 @@
 """Authorization is the process of determining which Slack credentials should be available
 while processing an incoming Slack event.
 
-Refer to https://slack.dev/bolt-python/concepts#authorization for details.
+Refer to https://docs.slack.dev/tools/bolt-python/concepts/authorization for details.
 """
 
 from .authorize_result import AuthorizeResult

--- a/slack_bolt/context/__init__.py
+++ b/slack_bolt/context/__init__.py
@@ -2,7 +2,7 @@
 Bolt automatically attaches information that is included in the incoming event,
 like `user_id`, `team_id`, `channel_id`, and `enterprise_id`.
 
-Refer to https://slack.dev/bolt-python/concepts#context for details.
+Refer to https://docs.slack.dev/tools/bolt-python/concepts/context for details.
 """
 
 # Don't add async module imports here

--- a/slack_bolt/lazy_listener/__init__.py
+++ b/slack_bolt/lazy_listener/__init__.py
@@ -19,7 +19,7 @@
         lazy=[run_long_process]
     )
 
-Refer to https://slack.dev/bolt-python/concepts#lazy-listeners for more details.
+Refer to https://docs.slack.dev/tools/bolt-python/concepts/lazy-listeners for more details.
 """
 
 # Don't add async module imports here

--- a/slack_bolt/listener_matcher/builtins.py
+++ b/slack_bolt/listener_matcher/builtins.py
@@ -294,7 +294,7 @@ def action(
             return dialog_submission(constraints["callback_id"], asyncio)
         if action_type == "dialog_cancellation":
             return dialog_cancellation(constraints["callback_id"], asyncio)
-        # https://api.slack.com/workflows/steps
+        # https://docs.slack.dev/legacy/legacy-steps-from-apps/
         if action_type == "workflow_step_edit":
             return workflow_step_edit(constraints["callback_id"], asyncio)
 

--- a/slack_bolt/logger/messages.py
+++ b/slack_bolt/logger/messages.py
@@ -348,7 +348,7 @@ def info_default_oauth_settings_loaded() -> str:
         "Bolt has enabled the file-based InstallationStore/OAuthStateStore for you. "
         "Note that these file-based stores are for local development. "
         "If you'd like to use a different data store, set the oauth_settings argument in the App constructor. "
-        "Please refer to https://slack.dev/bolt-python/concepts#authenticating-oauth for more details."
+        "Please refer to https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth for more details."
     )
 
 

--- a/slack_bolt/middleware/request_verification/async_request_verification.py
+++ b/slack_bolt/middleware/request_verification/async_request_verification.py
@@ -10,7 +10,7 @@ class AsyncRequestVerification(RequestVerification, AsyncMiddleware):
     """Verifies an incoming request by checking the validity of
     `x-slack-signature`, `x-slack-request-timestamp`, and its body data.
 
-    Refer to https://api.slack.com/authentication/verifying-requests-from-slack for details.
+    Refer to https://docs.slack.dev/authentication/verifying-requests-from-slack/ for details.
     """
 
     async def async_process(

--- a/slack_bolt/middleware/request_verification/request_verification.py
+++ b/slack_bolt/middleware/request_verification/request_verification.py
@@ -14,7 +14,7 @@ class RequestVerification(Middleware):
         """Verifies an incoming request by checking the validity of
         `x-slack-signature`, `x-slack-request-timestamp`, and its body data.
 
-        Refer to https://api.slack.com/authentication/verifying-requests-from-slack for details.
+        Refer to https://docs.slack.dev/authentication/verifying-requests-from-slack/ for details.
 
         Args:
             signing_secret: The signing secret

--- a/slack_bolt/middleware/ssl_check/ssl_check.py
+++ b/slack_bolt/middleware/ssl_check/ssl_check.py
@@ -17,11 +17,11 @@ class SslCheck(Middleware):
         base_logger: Optional[Logger] = None,
     ):
         """Handles `ssl_check` requests.
-        Refer to https://api.slack.com/interactivity/slash-commands for details.
+        Refer to https://docs.slack.dev/interactivity/implementing-slash-commands/ for details.
 
         Args:
             verification_token: The verification token to check
-                (optional as it's already deprecated - https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation)
+                (optional as it's already deprecated - https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation)
             base_logger: The base logger
         """  # noqa: E501
         self.verification_token = verification_token

--- a/slack_bolt/middleware/url_verification/url_verification.py
+++ b/slack_bolt/middleware/url_verification/url_verification.py
@@ -11,7 +11,7 @@ class UrlVerification(Middleware):
     def __init__(self, base_logger: Optional[Logger] = None):
         """Handles url_verification requests.
 
-        Refer to https://api.slack.com/events/url_verification for details.
+        Refer to https://docs.slack.dev/reference/events/url_verification/ for details.
 
         Args:
             base_logger: The base logger

--- a/slack_bolt/oauth/__init__.py
+++ b/slack_bolt/oauth/__init__.py
@@ -1,6 +1,6 @@
 """Slack OAuth flow support for building an app that is installable in any workspaces.
 
-Refer to https://slack.dev/bolt-python/concepts#authenticating-oauth for details.
+Refer to https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth for details.
 """
 
 # Don't add async module imports here

--- a/slack_bolt/request/__init__.py
+++ b/slack_bolt/request/__init__.py
@@ -1,6 +1,6 @@
 """Incoming request from Slack through either HTTP request or Socket Mode connection.
 
-Refer to https://api.slack.com/apis/connections for the two types of connections.
+Refer to https://docs.slack.dev/apis/events-api/ for the two types of connections.
 This interface encapsulates the difference between the two.
 """
 

--- a/slack_bolt/response/__init__.py
+++ b/slack_bolt/response/__init__.py
@@ -3,7 +3,7 @@
 In Socket Mode, the response data can be transformed to a WebSocket message. In the HTTP endpoint mode,
 the response data becomes an HTTP response data.
 
-Refer to https://api.slack.com/apis/connections for the two types of connections.
+Refer to https://docs.slack.dev/apis/events-api/ for the two types of connections.
 """
 
 from .response import BoltResponse

--- a/slack_bolt/workflows/__init__.py
+++ b/slack_bolt/workflows/__init__.py
@@ -6,5 +6,5 @@ Check the following API documents first:
 * `slack_bolt.workflows.step.utilities`
 * `slack_bolt.workflows.step.async_step` (if you use asyncio-based `AsyncApp`)
 
-Refer to https://api.slack.com/workflows/steps for details.
+Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details.
 """

--- a/slack_bolt/workflows/step/async_step.py
+++ b/slack_bolt/workflows/step/async_step.py
@@ -29,7 +29,7 @@ from ...middleware.async_middleware import AsyncMiddleware
 
 class AsyncWorkflowStepBuilder:
     """Steps from apps
-    Refer to https://api.slack.com/workflows/steps for details.
+    Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details.
     """
 
     callback_id: Union[str, Pattern]
@@ -47,7 +47,7 @@ class AsyncWorkflowStepBuilder:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         This builder is supposed to be used as decorator.
 
@@ -89,7 +89,7 @@ class AsyncWorkflowStepBuilder:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new edit listener with details.
 
@@ -142,7 +142,7 @@ class AsyncWorkflowStepBuilder:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new save listener with details.
 
@@ -195,7 +195,7 @@ class AsyncWorkflowStepBuilder:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new execute listener with details.
 
@@ -242,7 +242,7 @@ class AsyncWorkflowStepBuilder:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Constructs a WorkflowStep object. This method may raise an exception
         if the builder doesn't have enough configurations to build the object.
@@ -340,7 +340,7 @@ class AsyncWorkflowStep:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Args:
             callback_id: The callback_id for this step from app
@@ -386,7 +386,7 @@ class AsyncWorkflowStep:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
         """
         return AsyncWorkflowStepBuilder(callback_id, base_logger=base_logger)
 

--- a/slack_bolt/workflows/step/step.py
+++ b/slack_bolt/workflows/step/step.py
@@ -24,7 +24,7 @@ from slack_sdk.web import WebClient
 
 class WorkflowStepBuilder:
     """Steps from apps
-    Refer to https://api.slack.com/workflows/steps for details.
+    Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details.
     """
 
     callback_id: Union[str, Pattern]
@@ -42,7 +42,7 @@ class WorkflowStepBuilder:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         This builder is supposed to be used as decorator.
 
@@ -84,7 +84,7 @@ class WorkflowStepBuilder:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new edit listener with details.
 
@@ -138,7 +138,7 @@ class WorkflowStepBuilder:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new save listener with details.
 
@@ -191,7 +191,7 @@ class WorkflowStepBuilder:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Registers a new execute listener with details.
 
@@ -238,7 +238,7 @@ class WorkflowStepBuilder:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Constructs a WorkflowStep object. This method may raise an exception
         if the builder doesn't have enough configurations to build the object.
@@ -351,7 +351,7 @@ class WorkflowStep:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
 
         Args:
             callback_id: The callback_id for this step from app
@@ -393,7 +393,7 @@ class WorkflowStep:
         """
         Deprecated:
             Steps from apps for legacy workflows are now deprecated.
-            Use new custom steps: https://api.slack.com/automation/functions/custom-bolt
+            Use new custom steps: https://docs.slack.dev/workflows/workflow-steps/
         """
         return WorkflowStepBuilder(
             callback_id,

--- a/slack_bolt/workflows/step/utilities/async_configure.py
+++ b/slack_bolt/workflows/step/utilities/async_configure.py
@@ -32,7 +32,7 @@ class AsyncConfigure:
         )
         app.step(ws)
 
-    Refer to https://api.slack.com/workflows/steps for details.
+    Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details.
     """
 
     def __init__(self, *, callback_id: str, client: AsyncWebClient, body: dict):

--- a/slack_bolt/workflows/step/utilities/configure.py
+++ b/slack_bolt/workflows/step/utilities/configure.py
@@ -32,7 +32,7 @@ class Configure:
         )
         app.step(ws)
 
-    Refer to https://api.slack.com/workflows/steps for details.
+    Refer to https://docs.slack.dev/legacy/legacy-steps-from-apps/ for details.
     """
 
     def __init__(self, *, callback_id: str, client: WebClient, body: dict):

--- a/tests/scenario_tests/test_attachment_actions.py
+++ b/tests/scenario_tests/test_attachment_actions.py
@@ -164,7 +164,7 @@ class TestAttachmentActions:
         assert_auth_test_count(self, 1)
 
 
-# https://api.slack.com/legacy/interactive-messages
+# https://docs.slack.dev/legacy/legacy-messaging/legacy-making-messages-interactive/
 body = {
     "type": "interactive_message",
     "actions": [

--- a/tests/scenario_tests_async/test_attachment_actions.py
+++ b/tests/scenario_tests_async/test_attachment_actions.py
@@ -191,7 +191,7 @@ class TestAsyncAttachmentActions:
         await assert_auth_test_count_async(self, 1)
 
 
-# https://api.slack.com/legacy/interactive-messages
+# https://docs.slack.dev/legacy/legacy-messaging/legacy-making-messages-interactive/
 body = {
     "type": "interactive_message",
     "actions": [


### PR DESCRIPTION
## Summary

This PR replaces links from "api.slack.com" to "docs.slack.dev" redirects for the most current inline reference.

### Reviewers

Open each link! Or trust these replacements and a find and replacement:

<details>
<summary>Replacements</summary>

Note: This should be parsed from the bottom, ignoring lines without a substitute!

```
original_url
https://api.slack.com/apis/connections,https://docs.slack.dev/apis/events-api/
https://api.slack.com/apis/connections/events-api,https://docs.slack.dev/apis/events-api/
https://api.slack.com/authentication/verifying-requests-from-slack,https://docs.slack.dev/authentication/verifying-requests-from-slack/
https://api.slack.com/authentication/verifying-requests-from-slack#verification_token_deprecation,https://docs.slack.dev/authentication/verifying-requests-from-slack/#deprecation
https://api.slack.com/automation/functions/custom-bolt,https://docs.slack.dev/workflows/workflow-steps/
https://api.slack.com/dialogs,https://docs.slack.dev/legacy/legacy-dialogs/
https://api.slack.com/events-api,https://docs.slack.dev/apis/events-api/
https://api.slack.com/events-api#event_type_structure,https://docs.slack.dev/apis/events-api/#event-type-structure
https://api.slack.com/events/message,https://docs.slack.dev/reference/events/message/
https://api.slack.com/events/message/bot_message,https://docs.slack.dev/reference/events/message/bot_message
https://api.slack.com/events/message/file_share,https://docs.slack.dev/reference/events/message/file_share
https://api.slack.com/events/url_verification,https://docs.slack.dev/reference/events/url_verification/
https://api.slack.com/interactivity,https://docs.slack.dev/interactivity/
https://api.slack.com/interactivity/components,https://docs.slack.dev/block-kit/#making-things-interactive
https://api.slack.com/interactivity/shortcuts,https://docs.slack.dev/interactivity/implementing-shortcuts/
https://api.slack.com/interactivity/slash-commands,https://docs.slack.dev/interactivity/implementing-slash-commands/
https://api.slack.com/legacy/interactive-messages,https://docs.slack.dev/legacy/legacy-messaging/legacy-making-messages-interactive/
https://api.slack.com/legacy/message-buttons,https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/
https://api.slack.com/methods/workflows.stepCompleted
https://api.slack.com/methods/workflows.stepFailed
https://api.slack.com/methods/workflows.updateStep
https://api.slack.com/reference/block-kit/block-elements#external_multi_select,https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
https://api.slack.com/reference/block-kit/block-elements#external_select,https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
https://api.slack.com/reference/interaction-payloads/block-actions,https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/
https://api.slack.com/reference/interaction-payloads/views,https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload
https://api.slack.com/reference/interaction-payloads/views#view_closed,https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_closed
https://api.slack.com/reference/interaction-payloads/views#view_submission,https://docs.slack.dev/reference/interaction-payloads/view-interactions-payload/#view_submission
https://api.slack.com/socket-mode,https://docs.slack.dev/apis/events-api/using-socket-mode/
https://api.slack.com/tutorials/workflow-builder-steps
https://api.slack.com/workflows/steps,https://docs.slack.dev/legacy/legacy-steps-from-apps/
https://slack.dev/bolt-python,https://docs.slack.dev/tools/bolt-python
https://slack.dev/bolt-python/concepts#async,https://docs.slack.dev/tools/bolt-python/concepts/async
https://slack.dev/bolt-python/concepts#authenticating-oauth,https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth
https://slack.dev/bolt-python/concepts#authorization,https://docs.slack.dev/tools/bolt-python/concepts/authorization
https://slack.dev/bolt-python/concepts#context,https://docs.slack.dev/tools/bolt-python/concepts/context
https://slack.dev/bolt-python/concepts#global-middleware,https://docs.slack.dev/tools/bolt-python/concepts/global-middleware
https://slack.dev/bolt-python/concepts#lazy-listeners,https://docs.slack.dev/tools/bolt-python/concepts/lazy-listeners
https://slack.dev/bolt-python/tutorial/getting-started,https://docs.slack.dev/tools/bolt-python/building-an-app
https://slack.dev/bolt-python/tutorial/getting-started#setting-up-events,https://docs.slack.dev/tools/bolt-python/building-an-app#setting-up-events
https://tools.slack.dev/bolt-python,https://docs.slack.dev/tools/bolt-python/
https://tools.slack.dev/bolt-python/concepts/acknowledge,https://docs.slack.dev/tools/bolt-python/concepts/acknowledge/
https://tools.slack.dev/bolt-python/concepts/authenticating-oauth,https://docs.slack.dev/tools/bolt-python/concepts/authenticating-oauth/
https://tools.slack.dev/bolt-python/reference/,https://docs.slack.dev/tools/bolt-python/reference/
```

</details>

Confirming that no logic was changed - such as the `BASE_URL` of methods - would be so much appreciated! 👾

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Document pages under `/docs`

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
