### PR TITLE
feat: add has_been_called on `complete` & `fail` utility

### DIFF
--- a/slack_bolt/context/complete/async_complete.py
+++ b/slack_bolt/context/complete/async_complete.py
@@ -7,6 +7,7 @@ from slack_sdk.web.async_slack_response import AsyncSlackResponse
 class AsyncComplete:
     client: AsyncWebClient
     function_execution_id: Optional[str]
+    _called: bool
 
     def __init__(
         self,
@@ -15,6 +16,7 @@ class AsyncComplete:
     ):
         self.client = client
         self.function_execution_id = function_execution_id
+        self._called = False
 
     async def __call__(self, outputs: Optional[Dict[str, Any]] = None) -> AsyncSlackResponse:
         """Signal the successful completion of the custom function.
@@ -31,6 +33,15 @@ class AsyncComplete:
         if self.function_execution_id is None:
             raise ValueError("complete is unsupported here as there is no function_execution_id")
 
+        self._called = True
         return await self.client.functions_completeSuccess(
             function_execution_id=self.function_execution_id, outputs=outputs or {}
         )
+
+    def has_been_called(self) -> bool:
+        """Check if this complete function has been called.
+
+        Returns:
+            bool: True if the complete function has been called, False otherwise.
+        """
+        return self._called

--- a/slack_bolt/context/complete/complete.py
+++ b/slack_bolt/context/complete/complete.py
@@ -7,6 +7,7 @@ from slack_sdk.web import SlackResponse
 class Complete:
     client: WebClient
     function_execution_id: Optional[str]
+    _called: bool
 
     def __init__(
         self,
@@ -15,6 +16,7 @@ class Complete:
     ):
         self.client = client
         self.function_execution_id = function_execution_id
+        self._called = False
 
     def __call__(self, outputs: Optional[Dict[str, Any]] = None) -> SlackResponse:
         """Signal the successful completion of the custom function.
@@ -31,4 +33,13 @@ class Complete:
         if self.function_execution_id is None:
             raise ValueError("complete is unsupported here as there is no function_execution_id")
 
+        self._called = True
         return self.client.functions_completeSuccess(function_execution_id=self.function_execution_id, outputs=outputs or {})
+
+    def has_been_called(self) -> bool:
+        """Check if this complete function has been called.
+
+        Returns:
+            bool: True if the complete function has been called, False otherwise.
+        """
+        return self._called

--- a/slack_bolt/context/fail/async_fail.py
+++ b/slack_bolt/context/fail/async_fail.py
@@ -7,6 +7,7 @@ from slack_sdk.web.async_slack_response import AsyncSlackResponse
 class AsyncFail:
     client: AsyncWebClient
     function_execution_id: Optional[str]
+    _called: bool
 
     def __init__(
         self,
@@ -15,6 +16,7 @@ class AsyncFail:
     ):
         self.client = client
         self.function_execution_id = function_execution_id
+        self._called = False
 
     async def __call__(self, error: str) -> AsyncSlackResponse:
         """Signal that the custom function failed to complete.
@@ -31,4 +33,13 @@ class AsyncFail:
         if self.function_execution_id is None:
             raise ValueError("fail is unsupported here as there is no function_execution_id")
 
+        self._called = True
         return await self.client.functions_completeError(function_execution_id=self.function_execution_id, error=error)
+
+    def has_been_called(self) -> bool:
+        """Check if this fail function has been called.
+
+        Returns:
+            bool: True if the fail function has been called, False otherwise.
+        """
+        return self._called

--- a/slack_bolt/context/fail/fail.py
+++ b/slack_bolt/context/fail/fail.py
@@ -7,6 +7,7 @@ from slack_sdk.web import SlackResponse
 class Fail:
     client: WebClient
     function_execution_id: Optional[str]
+    _called: bool
 
     def __init__(
         self,
@@ -15,6 +16,7 @@ class Fail:
     ):
         self.client = client
         self.function_execution_id = function_execution_id
+        self._called = False
 
     def __call__(self, error: str) -> SlackResponse:
         """Signal that the custom function failed to complete.
@@ -31,4 +33,13 @@ class Fail:
         if self.function_execution_id is None:
             raise ValueError("fail is unsupported here as there is no function_execution_id")
 
+        self._called = True
         return self.client.functions_completeError(function_execution_id=self.function_execution_id, error=error)
+
+    def has_been_called(self) -> bool:
+        """Check if this fail function has been called.
+
+        Returns:
+            bool: True if the fail function has been called, False otherwise.
+        """
+        return self._called

--- a/tests/scenario_tests/test_function.py
+++ b/tests/scenario_tests/test_function.py
@@ -300,16 +300,20 @@ def reverse(body, event, context, client, complete, inputs):
     assert context.client.token == "xwfp-valid"
     assert client.token == "xwfp-valid"
     assert complete.client.token == "xwfp-valid"
