### PR TITLE
#732 Add an easier way to access Events API retry info

### DIFF
--- a/slack_bolt/adapter/__init__.py
+++ b/slack_bolt/adapter/__init__.py
@@ -1,2 +1,1 @@
-"""Adapter modules for running Bolt apps along with Web frameworks or Socket Mode.
-"""
+"""Adapter modules for running Bolt apps along with Web frameworks or Socket Mode."""

--- a/slack_bolt/adapter/socket_mode/async_internals.py
+++ b/slack_bolt/adapter/socket_mode/async_internals.py
@@ -3,6 +3,7 @@
 import json
 import logging
 from time import time
+from typing import Dict, Union, Sequence
 
 from slack_sdk.socket_mode.async_client import AsyncBaseSocketModeClient
 from slack_sdk.socket_mode.request import SocketModeRequest
@@ -14,7 +15,13 @@ from slack_bolt.response import BoltResponse
 
 
 async def run_async_bolt_app(app: AsyncApp, req: SocketModeRequest):
-    bolt_req: AsyncBoltRequest = AsyncBoltRequest(mode="socket_mode", body=req.payload)
+    headers: Dict[str, Union[str, Sequence[str]]] = {}
+    if req.retry_attempt is not None:
+        headers["X-Slack-Retry-Num"] = str(req.retry_attempt)
+    if req.retry_reason is not None:
+        headers["X-Slack-Retry-Reason"] = req.retry_reason
+
+    bolt_req: AsyncBoltRequest = AsyncBoltRequest(mode="socket_mode", body=req.payload, headers=headers)
     bolt_resp: BoltResponse = await app.async_dispatch(bolt_req)
     return bolt_resp
 

--- a/slack_bolt/adapter/socket_mode/internals.py
+++ b/slack_bolt/adapter/socket_mode/internals.py
@@ -3,6 +3,7 @@
 import json
 import logging
 from time import time
+from typing import Dict, Union, Sequence
 
 from slack_sdk.socket_mode.client import BaseSocketModeClient
 from slack_sdk.socket_mode.request import SocketModeRequest
@@ -14,7 +15,13 @@ from slack_bolt.response import BoltResponse
 
 
 def run_bolt_app(app: App, req: SocketModeRequest):
-    bolt_req: BoltRequest = BoltRequest(mode="socket_mode", body=req.payload)
+    headers: Dict[str, Union[str, Sequence[str]]] = {}
+    if req.retry_attempt is not None:
+        headers["X-Slack-Retry-Num"] = str(req.retry_attempt)
+    if req.retry_reason is not None:
+        headers["X-Slack-Retry-Reason"] = req.retry_reason
+
+    bolt_req: BoltRequest = BoltRequest(mode="socket_mode", body=req.payload, headers=headers)
     bolt_resp: BoltResponse = app.dispatch(bolt_req)
     return bolt_resp
 

--- a/slack_bolt/context/base_context.py
+++ b/slack_bolt/context/base_context.py
@@ -38,6 +38,8 @@ class BaseContext(dict):
         "set_status",
         "set_title",
         "set_suggested_prompts",
+        "retry_num",
+        "retry_reason",
     ]
     # Note that these items are not copyable, so when you add new items to this list,
     # you must modify ThreadListenerRunner/AsyncioListenerRunner's _build_lazy_request method to pass the values.
@@ -172,6 +174,16 @@ class BaseContext(dict):
     def user_token(self) -> Optional[str]:
         """The user token resolved for this request."""
         return self.get("user_token")
+
+    @property
+    def retry_num(self) -> Optional[int]:
+        """The retry number for this request (X-Slack-Retry-Num header in HTTP mode, retry_attempt in Socket Mode)."""
+        return self.get("retry_num")
+
+    @property
+    def retry_reason(self) -> Optional[str]:
+        """The retry reason for this request (X-Slack-Retry-Reason header in HTTP mode, retry_reason in Socket Mode)."""
+        return self.get("retry_reason")
 
     def set_authorize_result(self, authorize_result: AuthorizeResult):
         self["authorize_result"] = authorize_result

--- a/slack_bolt/request/async_request.py
+++ b/slack_bolt/request/async_request.py
@@ -67,7 +67,7 @@ class AsyncBoltRequest:
         else:
             self.body = {}
 
-        self.context = build_async_context(AsyncBoltContext(context if context else {}), self.body)
+        self.context = build_async_context(AsyncBoltContext(context if context else {}), self.body, self.headers)
         self.lazy_only = bool(self.headers.get("x-slack-bolt-lazy-only", [False])[0])
         self.lazy_function_name = self.headers.get("x-slack-bolt-lazy-function-name", [None])[0]
         self.mode = mode

--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -268,7 +268,9 @@ def extract_function_inputs(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]
     return None
 
 
-def build_context(context: BoltContext, body: Dict[str, Any]) -> BoltContext:
+def build_context(
+    context: BoltContext, body: Dict[str, Any], headers: Optional[Dict[str, Sequence[str]]] = None
+) -> BoltContext:
     context["is_enterprise_install"] = extract_is_enterprise_install(body)
     enterprise_id = extract_enterprise_id(body)
     if enterprise_id:
@@ -314,6 +316,19 @@ def build_context(context: BoltContext, body: Dict[str, Any]) -> BoltContext:
                 context.logger.debug(debug_multiple_response_urls_detected())
             response_url = response_urls[0].get("response_url")
             context["response_url"] = response_url
+
+    if headers is not None:
+        retry_num_header = headers.get("x-slack-retry-num")
+        if retry_num_header is not None and len(retry_num_header) > 0:
+            try:
+                context["retry_num"] = int(retry_num_header[0])
+            except (ValueError, TypeError):
+                pass
+
+        retry_reason_header = headers.get("x-slack-retry-reason")
+        if retry_reason_header is not None and len(retry_reason_header) > 0:
+            context["retry_reason"] = retry_reason_header[0]
+
     return context
 
 

--- a/slack_bolt/request/request.py
+++ b/slack_bolt/request/request.py
@@ -66,7 +66,7 @@ class BoltRequest:
         else:
             self.body = {}
 
-        self.context = build_context(BoltContext(context if context else {}), self.body)
+        self.context = build_context(BoltContext(context if context else {}), self.body, self.headers)
         self.lazy_only = bool(self.headers.get("x-slack-bolt-lazy-only", [False])[0])
         self.lazy_function_name = self.headers.get("x-slack-bolt-lazy-function-name", [None])[0]
         self.mode = mode


### PR DESCRIPTION
This PR adds an easier way to access Events API retry information within Bolt for Python apps by mirroring [slackapi/java-slack-sdk#677](https://github.com/slackapi/java-slack-sdk/issues/677)
Addresses issue [#732](https://github.com/slackapi/bolt-python/issues/732)

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
