### PR TITLE
ci: upload test results using the recommended codecov action

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -39,6 +39,6 @@ jobs:
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           fail_ci_if_error: true
-          report-type: coverage
+          report_type: coverage
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
           directory: ./reports/
           fail_ci_if_error: true
           flags: ${{ matrix.python-version }}
-          report-type: test_results
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
   notifications:


### PR DESCRIPTION
## Summary

This PR uses the recommended [`codecov/codecov-action`](https://github.com/codecov/codecov-action) to both upload test coverage and test  results 🧪 ✨ 

From the pages of the [`codecov/test-results-action`](https://github.com/codecov/test-results-action) action:

> **⚠️ Deprecation Warning ⚠️**
>
> This Action causes issues for users uploading test analytics to Codecov

🔗 https://github.com/codecov/test-results-action?tab=readme-ov-file#%EF%B8%8F-deprecation-warning-%EF%B8%8F

### Testing

Hopes to fix ongoing issues in CI:

⏳ https://github.com/slackapi/bolt-python/actions?query=event%3Aschedule
🤖 https://github.com/slackapi/bolt-python/actions/runs/19250630230/job/55034658717

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