+    assert complete.has_been_called() is False
     complete(
         outputs={"reverseString": "olleh"},
     )
+    assert complete.has_been_called() is True
 
 
 def reverse_error(body, event, fail):
     assert body == function_body
     assert event == function_body["event"]
     assert fail.function_execution_id == "Fx111"
+    assert fail.has_been_called() is False
     fail(error="there was an error")
+    assert fail.has_been_called() is True
 
 
 def complete_it(body, event, complete):

--- a/tests/scenario_tests_async/test_function.py
+++ b/tests/scenario_tests_async/test_function.py
@@ -312,18 +312,22 @@ async def reverse(body, event, client, context, complete, inputs):
     assert context.client.token == "xwfp-valid"
     assert client.token == "xwfp-valid"
     assert complete.client.token == "xwfp-valid"
+    assert complete.has_been_called() is False
     await complete(
         outputs={"reverseString": "olleh"},
     )
+    assert complete.has_been_called() is True
 
 
 async def reverse_error(body, event, fail):
     assert body == function_body
     assert event == function_body["event"]
     assert fail.function_execution_id == "Fx111"
+    assert fail.has_been_called() is False
     await fail(
         error="there was an error",
     )
+    assert fail.has_been_called() is True
 
 
 async def complete_it(body, event, complete):

--- a/tests/slack_bolt/context/test_complete.py
+++ b/tests/slack_bolt/context/test_complete.py
@@ -30,3 +30,12 @@ class TestComplete:
 
         with pytest.raises(ValueError):
             complete(outputs={"key": "value"})
+
+    def test_has_been_called_false_initially(self):
+        complete = Complete(client=self.web_client, function_execution_id="fn1111")
+        assert complete.has_been_called() is False
+
+    def test_has_been_called_true_after_complete(self):
+        complete = Complete(client=self.web_client, function_execution_id="fn1111")
+        complete(outputs={"key": "value"})
+        assert complete.has_been_called() is True

--- a/tests/slack_bolt/context/test_fail.py
+++ b/tests/slack_bolt/context/test_fail.py
@@ -30,3 +30,12 @@ class TestFail:
 
         with pytest.raises(ValueError):
             fail(error="there was an error")
+
+    def test_has_been_called_false_initially(self):
+        fail = Fail(client=self.web_client, function_execution_id="fn1111")
+        assert fail.has_been_called() is False
+
+    def test_has_been_called_true_after_fail(self):
+        fail = Fail(client=self.web_client, function_execution_id="fn1111")
+        fail(error="there was an error")
+        assert fail.has_been_called() is True

--- a/tests/slack_bolt_async/context/test_async_complete.py
+++ b/tests/slack_bolt_async/context/test_async_complete.py
@@ -36,3 +36,14 @@ class TestAsyncComplete:
 
         with pytest.raises(ValueError):
             await complete(outputs={"key": "value"})
+
+    @pytest.mark.asyncio
+    async def test_has_been_called_false_initially(self):
+        complete = AsyncComplete(client=self.web_client, function_execution_id="fn1111")
+        assert complete.has_been_called() is False
+
+    @pytest.mark.asyncio
+    async def test_has_been_called_true_after_complete(self):
+        complete = AsyncComplete(client=self.web_client, function_execution_id="fn1111")
+        await complete(outputs={"key": "value"})
+        assert complete.has_been_called() is True

--- a/tests/slack_bolt_async/context/test_async_fail.py
+++ b/tests/slack_bolt_async/context/test_async_fail.py
@@ -36,3 +36,14 @@ class TestAsyncFail:
 
         with pytest.raises(ValueError):
             await fail(error="there was an error")
+
+    @pytest.mark.asyncio
+    async def test_has_been_called_false_initially(self):
+        fail = AsyncFail(client=self.web_client, function_execution_id="fn1111")
+        assert fail.has_been_called() is False
+
+    @pytest.mark.asyncio
+    async def test_has_been_called_true_after_fail(self):
+        fail = AsyncFail(client=self.web_client, function_execution_id="fn1111")
+        await fail(error="there was an error")
+        assert fail.has_been_called() is True


### PR DESCRIPTION
## Summary

These changes allow to easily determine if `fail` or `complete` was invoked, invoking both in the same handler can sometimes lead to errors returned from the Slack API

### Testing

```python
try:
    # do some things to create the step output
    
    complete(outputs={"search_result": invalid_object}) # this could cause a parameter validation error from the Slack API
except Exception as e:
    logger.error("Unexpected error occurred")
    if not complete.has_been_called():
        fail(error="internal error")
```

The same applies to the `fail` utility function 🙏 

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
