### PR TITLE
feat: add `[async]` optional dependencies for easier async setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,7 @@ python -m venv .venv
 source .venv/bin/activate
 
 pip install -U pip
-# aiohttp is required
-pip install slack_bolt aiohttp
+pip install "slack_bolt[async]"
 ```
 
 In async apps, all middleware/listeners must be async functions. When calling utility methods (like `ack` and `say`) within these functions, it's required to use the `await` keyword.

--- a/docs/english/concepts/async.md
+++ b/docs/english/concepts/async.md
@@ -1,11 +1,11 @@
 # Using async (asyncio)
 
-To use the async version of Bolt, you can import and initialize an `AsyncApp` instance (rather than `App`). `AsyncApp` relies on [AIOHTTP](https://docs.aiohttp.org) to make API requests, which means you'll need to install `aiohttp` (by adding to `requirements.txt` or running `pip install aiohttp`).
+To use the async version of Bolt, you can import and initialize an `AsyncApp` instance (rather than `App`). `AsyncApp` relies on [AIOHTTP](https://docs.aiohttp.org) to make API requests, which means you'll need to install the async extras (by running `pip install "slack-bolt[async]"`).
 
 Sample async projects can be found within the repository's [examples](https://github.com/slackapi/bolt-python/tree/main/examples) folder.
 
 ```python
-# Requirement: install aiohttp
+# Requirement: pip install "slack-bolt[async]"
 from slack_bolt.async_app import AsyncApp
 app = AsyncApp()
 

--- a/docs/japanese/concepts/async.md
+++ b/docs/japanese/concepts/async.md
@@ -1,11 +1,11 @@
 # Async（asyncio）の使用
 
-非同期バージョンの Bolt を使用する場合は、`App` の代わりに `AsyncApp` インスタンスをインポートして初期化します。`AsyncApp` では [AIOHTTP](https://docs.aiohttp.org/) を使って API リクエストを行うため、`aiohttp` をインストールする必要があります（`requirements.txt` に追記するか、`pip install aiohttp` を実行します）。
+非同期バージョンの Bolt を使用する場合は、`App` の代わりに `AsyncApp` インスタンスをインポートして初期化します。`AsyncApp` では [AIOHTTP](https://docs.aiohttp.org/) を使って API リクエストを行うため、async extras のインストールが必要です（`pip install "slack-bolt[async]"` を実行します）。
 
 非同期バージョンのプロジェクトのサンプルは、リポジトリの [`examples` フォルダ](https://github.com/slackapi/bolt-python/tree/main/examples)にあります。
 
 ```python
-# aiohttp のインストールが必要です
+# pip install "slack-bolt[async]" が必要です
 from slack_bolt.async_app import AsyncApp
 app = AsyncApp()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack_bolt"
-dynamic = ["version", "readme", "authors"]
+dynamic = ["version", "readme", "authors", "optional-dependencies"]
 description = "The Bolt Framework for Python"
 license = { text = "MIT" }
 classifiers = [
@@ -33,6 +33,7 @@ include = ["slack_bolt*"]
 [tool.setuptools.dynamic]
 version = { attr = "slack_bolt.version.__version__" }
 readme = { file = ["README.md"], content-type = "text/markdown" }
+optional-dependencies.async = { file = ["requirements/async.txt"] }
 
 [tool.distutils.bdist_wheel]
 universal = true

--- a/slack_bolt/adapter/__init__.py
+++ b/slack_bolt/adapter/__init__.py
@@ -1,2 +1,1 @@
-"""Adapter modules for running Bolt apps along with Web frameworks or Socket Mode.
-"""
+"""Adapter modules for running Bolt apps along with Web frameworks or Socket Mode."""

--- a/slack_bolt/async_app.py
+++ b/slack_bolt/async_app.py
@@ -10,8 +10,7 @@ python -m venv .venv
 source .venv/bin/activate
 
 pip install -U pip
-# aiohttp is required
-pip install slack_bolt aiohttp
+pip install "slack_bolt[async]"
 ```
 
 In async apps, all middleware/listeners must be async functions. When calling utility methods (like `ack` and `say`) within these functions, it's required to use the `await` keyword.


### PR DESCRIPTION
## Summary

Add `[async]` optional dependencies to `pyproject.toml` so users can install async requirements with `pip install "slack-bolt[async]"` instead of manually installing `aiohttp`.

Changes:
- Add `optional-dependencies.async` to `pyproject.toml` (references existing `requirements/async.txt`)
- Update install instructions in `README.md`, `docs/`, and `slack_bolt/async_app.py` docstring

### Category

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [x] Others

## Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.