### PR TITLE
fix: pin setuptools to maintain support for pyramid adapter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
+    ignore:
+      # setuptools is pinned due to pyramid's dependency on deprecated pkg_resources
+      # See: https://github.com/Pylons/pyramid/issues/3731
+      - dependency-name: "setuptools"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/requirements/adapter.txt
+++ b/requirements/adapter.txt
@@ -13,6 +13,7 @@ fastapi>=0.70.0,<1
 Flask>=1,<4
 Werkzeug>=2,<4
 pyramid>=1,<3
+setuptools<82  # Pinned: Pyramid depends on pkg_resources (deprecated in setuptools 67.5.0, removed in 82+). See: https://github.com/Pylons/pyramid/issues/3731
 
 # Sanic and its dependencies
 # Note: Sanic imports tracerite with wild card versions


### PR DESCRIPTION
## Summary

The [pyramid](https://trypyramid.com/) framework is dependent on [setuptools](https://pypi.org/project/setuptools/) `pkg_resources` module. This module has been deprecated since [setuptools v67.5.0](https://setuptools.pypa.io/en/latest/history.html#v67-5-0) and removed in [setuptools v82.0.0](https://setuptools.pypa.io/en/latest/history.html#v82-0-0). See https://github.com/Pylons/pyramid/issues/3731 for all the details.

These changes pins [setuptools v82.0.0](https://setuptools.pypa.io/en/latest/history.html#v82-0-0) when unit testing the project in order to allow the tests around the [Pyramid Adapter](https://github.com/slackapi/bolt-python/tree/main/tests/adapter_tests/pyramid) to run.

When pyramids dependence on `pkg_resources` is resolved we should remove the [setuptools v82.0.0](https://setuptools.pypa.io/en/latest/history.html#v82-0-0) pin.

### Testing

Continuous integration tests should be sufficient

You can also pull this branch and run the tests locally, everything should pass

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
