### PR TITLE
feat: tool registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ venv/
 .venv*
 .env/
 
+# claude
+.claude/*.local.json
+
 # codecov / coverage
 .coverage
 cov_*

--- a/docs/english/_sidebar.json
+++ b/docs/english/_sidebar.json
@@ -87,6 +87,11 @@
 	},
 	{
 		"type": "category",
+		"label": "Experiments",
+		"items": ["tools/bolt-python/experiments"]
+	},
+	{
+		"type": "category",
 		"label": "Legacy",
 		"items": ["tools/bolt-python/legacy/steps-from-apps"]
 	},

--- a/docs/english/experiments.md
+++ b/docs/english/experiments.md
@@ -1,0 +1,34 @@
+# Experiments
+
+Bolt for Python includes experimental features still under active development. These features may be fleeting, may not be perfectly polished, and should be thought of as available for use "at your own risk." 
+
+Experimental features are categorized as `semver:patch` until the experimental status is removed.
+
+We love feedback from our community, so we encourage you to explore and interact with the [GitHub repo](https://github.com/slackapi/bolt-python). Contributions, bug reports, and any feedback are all helpful; let us nurture the Slack CLI together to help make building Slack apps more pleasant for everyone.
+
+## Available experiments
+* [Agent listener argument](#agent)
+
+## Agent listener argument {#agent}
+
+The `agent: BoltAgent` listener argument provides access to AI agent-related features.
+
+The `BoltAgent` and `AsyncBoltAgent` classes offer a `chat_stream()` method that comes pre-configured with event context defaults: `channel_id`, `thread_ts`, `team_id`, and `user_id` fields. 
+
+The listener argument is wired into the Bolt `kwargs` injection system, so listeners can declare it as a parameter or access it via the `context.agent` property.
+
+### Example
+
+```python
+from slack_bolt import BoltAgent
+
+@app.event("app_mention")
+def handle_mention(agent: BoltAgent):
+    stream = agent.chat_stream()
+    stream.append(markdown_text="Hello!")
+    stream.stop()
+```
+
+### Limitations
+
+The `chat_stream()` method currently only works when the `thread_ts` field is available in the event context (DMs and threaded replies). Top-level channel messages do not have a `thread_ts` field, and the `ts` field is not yet provided to `BoltAgent`.

--- a/slack_bolt/__init__.py
+++ b/slack_bolt/__init__.py
@@ -21,6 +21,7 @@ from .request import BoltRequest
 from .response import BoltResponse
 
 # AI Agents & Assistants
+from .agent import BoltAgent
 from .middleware.assistant.assistant import (
     Assistant,
 )
@@ -46,6 +47,7 @@ __all__ = [
     "CustomListenerMatcher",
     "BoltRequest",
     "BoltResponse",
+    "BoltAgent",
     "Assistant",
     "AssistantThreadContext",
     "AssistantThreadContextStore",

--- a/slack_bolt/__init__.py
+++ b/slack_bolt/__init__.py
@@ -22,6 +22,7 @@ from .response import BoltResponse
 
 # AI Agents & Assistants
 from .agent import BoltAgent
+from .agent import Tools
 from .middleware.assistant.assistant import (
     Assistant,
 )
@@ -48,6 +49,7 @@ __all__ = [
     "BoltRequest",
     "BoltResponse",
     "BoltAgent",
+    "Tools",
     "Assistant",
     "AssistantThreadContext",
     "AssistantThreadContextStore",

--- a/slack_bolt/adapter/__init__.py
+++ b/slack_bolt/adapter/__init__.py
@@ -1,2 +1,1 @@
-"""Adapter modules for running Bolt apps along with Web frameworks or Socket Mode.
-"""
+"""Adapter modules for running Bolt apps along with Web frameworks or Socket Mode."""

--- a/slack_bolt/agent/__init__.py
+++ b/slack_bolt/agent/__init__.py
@@ -1,5 +1,7 @@
 from .agent import BoltAgent
+from .tools import Tools
 
 __all__ = [
     "BoltAgent",
+    "Tools",
 ]

--- a/slack_bolt/agent/__init__.py
+++ b/slack_bolt/agent/__init__.py
@@ -1,5 +1,7 @@
 from slack_bolt.agent.agent import BoltAgent
+from slack_bolt.agent.async_agent import AsyncBoltAgent
 
 __all__ = [
+    "AsyncBoltAgent",
     "BoltAgent",
 ]

--- a/slack_bolt/agent/__init__.py
+++ b/slack_bolt/agent/__init__.py
@@ -1,4 +1,4 @@
-from slack_bolt.agent.agent import BoltAgent
+from .agent import BoltAgent
 
 __all__ = [
     "BoltAgent",

--- a/slack_bolt/agent/__init__.py
+++ b/slack_bolt/agent/__init__.py
@@ -1,0 +1,5 @@
+from slack_bolt.agent.agent import BoltAgent
+
+__all__ = [
+    "BoltAgent",
+]

--- a/slack_bolt/agent/__init__.py
+++ b/slack_bolt/agent/__init__.py
@@ -1,7 +1,5 @@
 from slack_bolt.agent.agent import BoltAgent
-from slack_bolt.agent.async_agent import AsyncBoltAgent
 
 __all__ = [
-    "AsyncBoltAgent",
     "BoltAgent",
 ]

--- a/slack_bolt/agent/agent.py
+++ b/slack_bolt/agent/agent.py
@@ -58,6 +58,11 @@ class BoltAgent:
         Returns:
             A new ``ChatStream`` instance.
         """
+        provided = [arg for arg in (channel, thread_ts, recipient_team_id, recipient_user_id) if arg is not None]
+        if provided and len(provided) < 4:
+            raise ValueError(
+                "Either provide all of channel, thread_ts, recipient_team_id, and recipient_user_id, or none of them"
+            )
         resolved_channel = channel or self._channel_id
         resolved_thread_ts = thread_ts or self._thread_ts
         if resolved_channel is None:

--- a/slack_bolt/agent/agent.py
+++ b/slack_bolt/agent/agent.py
@@ -1,0 +1,74 @@
+from typing import Optional
+
+from slack_sdk import WebClient
+from slack_sdk.web.chat_stream import ChatStream
+
+
+class BoltAgent:
+    """Agent listener argument for building AI-powered Slack agents.
+
+    Experimental:
+        This API is experimental and may change in future releases.
+
+        @app.event("app_mention")
+        def handle_mention(agent):
+            stream = agent.chat_stream()
+            stream.append(markdown_text="Hello!")
+            stream.stop()
+    """
+
+    def __init__(
+        self,
+        *,
+        client: WebClient,
+        channel_id: Optional[str] = None,
+        thread_ts: Optional[str] = None,
+        team_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ):
+        self._client = client
+        self._channel_id = channel_id
+        self._thread_ts = thread_ts
+        self._team_id = team_id
+        self._user_id = user_id
+
+    def chat_stream(
+        self,
+        *,
+        channel: Optional[str] = None,
+        thread_ts: Optional[str] = None,
+        recipient_team_id: Optional[str] = None,
+        recipient_user_id: Optional[str] = None,
+        **kwargs,
+    ) -> ChatStream:
+        """Creates a ChatStream with defaults from event context.
+
+        Each call creates a new instance. Create multiple for parallel streams.
+
+        Args:
+            channel: Channel ID. Defaults to the channel from the event context.
+            thread_ts: Thread timestamp. Defaults to the thread_ts from the event context.
+            recipient_team_id: Team ID of the recipient. Defaults to the team from the event context.
+            recipient_user_id: User ID of the recipient. Defaults to the user from the event context.
+            **kwargs: Additional arguments passed to ``WebClient.chat_stream()``.
+
+        Returns:
+            A new ``ChatStream`` instance.
+        """
+        resolved_channel = channel or self._channel_id
+        resolved_thread_ts = thread_ts or self._thread_ts
+        if resolved_channel is None:
+            raise ValueError(
+                "channel is required: provide it as an argument or ensure channel_id is set in the event context"
+            )
+        if resolved_thread_ts is None:
+            raise ValueError(
+                "thread_ts is required: provide it as an argument or ensure thread_ts is set in the event context"
+            )
+        return self._client.chat_stream(
+            channel=resolved_channel,
+            thread_ts=resolved_thread_ts,
+            recipient_team_id=recipient_team_id or self._team_id,
+            recipient_user_id=recipient_user_id or self._user_id,
+            **kwargs,
+        )

--- a/slack_bolt/agent/agent.py
+++ b/slack_bolt/agent/agent.py
@@ -10,6 +10,9 @@ class BoltAgent:
     Experimental:
         This API is experimental and may change in future releases.
 
+        FIXME: chat_stream() only works when thread_ts is available (DMs and threaded replies).
+        It does not work on channel messages because ts is not provided to BoltAgent yet.
+
         @app.event("app_mention")
         def handle_mention(agent):
             stream = agent.chat_stream()

--- a/slack_bolt/agent/async_agent.py
+++ b/slack_bolt/agent/async_agent.py
@@ -1,0 +1,74 @@
+from typing import Optional
+
+from slack_sdk.web.async_client import AsyncWebClient
+from slack_sdk.web.async_chat_stream import AsyncChatStream
+
+
+class AsyncBoltAgent:
+    """Async agent listener argument for building AI-powered Slack agents.
+
+    Experimental:
+        This API is experimental and may change in future releases.
+
+        @app.event("app_mention")
+        async def handle_mention(agent):
+            stream = await agent.chat_stream()
+            await stream.append(markdown_text="Hello!")
+            await stream.stop()
+    """
+
+    def __init__(
+        self,
+        *,
+        client: AsyncWebClient,
+        channel_id: Optional[str] = None,
+        thread_ts: Optional[str] = None,
+        team_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ):
+        self._client = client
+        self._channel_id = channel_id
+        self._thread_ts = thread_ts
+        self._team_id = team_id
+        self._user_id = user_id
+
+    async def chat_stream(
+        self,
+        *,
+        channel: Optional[str] = None,
+        thread_ts: Optional[str] = None,
+        recipient_team_id: Optional[str] = None,
+        recipient_user_id: Optional[str] = None,
+        **kwargs,
+    ) -> AsyncChatStream:
+        """Creates an AsyncChatStream with defaults from event context.
+
+        Each call creates a new instance. Create multiple for parallel streams.
+
+        Args:
+            channel: Channel ID. Defaults to the channel from the event context.
+            thread_ts: Thread timestamp. Defaults to the thread_ts from the event context.
+            recipient_team_id: Team ID of the recipient. Defaults to the team from the event context.
+            recipient_user_id: User ID of the recipient. Defaults to the user from the event context.
+            **kwargs: Additional arguments passed to ``AsyncWebClient.chat_stream()``.
+
+        Returns:
+            A new ``AsyncChatStream`` instance.
+        """
+        resolved_channel = channel or self._channel_id
+        resolved_thread_ts = thread_ts or self._thread_ts
+        if resolved_channel is None:
+            raise ValueError(
+                "channel is required: provide it as an argument or ensure channel_id is set in the event context"
+            )
+        if resolved_thread_ts is None:
+            raise ValueError(
+                "thread_ts is required: provide it as an argument or ensure thread_ts is set in the event context"
+            )
+        return await self._client.chat_stream(
+            channel=resolved_channel,
+            thread_ts=resolved_thread_ts,
+            recipient_team_id=recipient_team_id or self._team_id,
+            recipient_user_id=recipient_user_id or self._user_id,
+            **kwargs,
+        )

--- a/slack_bolt/agent/async_agent.py
+++ b/slack_bolt/agent/async_agent.py
@@ -55,6 +55,11 @@ class AsyncBoltAgent:
         Returns:
             A new ``AsyncChatStream`` instance.
         """
+        provided = [arg for arg in (channel, thread_ts, recipient_team_id, recipient_user_id) if arg is not None]
+        if provided and len(provided) < 4:
+            raise ValueError(
+                "Either provide all of channel, thread_ts, recipient_team_id, and recipient_user_id, or none of them"
+            )
         resolved_channel = channel or self._channel_id
         resolved_thread_ts = thread_ts or self._thread_ts
         if resolved_channel is None:

--- a/slack_bolt/agent/tools.py
+++ b/slack_bolt/agent/tools.py
@@ -1,0 +1,278 @@
+import copy
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from slack_sdk.web.chat_stream import ChatStream
+
+
+@dataclass
+class ToolDefinition:
+    """Internal representation of a registered tool."""
+
+    name: str
+    handler: Callable[..., str]
+    description: str
+    parameters: Dict[str, Any]
+    required: List[str]
+
+
+_TYPE_MAP = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+    list: "array",
+    dict: "object",
+}
+
+
+def _introspect_handler(func: Callable) -> dict:
+    """Extract metadata from a function signature to build JSON Schema parameters.
+
+    Uses ``typing.get_type_hints()`` and ``inspect.signature()`` to derive
+    parameter types. Falls back to the function docstring for the description.
+
+    Returns:
+        dict with keys ``description``, ``parameters``, and ``required``.
+    """
+    try:
+        hints = __import__("typing").get_type_hints(func)
+    except Exception:
+        hints = {}
+
+    sig = inspect.signature(func)
+    parameters: Dict[str, Any] = {}
+    required: List[str] = []
+
+    for param_name, param in sig.parameters.items():
+        json_type = _TYPE_MAP.get(hints.get(param_name), "string")
+        parameters[param_name] = {"type": json_type}
+        if param.default is inspect.Parameter.empty:
+            required.append(param_name)
+
+    description = (func.__doc__ or "").strip()
+
+    return {
+        "description": description,
+        "parameters": parameters,
+        "required": required,
+    }
+
+
+class Tools:
+    """Tool registry for AI-powered Slack agents.
+
+    Experimental:
+        This API is experimental and may change in future releases.
+
+    Example::
+
+        tools = Tools()
+
+        @tools.add("search")
+        def search(query: str) -> str:
+            return f"Results for {query}"
+
+        # Or programmatically:
+        tools.add("greet", handler=greet_fn, description="Greet a user")
+    """
+
+    def __init__(self) -> None:
+        self._definitions: Dict[str, ToolDefinition] = {}
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    def add(
+        self,
+        name: str,
+        handler: Optional[Callable[..., str]] = None,
+        *,
+        description: Optional[str] = None,
+        parameters: Optional[Dict[str, Any]] = None,
+        required: Optional[List[str]] = None,
+    ):
+        """Register a tool handler.
+
+        Can be used as a decorator::
+
+            @tools.add("search")
+            def search(query: str) -> str:
+                return f"Results for {query}"
+
+        Or called programmatically::
+
+            tools.add("search", handler=search_fn, description="Search")
+
+        Args:
+            name: Unique tool identifier.
+            handler: The function to invoke. When ``None``, returns a decorator.
+            description: Human-readable description. Defaults to handler docstring.
+            parameters: JSON Schema properties dict. Defaults to introspected signature.
+            required: Required parameter names. Defaults to introspected signature.
+
+        Returns:
+            The handler function (when used as a decorator) or ``None``.
+
+        Raises:
+            ValueError: If a tool with *name* is already registered.
+        """
+        if name in self._definitions:
+            raise ValueError(f"Tool already registered: {name!r}")
+
+        def _register(func: Callable[..., str]) -> Callable[..., str]:
+            introspected = _introspect_handler(func)
+            self._definitions[name] = ToolDefinition(
+                name=name,
+                handler=func,
+                description=description if description is not None else introspected["description"],
+                parameters=parameters if parameters is not None else introspected["parameters"],
+                required=required if required is not None else introspected["required"],
+            )
+            return func
+
+        if handler is not None:
+            _register(handler)
+            return None
+
+        return _register
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    def execute(
+        self,
+        stream: ChatStream,
+        call_id: str,
+        name: str,
+        arguments: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Execute a registered tool and send status updates via *stream*.
+
+        Sends ``task_update`` kwargs through ``stream.append()`` to indicate
+        ``in_progress``, ``completed``, or ``failed`` status.
+
+        Args:
+            stream: A ``ChatStream`` instance for status updates.
+            call_id: Identifier for the tool call (passed in ``task_update``).
+            name: The registered tool name.
+            arguments: Keyword arguments forwarded to the handler.
+
+        Returns:
+            The string result from the handler.
+
+        Raises:
+            KeyError: If *name* is not registered.
+        """
+        if name not in self._definitions:
+            raise KeyError(f"Unknown tool: {name!r}")
+
+        definition = self._definitions[name]
+        kwargs = arguments or {}
+
+        stream.append(
+            markdown_text="",
+            task_update={"call_id": call_id, "status": "in_progress"},
+        )
+
+        try:
+            result = definition.handler(**kwargs)
+        except Exception as exc:
+            stream.append(
+                markdown_text="",
+                task_update={"call_id": call_id, "status": "failed", "output": str(exc)},
+            )
+            raise
+
+        stream.append(
+            markdown_text="",
+            task_update={"call_id": call_id, "status": "completed", "output": result},
+        )
+        return result
+
+    # ------------------------------------------------------------------
+    # Schema export
+    # ------------------------------------------------------------------
+
+    def schema(self, provider: str) -> List[Dict[str, Any]]:
+        """Export tool schemas for an LLM provider.
+
+        Args:
+            provider: ``"openai"`` or ``"anthropic"``.
+
+        Returns:
+            List of tool schema dicts in the provider's format.
+
+        Raises:
+            ValueError: If *provider* is not supported.
+        """
+        if provider == "openai":
+            return self._schema_openai()
+        elif provider == "anthropic":
+            return self._schema_anthropic()
+        else:
+            raise ValueError(f"Unsupported provider: {provider!r}. Use 'openai' or 'anthropic'.")
+
+    def _schema_openai(self) -> List[Dict[str, Any]]:
+        result = []
+        for defn in self._definitions.values():
+            result.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": defn.name,
+                        "description": defn.description,
+                        "parameters": {
+                            "type": "object",
+                            "properties": defn.parameters,
+                            "required": defn.required,
+                        },
+                    },
+                }
+            )
+        return result
+
+    def _schema_anthropic(self) -> List[Dict[str, Any]]:
+        result = []
+        for defn in self._definitions.values():
+            result.append(
+                {
+                    "name": defn.name,
+                    "description": defn.description,
+                    "input_schema": {
+                        "type": "object",
+                        "properties": defn.parameters,
+                        "required": defn.required,
+                    },
+                }
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+
+    def copy(self) -> "Tools":
+        """Create an independent copy of the registry.
+
+        Handler references are shared; definitions are deep-copied.
+        """
+        new = Tools()
+        for name, defn in self._definitions.items():
+            new._definitions[name] = ToolDefinition(
+                name=defn.name,
+                handler=defn.handler,
+                description=defn.description,
+                parameters=copy.deepcopy(defn.parameters),
+                required=list(defn.required),
+            )
+        return new
+
+    def __len__(self) -> int:
+        return len(self._definitions)
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._definitions

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -9,6 +9,7 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from http.server import SimpleHTTPRequestHandler, HTTPServer
 from typing import List, Union, Pattern, Callable, Dict, Optional, Sequence, Any
 
+from slack_bolt.agent.agent import BoltAgent
 from slack_sdk.errors import SlackApiError
 from slack_sdk.oauth.installation_store import InstallationStore
 from slack_sdk.web import WebClient
@@ -703,6 +704,9 @@ class App:
 
     def assistant(self, assistant: Assistant) -> Optional[Callable]:
         return self.middleware(assistant)
+    
+    def agent(self, agent: BoltAgent) -> Optional[Callable]:
+        return self.middleware(agent)
 
     # -------------------------
     # Workflows: Steps from apps

--- a/slack_bolt/context/async_context.py
+++ b/slack_bolt/context/async_context.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from slack_sdk.web.async_client import AsyncWebClient
 
@@ -14,6 +14,9 @@ from slack_bolt.context.set_status.async_set_status import AsyncSetStatus
 from slack_bolt.context.set_suggested_prompts.async_set_suggested_prompts import AsyncSetSuggestedPrompts
 from slack_bolt.context.set_title.async_set_title import AsyncSetTitle
 from slack_bolt.util.utils import create_copy
+
+if TYPE_CHECKING:
+    from slack_bolt.agent.async_agent import AsyncBoltAgent
 
 
 class AsyncBoltContext(BaseContext):
@@ -186,6 +189,34 @@ class AsyncBoltContext(BaseContext):
         if "fail" not in self:
             self["fail"] = AsyncFail(client=self.client, function_execution_id=self.function_execution_id)
         return self["fail"]
+
+    @property
+    def agent(self) -> "AsyncBoltAgent":
+        """`agent` listener argument for building AI-powered Slack agents.
+
+        Experimental:
+            This API is experimental and may change in future releases.
+
+            @app.event("app_mention")
+            async def handle_mention(agent):
+                stream = await agent.chat_stream()
+                await stream.append(markdown_text="Hello!")
+                await stream.stop()
+
+        Returns:
+            `AsyncBoltAgent` instance
+        """
+        if "agent" not in self:
+            from slack_bolt.agent.async_agent import AsyncBoltAgent
+
+            self["agent"] = AsyncBoltAgent(
+                client=self.client,
+                channel_id=self.channel_id,
+                thread_ts=self.thread_ts,
+                team_id=self.team_id,
+                user_id=self.user_id,
+            )
+        return self["agent"]
 
     @property
     def set_title(self) -> Optional[AsyncSetTitle]:

--- a/slack_bolt/context/base_context.py
+++ b/slack_bolt/context/base_context.py
@@ -38,6 +38,7 @@ class BaseContext(dict):
         "set_status",
         "set_title",
         "set_suggested_prompts",
+        "agent",
     ]
     # Note that these items are not copyable, so when you add new items to this list,
     # you must modify ThreadListenerRunner/AsyncioListenerRunner's _build_lazy_request method to pass the values.

--- a/slack_bolt/context/context.py
+++ b/slack_bolt/context/context.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from slack_sdk import WebClient
 
@@ -14,6 +14,9 @@ from slack_bolt.context.set_status import SetStatus
 from slack_bolt.context.set_suggested_prompts import SetSuggestedPrompts
 from slack_bolt.context.set_title import SetTitle
 from slack_bolt.util.utils import create_copy
+
+if TYPE_CHECKING:
+    from slack_bolt.agent.agent import BoltAgent
 
 
 class BoltContext(BaseContext):
@@ -187,6 +190,34 @@ class BoltContext(BaseContext):
         if "fail" not in self:
             self["fail"] = Fail(client=self.client, function_execution_id=self.function_execution_id)
         return self["fail"]
+
+    @property
+    def agent(self) -> "BoltAgent":
+        """`agent` listener argument for building AI-powered Slack agents.
+
+        Experimental:
+            This API is experimental and may change in future releases.
+
+            @app.event("app_mention")
+            def handle_mention(agent):
+                stream = agent.chat_stream()
+                stream.append(markdown_text="Hello!")
+                stream.stop()
+
+        Returns:
+            `BoltAgent` instance
+        """
+        if "agent" not in self:
+            from slack_bolt.agent.agent import BoltAgent
+
+            self["agent"] = BoltAgent(
+                client=self.client,
+                channel_id=self.channel_id,
+                thread_ts=self.thread_ts,
+                team_id=self.team_id,
+                user_id=self.user_id,
+            )
+        return self["agent"]
 
     @property
     def set_title(self) -> Optional[SetTitle]:

--- a/slack_bolt/kwargs_injection/args.py
+++ b/slack_bolt/kwargs_injection/args.py
@@ -8,6 +8,7 @@ from slack_bolt.context.complete import Complete
 from slack_bolt.context.fail import Fail
 from slack_bolt.context.get_thread_context.get_thread_context import GetThreadContext
 from slack_bolt.context.respond import Respond
+from slack_bolt.agent.agent import BoltAgent
 from slack_bolt.context.save_thread_context import SaveThreadContext
 from slack_bolt.context.say import Say
 from slack_bolt.context.set_status import SetStatus
@@ -102,6 +103,8 @@ class Args:
     """`get_thread_context()` utility function for AI Agents & Assistants"""
     save_thread_context: Optional[SaveThreadContext]
     """`save_thread_context()` utility function for AI Agents & Assistants"""
+    agent: Optional[BoltAgent]
+    """`agent` listener argument for AI Agents & Assistants"""
     # middleware
     next: Callable[[], None]
     """`next()` utility function, which tells the middleware chain that it can continue with the next one"""
@@ -135,6 +138,7 @@ class Args:
         set_suggested_prompts: Optional[SetSuggestedPrompts] = None,
         get_thread_context: Optional[GetThreadContext] = None,
         save_thread_context: Optional[SaveThreadContext] = None,
+        agent: Optional[BoltAgent] = None,
         # As this method is not supposed to be invoked by bolt-python users,
         # the naming conflict with the built-in one affects
         # only the internals of this method
@@ -168,6 +172,7 @@ class Args:
         self.set_suggested_prompts = set_suggested_prompts
         self.get_thread_context = get_thread_context
         self.save_thread_context = save_thread_context
+        self.agent = agent
 
         self.next: Callable[[], None] = next
         self.next_: Callable[[], None] = next

--- a/slack_bolt/kwargs_injection/async_args.py
+++ b/slack_bolt/kwargs_injection/async_args.py
@@ -1,6 +1,7 @@
 from logging import Logger
 from typing import Callable, Awaitable, Dict, Any, Optional
 
+from slack_bolt.agent.async_agent import AsyncBoltAgent
 from slack_bolt.context.ack.async_ack import AsyncAck
 from slack_bolt.context.async_context import AsyncBoltContext
 from slack_bolt.context.complete.async_complete import AsyncComplete
@@ -101,6 +102,8 @@ class AsyncArgs:
     """`get_thread_context()` utility function for AI Agents & Assistants"""
     save_thread_context: Optional[AsyncSaveThreadContext]
     """`save_thread_context()` utility function for AI Agents & Assistants"""
+    agent: Optional[AsyncBoltAgent]
+    """`agent` listener argument for AI Agents & Assistants"""
     # middleware
     next: Callable[[], Awaitable[None]]
     """`next()` utility function, which tells the middleware chain that it can continue with the next one"""
@@ -134,6 +137,7 @@ class AsyncArgs:
         set_suggested_prompts: Optional[AsyncSetSuggestedPrompts] = None,
         get_thread_context: Optional[AsyncGetThreadContext] = None,
         save_thread_context: Optional[AsyncSaveThreadContext] = None,
+        agent: Optional[AsyncBoltAgent] = None,
         next: Callable[[], Awaitable[None]],
         **kwargs,  # noqa
     ):
@@ -164,6 +168,7 @@ class AsyncArgs:
         self.set_suggested_prompts = set_suggested_prompts
         self.get_thread_context = get_thread_context
         self.save_thread_context = save_thread_context
+        self.agent = agent
 
         self.next: Callable[[], Awaitable[None]] = next
         self.next_: Callable[[], Awaitable[None]] = next

--- a/slack_bolt/kwargs_injection/async_utils.py
+++ b/slack_bolt/kwargs_injection/async_utils.py
@@ -1,9 +1,11 @@
 import inspect
 import logging
+import warnings
 from typing import Callable, Dict, MutableSequence, Optional, Any
 
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
+from slack_bolt.warning import ExperimentalWarning
 from .async_args import AsyncArgs
 from slack_bolt.request.payload_utils import (
     to_options,
@@ -86,6 +88,12 @@ def build_async_required_kwargs(
     # Defer agent creation to avoid constructing AsyncBoltAgent on every request
     if "agent" in required_arg_names or "args" in required_arg_names:
         all_available_args["agent"] = request.context.agent
+        if "agent" in required_arg_names:
+            warnings.warn(
+                "The agent listener argument is experimental and may change in future versions.",
+                category=ExperimentalWarning,
+                stacklevel=2,  # Point to the caller, not this internal helper
+            )
 
     if len(required_arg_names) > 0:
         # To support instance/class methods in a class for listeners/middleware,

--- a/slack_bolt/kwargs_injection/async_utils.py
+++ b/slack_bolt/kwargs_injection/async_utils.py
@@ -29,7 +29,7 @@ def build_async_required_kwargs(
     error: Optional[Exception] = None,  # for error handlers
     next_keys_required: bool = True,  # False for listeners / middleware / error handlers
 ) -> Dict[str, Any]:
-    all_available_args = {
+    all_available_args: Dict[str, Any] = {
         "logger": logger,
         "client": request.context.client,
         "req": request,
@@ -58,6 +58,7 @@ def build_async_required_kwargs(
         "set_suggested_prompts": request.context.set_suggested_prompts,
         "get_thread_context": request.context.get_thread_context,
         "save_thread_context": request.context.save_thread_context,
+        "agent": request.context.agent,
         # middleware
         "next": next_func,
         "next_": next_func,  # for the middleware using Python's built-in `next()` function
@@ -102,7 +103,7 @@ def build_async_required_kwargs(
     for name in required_arg_names:
         if name == "args":
             if isinstance(request, AsyncBoltRequest):
-                kwargs[name] = AsyncArgs(**all_available_args)  # type: ignore[arg-type]
+                kwargs[name] = AsyncArgs(**all_available_args)
             else:
                 logger.warning(f"Unknown Request object type detected ({type(request)})")
 

--- a/slack_bolt/kwargs_injection/async_utils.py
+++ b/slack_bolt/kwargs_injection/async_utils.py
@@ -58,7 +58,6 @@ def build_async_required_kwargs(
         "set_suggested_prompts": request.context.set_suggested_prompts,
         "get_thread_context": request.context.get_thread_context,
         "save_thread_context": request.context.save_thread_context,
-        "agent": request.context.agent,
         # middleware
         "next": next_func,
         "next_": next_func,  # for the middleware using Python's built-in `next()` function
@@ -83,6 +82,10 @@ def build_async_required_kwargs(
     for k, v in request.context.items():
         if k not in all_available_args:
             all_available_args[k] = v
+
+    # Defer agent creation to avoid constructing AsyncBoltAgent on every request
+    if "agent" in required_arg_names or "args" in required_arg_names:
+        all_available_args["agent"] = request.context.agent
 
     if len(required_arg_names) > 0:
         # To support instance/class methods in a class for listeners/middleware,

--- a/slack_bolt/kwargs_injection/utils.py
+++ b/slack_bolt/kwargs_injection/utils.py
@@ -29,7 +29,7 @@ def build_required_kwargs(
     error: Optional[Exception] = None,  # for error handlers
     next_keys_required: bool = True,  # False for listeners / middleware / error handlers
 ) -> Dict[str, Any]:
-    all_available_args = {
+    all_available_args: Dict[str, Any] = {
         "logger": logger,
         "client": request.context.client,
         "req": request,
@@ -57,6 +57,7 @@ def build_required_kwargs(
         "set_title": request.context.set_title,
         "set_suggested_prompts": request.context.set_suggested_prompts,
         "save_thread_context": request.context.save_thread_context,
+        "agent": request.context.agent,
         # middleware
         "next": next_func,
         "next_": next_func,  # for the middleware using Python's built-in `next()` function
@@ -101,7 +102,7 @@ def build_required_kwargs(
     for name in required_arg_names:
         if name == "args":
             if isinstance(request, BoltRequest):
-                kwargs[name] = Args(**all_available_args)  # type: ignore[arg-type]
+                kwargs[name] = Args(**all_available_args)
             else:
                 logger.warning(f"Unknown Request object type detected ({type(request)})")
 

--- a/slack_bolt/kwargs_injection/utils.py
+++ b/slack_bolt/kwargs_injection/utils.py
@@ -1,9 +1,11 @@
 import inspect
 import logging
+import warnings
 from typing import Callable, Dict, MutableSequence, Optional, Any
 
 from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
+from slack_bolt.warning import ExperimentalWarning
 from .args import Args
 from slack_bolt.request.payload_utils import (
     to_options,
@@ -85,6 +87,12 @@ def build_required_kwargs(
     # Defer agent creation to avoid constructing BoltAgent on every request
     if "agent" in required_arg_names or "args" in required_arg_names:
         all_available_args["agent"] = request.context.agent
+        if "agent" in required_arg_names:
+            warnings.warn(
+                "The agent listener argument is experimental and may change in future versions.",
+                category=ExperimentalWarning,
+                stacklevel=2,  # Point to the caller, not this internal helper
+            )
 
     if len(required_arg_names) > 0:
         # To support instance/class methods in a class for listeners/middleware,

--- a/slack_bolt/kwargs_injection/utils.py
+++ b/slack_bolt/kwargs_injection/utils.py
@@ -57,7 +57,6 @@ def build_required_kwargs(
         "set_title": request.context.set_title,
         "set_suggested_prompts": request.context.set_suggested_prompts,
         "save_thread_context": request.context.save_thread_context,
-        "agent": request.context.agent,
         # middleware
         "next": next_func,
         "next_": next_func,  # for the middleware using Python's built-in `next()` function
@@ -82,6 +81,10 @@ def build_required_kwargs(
     for k, v in request.context.items():
         if k not in all_available_args:
             all_available_args[k] = v
+
+    # Defer agent creation to avoid constructing BoltAgent on every request
+    if "agent" in required_arg_names or "args" in required_arg_names:
+        all_available_args["agent"] = request.context.agent
 
     if len(required_arg_names) > 0:
         # To support instance/class methods in a class for listeners/middleware,

--- a/slack_bolt/warning/__init__.py
+++ b/slack_bolt/warning/__init__.py
@@ -1,0 +1,7 @@
+"""Bolt specific warning types."""
+
+
+class ExperimentalWarning(FutureWarning):
+    """Warning for features that are still in experimental phase."""
+
+    pass

--- a/tests/scenario_tests/test_events_agent.py
+++ b/tests/scenario_tests/test_events_agent.py
@@ -1,10 +1,8 @@
 import json
 from time import sleep
-from unittest.mock import patch, MagicMock
 
 import pytest
 from slack_sdk.web import WebClient
-from slack_sdk.web.chat_stream import ChatStream
 
 from slack_bolt import App, BoltRequest, BoltContext, BoltAgent
 from slack_bolt.agent.agent import BoltAgent as BoltAgentDirect
@@ -57,90 +55,6 @@ class TestEventsAgent:
         assert response.status == 200
         assert_target_called()
 
-    def test_agent_chat_stream_uses_context_defaults(self):
-        """BoltAgent.chat_stream() passes context defaults to WebClient.chat_stream()."""
-        client = MagicMock(spec=WebClient)
-        client.chat_stream.return_value = MagicMock(spec=ChatStream)
-
-        agent = BoltAgentDirect(
-            client=client,
-            channel_id="C111",
-            thread_ts="1234567890.123456",
-            team_id="T111",
-            user_id="W222",
-        )
-        stream = agent.chat_stream()
-
-        client.chat_stream.assert_called_once_with(
-            channel="C111",
-            thread_ts="1234567890.123456",
-            recipient_team_id="T111",
-            recipient_user_id="W222",
-        )
-        assert stream is not None
-
-    def test_agent_chat_stream_overrides_context_defaults(self):
-        """Explicit kwargs to chat_stream() override context defaults."""
-        client = MagicMock(spec=WebClient)
-        client.chat_stream.return_value = MagicMock(spec=ChatStream)
-
-        agent = BoltAgentDirect(
-            client=client,
-            channel_id="C111",
-            thread_ts="1234567890.123456",
-            team_id="T111",
-            user_id="W222",
-        )
-        stream = agent.chat_stream(
-            channel="C999",
-            thread_ts="9999999999.999999",
-            recipient_team_id="T999",
-            recipient_user_id="U999",
-        )
-
-        client.chat_stream.assert_called_once_with(
-            channel="C999",
-            thread_ts="9999999999.999999",
-            recipient_team_id="T999",
-            recipient_user_id="U999",
-        )
-        assert stream is not None
-
-    def test_agent_chat_stream_rejects_partial_overrides(self):
-        """Passing only some of the four context args raises ValueError."""
-        client = MagicMock(spec=WebClient)
-        agent = BoltAgentDirect(
-            client=client,
-            channel_id="C111",
-            thread_ts="1234567890.123456",
-            team_id="T111",
-            user_id="W222",
-        )
-        with pytest.raises(ValueError, match="Either provide all of"):
-            agent.chat_stream(channel="C999")
-
-    def test_agent_chat_stream_passes_extra_kwargs(self):
-        """Extra kwargs are forwarded to WebClient.chat_stream()."""
-        client = MagicMock(spec=WebClient)
-        client.chat_stream.return_value = MagicMock(spec=ChatStream)
-
-        agent = BoltAgentDirect(
-            client=client,
-            channel_id="C111",
-            thread_ts="1234567890.123456",
-            team_id="T111",
-            user_id="W222",
-        )
-        agent.chat_stream(buffer_size=512)
-
-        client.chat_stream.assert_called_once_with(
-            channel="C111",
-            thread_ts="1234567890.123456",
-            recipient_team_id="T111",
-            recipient_user_id="W222",
-            buffer_size=512,
-        )
-
     def test_agent_available_in_action_listener(self):
         app = App(client=self.web_client)
 
@@ -192,16 +106,6 @@ class TestEventsAgent:
         response = app.dispatch(request)
         assert response.status == 200
         assert_target_called()
-
-    def test_agent_import_from_slack_bolt(self):
-        from slack_bolt import BoltAgent as ImportedBoltAgent
-
-        assert ImportedBoltAgent is BoltAgentDirect
-
-    def test_agent_import_from_agent_module(self):
-        from slack_bolt.agent import BoltAgent as ImportedBoltAgent
-
-        assert ImportedBoltAgent is BoltAgentDirect
 
     def test_agent_kwarg_emits_experimental_warning(self):
         app = App(client=self.web_client)

--- a/tests/scenario_tests/test_events_agent.py
+++ b/tests/scenario_tests/test_events_agent.py
@@ -1,0 +1,247 @@
+import json
+from time import sleep
+from unittest.mock import patch, MagicMock
+
+from slack_sdk.web import WebClient
+from slack_sdk.web.chat_stream import ChatStream
+
+from slack_bolt import App, BoltRequest, BoltContext, BoltAgent
+from slack_bolt.agent.agent import BoltAgent as BoltAgentDirect
+from tests.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class TestEventsAgent:
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    web_client = WebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    def setup_method(self):
+        self.old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server(self)
+
+    def teardown_method(self):
+        cleanup_mock_web_api_server(self)
+        restore_os_env(self.old_os_env)
+
+    def test_agent_injected_for_app_mention(self):
+        app = App(client=self.web_client)
+
+        state = {"called": False}
+
+        def assert_target_called():
+            count = 0
+            while state["called"] is False and count < 20:
+                sleep(0.1)
+                count += 1
+            assert state["called"] is True
+            state["called"] = False
+
+        @app.event("app_mention")
+        def handle_mention(agent: BoltAgent, context: BoltContext):
+            assert agent is not None
+            assert isinstance(agent, BoltAgentDirect)
+            assert context.channel_id == "C111"
+            state["called"] = True
+
+        request = BoltRequest(body=app_mention_event_body, mode="socket_mode")
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert_target_called()
+
+    def test_agent_chat_stream_uses_context_defaults(self):
+        """BoltAgent.chat_stream() passes context defaults to WebClient.chat_stream()."""
+        client = MagicMock(spec=WebClient)
+        client.chat_stream.return_value = MagicMock(spec=ChatStream)
+
+        agent = BoltAgentDirect(
+            client=client,
+            channel_id="C111",
+            thread_ts="1234567890.123456",
+            team_id="T111",
+            user_id="W222",
+        )
+        stream = agent.chat_stream()
+
+        client.chat_stream.assert_called_once_with(
+            channel="C111",
+            thread_ts="1234567890.123456",
+            recipient_team_id="T111",
+            recipient_user_id="W222",
+        )
+        assert stream is not None
+
+    def test_agent_chat_stream_overrides_context_defaults(self):
+        """Explicit kwargs to chat_stream() override context defaults."""
+        client = MagicMock(spec=WebClient)
+        client.chat_stream.return_value = MagicMock(spec=ChatStream)
+
+        agent = BoltAgentDirect(
+            client=client,
+            channel_id="C111",
+            thread_ts="1234567890.123456",
+            team_id="T111",
+            user_id="W222",
+        )
+        stream = agent.chat_stream(
+            channel="C999",
+            thread_ts="9999999999.999999",
+            recipient_team_id="T999",
+            recipient_user_id="U999",
+        )
+
+        client.chat_stream.assert_called_once_with(
+            channel="C999",
+            thread_ts="9999999999.999999",
+            recipient_team_id="T999",
+            recipient_user_id="U999",
+        )
+        assert stream is not None
+
+    def test_agent_chat_stream_passes_extra_kwargs(self):
+        """Extra kwargs are forwarded to WebClient.chat_stream()."""
+        client = MagicMock(spec=WebClient)
+        client.chat_stream.return_value = MagicMock(spec=ChatStream)
+
+        agent = BoltAgentDirect(
+            client=client,
+            channel_id="C111",
+            thread_ts="1234567890.123456",
+            team_id="T111",
+            user_id="W222",
+        )
+        agent.chat_stream(buffer_size=512)
+
+        client.chat_stream.assert_called_once_with(
+            channel="C111",
+            thread_ts="1234567890.123456",
+            recipient_team_id="T111",
+            recipient_user_id="W222",
+            buffer_size=512,
+        )
+
+    def test_agent_available_in_action_listener(self):
+        app = App(client=self.web_client)
+
+        state = {"called": False}
+
+        def assert_target_called():
+            count = 0
+            while state["called"] is False and count < 20:
+                sleep(0.1)
+                count += 1
+            assert state["called"] is True
+            state["called"] = False
+
+        @app.action("test_action")
+        def handle_action(ack, agent: BoltAgent):
+            ack()
+            assert agent is not None
+            assert isinstance(agent, BoltAgentDirect)
+            state["called"] = True
+
+        request = BoltRequest(body=json.dumps(action_event_body), mode="socket_mode")
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert_target_called()
+
+    def test_agent_accessible_via_context(self):
+        app = App(client=self.web_client)
+
+        state = {"called": False}
+
+        def assert_target_called():
+            count = 0
+            while state["called"] is False and count < 20:
+                sleep(0.1)
+                count += 1
+            assert state["called"] is True
+            state["called"] = False
+
+        @app.event("app_mention")
+        def handle_mention(context: BoltContext):
+            agent = context.agent
+            assert agent is not None
+            assert isinstance(agent, BoltAgentDirect)
+            # Verify the same instance is returned on subsequent access
+            assert context.agent is agent
+            state["called"] = True
+
+        request = BoltRequest(body=app_mention_event_body, mode="socket_mode")
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert_target_called()
+
+    def test_agent_import_from_slack_bolt(self):
+        from slack_bolt import BoltAgent as ImportedBoltAgent
+
+        assert ImportedBoltAgent is BoltAgentDirect
+
+    def test_agent_import_from_agent_module(self):
+        from slack_bolt.agent import BoltAgent as ImportedBoltAgent
+
+        assert ImportedBoltAgent is BoltAgentDirect
+
+
+# ---- Test event bodies ----
+
+
+def build_payload(event: dict) -> dict:
+    return {
+        "token": "verification_token",
+        "team_id": "T111",
+        "enterprise_id": "E111",
+        "api_app_id": "A111",
+        "event": event,
+        "type": "event_callback",
+        "event_id": "Ev111",
+        "event_time": 1599616881,
+        "authorizations": [
+            {
+                "enterprise_id": "E111",
+                "team_id": "T111",
+                "user_id": "W111",
+                "is_bot": True,
+                "is_enterprise_install": False,
+            }
+        ],
+    }
+
+
+app_mention_event_body = build_payload(
+    {
+        "type": "app_mention",
+        "user": "W222",
+        "text": "<@W111> hello",
+        "ts": "1234567890.123456",
+        "channel": "C111",
+        "event_ts": "1234567890.123456",
+    }
+)
+
+action_event_body = {
+    "type": "block_actions",
+    "user": {"id": "W222", "username": "test_user", "name": "test_user", "team_id": "T111"},
+    "api_app_id": "A111",
+    "token": "verification_token",
+    "container": {"type": "message", "message_ts": "1234567890.123456", "channel_id": "C111", "is_ephemeral": False},
+    "channel": {"id": "C111", "name": "test-channel"},
+    "team": {"id": "T111", "domain": "test"},
+    "enterprise": {"id": "E111", "name": "test"},
+    "trigger_id": "111.222.xxx",
+    "actions": [
+        {
+            "type": "button",
+            "block_id": "b",
+            "action_id": "test_action",
+            "text": {"type": "plain_text", "text": "Button"},
+            "action_ts": "1234567890.123456",
+        }
+    ],
+}

--- a/tests/scenario_tests/test_events_agent.py
+++ b/tests/scenario_tests/test_events_agent.py
@@ -106,6 +106,19 @@ class TestEventsAgent:
         )
         assert stream is not None
 
+    def test_agent_chat_stream_rejects_partial_overrides(self):
+        """Passing only some of the four context args raises ValueError."""
+        client = MagicMock(spec=WebClient)
+        agent = BoltAgentDirect(
+            client=client,
+            channel_id="C111",
+            thread_ts="1234567890.123456",
+            team_id="T111",
+            user_id="W222",
+        )
+        with pytest.raises(ValueError, match="Either provide all of"):
+            agent.chat_stream(channel="C999")
+
     def test_agent_chat_stream_passes_extra_kwargs(self):
         """Extra kwargs are forwarded to WebClient.chat_stream()."""
         client = MagicMock(spec=WebClient)

--- a/tests/scenario_tests/test_events_agent.py
+++ b/tests/scenario_tests/test_events_agent.py
@@ -2,11 +2,13 @@ import json
 from time import sleep
 from unittest.mock import patch, MagicMock
 
+import pytest
 from slack_sdk.web import WebClient
 from slack_sdk.web.chat_stream import ChatStream
 
 from slack_bolt import App, BoltRequest, BoltContext, BoltAgent
 from slack_bolt.agent.agent import BoltAgent as BoltAgentDirect
+from slack_bolt.warning import ExperimentalWarning
 from tests.mock_web_api_server import (
     setup_mock_web_api_server,
     cleanup_mock_web_api_server,
@@ -187,6 +189,29 @@ class TestEventsAgent:
         from slack_bolt.agent import BoltAgent as ImportedBoltAgent
 
         assert ImportedBoltAgent is BoltAgentDirect
+
+    def test_agent_kwarg_emits_experimental_warning(self):
+        app = App(client=self.web_client)
+
+        state = {"called": False}
+
+        def assert_target_called():
+            count = 0
+            while state["called"] is False and count < 20:
+                sleep(0.1)
+                count += 1
+            assert state["called"] is True
+            state["called"] = False
+
+        @app.event("app_mention")
+        def handle_mention(agent: BoltAgent):
+            state["called"] = True
+
+        request = BoltRequest(body=app_mention_event_body, mode="socket_mode")
+        with pytest.warns(ExperimentalWarning, match="agent listener argument is experimental"):
+            response = app.dispatch(request)
+        assert response.status == 200
+        assert_target_called()
 
 
 # ---- Test event bodies ----

--- a/tests/scenario_tests_async/test_events_agent.py
+++ b/tests/scenario_tests_async/test_events_agent.py
@@ -1,6 +1,9 @@
 import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock
+try:
+    from unittest.mock import AsyncMock, MagicMock
+except ImportError:
+    from mock import AsyncMock, MagicMock  # type: ignore
 
 import pytest
 from slack_sdk.web.async_client import AsyncWebClient

--- a/tests/scenario_tests_async/test_events_agent.py
+++ b/tests/scenario_tests_async/test_events_agent.py
@@ -1,10 +1,8 @@
 import asyncio
 import json
-from unittest.mock import MagicMock
 
 import pytest
 from slack_sdk.web.async_client import AsyncWebClient
-from slack_sdk.web.async_chat_stream import AsyncChatStream
 
 from slack_bolt.agent.async_agent import AsyncBoltAgent
 from slack_bolt.app.async_app import AsyncApp
@@ -16,17 +14,6 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server_async,
 )
 from tests.utils import remove_os_env_temporarily, restore_os_env
-
-
-def _make_async_chat_stream_mock():
-    mock_stream = MagicMock(spec=AsyncChatStream)
-    call_tracker = MagicMock()
-
-    async def fake_chat_stream(**kwargs):
-        call_tracker(**kwargs)
-        return mock_stream
-
-    return fake_chat_stream, call_tracker, mock_stream
 
 
 class TestAsyncEventsAgent:
@@ -72,94 +59,6 @@ class TestAsyncEventsAgent:
         response = await app.async_dispatch(request)
         assert response.status == 200
         await assert_target_called()
-
-    @pytest.mark.asyncio
-    async def test_agent_chat_stream_uses_context_defaults(self):
-        """AsyncBoltAgent.chat_stream() passes context defaults to AsyncWebClient.chat_stream()."""
-        client = MagicMock(spec=AsyncWebClient)
-        client.chat_stream, call_tracker, _ = _make_async_chat_stream_mock()
-
-        agent = AsyncBoltAgent(
-            client=client,
-            channel_id="C111",
-            thread_ts="1234567890.123456",
-            team_id="T111",
-            user_id="W222",
-        )
-        stream = await agent.chat_stream()
-
-        call_tracker.assert_called_once_with(
-            channel="C111",
-            thread_ts="1234567890.123456",
-            recipient_team_id="T111",
-            recipient_user_id="W222",
-        )
-        assert stream is not None
-
-    @pytest.mark.asyncio
-    async def test_agent_chat_stream_overrides_context_defaults(self):
-        """Explicit kwargs to chat_stream() override context defaults."""
-        client = MagicMock(spec=AsyncWebClient)
-        client.chat_stream, call_tracker, _ = _make_async_chat_stream_mock()
-
-        agent = AsyncBoltAgent(
-            client=client,
-            channel_id="C111",
-            thread_ts="1234567890.123456",
-            team_id="T111",
-            user_id="W222",
-        )
-        stream = await agent.chat_stream(
-            channel="C999",
-            thread_ts="9999999999.999999",
-            recipient_team_id="T999",
-            recipient_user_id="U999",
-        )
-
-        call_tracker.assert_called_once_with(
-            channel="C999",
-            thread_ts="9999999999.999999",
-            recipient_team_id="T999",
-            recipient_user_id="U999",
-        )
-        assert stream is not None
-
-    @pytest.mark.asyncio
-    async def test_agent_chat_stream_rejects_partial_overrides(self):
-        """Passing only some of the four context args raises ValueError."""
-        client = MagicMock(spec=AsyncWebClient)
-        agent = AsyncBoltAgent(
-            client=client,
-            channel_id="C111",
-            thread_ts="1234567890.123456",
-            team_id="T111",
-            user_id="W222",
-        )
-        with pytest.raises(ValueError, match="Either provide all of"):
-            await agent.chat_stream(channel="C999")
-
-    @pytest.mark.asyncio
-    async def test_agent_chat_stream_passes_extra_kwargs(self):
-        """Extra kwargs are forwarded to AsyncWebClient.chat_stream()."""
-        client = MagicMock(spec=AsyncWebClient)
-        client.chat_stream, call_tracker, _ = _make_async_chat_stream_mock()
-
-        agent = AsyncBoltAgent(
-            client=client,
-            channel_id="C111",
-            thread_ts="1234567890.123456",
-            team_id="T111",
-            user_id="W222",
-        )
-        await agent.chat_stream(buffer_size=512)
-
-        call_tracker.assert_called_once_with(
-            channel="C111",
-            thread_ts="1234567890.123456",
-            recipient_team_id="T111",
-            recipient_user_id="W222",
-            buffer_size=512,
-        )
 
     @pytest.mark.asyncio
     async def test_agent_available_in_action_listener(self):
@@ -214,12 +113,6 @@ class TestAsyncEventsAgent:
         response = await app.async_dispatch(request)
         assert response.status == 200
         await assert_target_called()
-
-    @pytest.mark.asyncio
-    async def test_agent_import_from_agent_module(self):
-        from slack_bolt.agent.async_agent import AsyncBoltAgent as ImportedAsyncBoltAgent
-
-        assert ImportedAsyncBoltAgent is AsyncBoltAgent
 
     @pytest.mark.asyncio
     async def test_agent_kwarg_emits_experimental_warning(self):

--- a/tests/scenario_tests_async/test_events_agent.py
+++ b/tests/scenario_tests_async/test_events_agent.py
@@ -125,6 +125,20 @@ class TestAsyncEventsAgent:
         assert stream is not None
 
     @pytest.mark.asyncio
+    async def test_agent_chat_stream_rejects_partial_overrides(self):
+        """Passing only some of the four context args raises ValueError."""
+        client = MagicMock(spec=AsyncWebClient)
+        agent = AsyncBoltAgent(
+            client=client,
+            channel_id="C111",
+            thread_ts="1234567890.123456",
+            team_id="T111",
+            user_id="W222",
+        )
+        with pytest.raises(ValueError, match="Either provide all of"):
+            await agent.chat_stream(channel="C999")
+
+    @pytest.mark.asyncio
     async def test_agent_chat_stream_passes_extra_kwargs(self):
         """Extra kwargs are forwarded to AsyncWebClient.chat_stream()."""
         client = MagicMock(spec=AsyncWebClient)

--- a/tests/scenario_tests_async/test_events_agent.py
+++ b/tests/scenario_tests_async/test_events_agent.py
@@ -1,0 +1,254 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from slack_sdk.web.async_client import AsyncWebClient
+from slack_sdk.web.async_chat_stream import AsyncChatStream
+
+from slack_bolt.agent.async_agent import AsyncBoltAgent
+from slack_bolt.app.async_app import AsyncApp
+from slack_bolt.context.async_context import AsyncBoltContext
+from slack_bolt.request.async_request import AsyncBoltRequest
+from tests.mock_web_api_server import (
+    cleanup_mock_web_api_server_async,
+    setup_mock_web_api_server_async,
+)
+from tests.utils import remove_os_env_temporarily, restore_os_env
+
+
+class TestAsyncEventsAgent:
+    valid_token = "xoxb-valid"
+    mock_api_server_base_url = "http://localhost:8888"
+    web_client = AsyncWebClient(
+        token=valid_token,
+        base_url=mock_api_server_base_url,
+    )
+
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_teardown(self):
+        old_os_env = remove_os_env_temporarily()
+        setup_mock_web_api_server_async(self)
+        try:
+            yield
+        finally:
+            cleanup_mock_web_api_server_async(self)
+            restore_os_env(old_os_env)
+
+    @pytest.mark.asyncio
+    async def test_agent_injected_for_app_mention(self):
+        app = AsyncApp(client=self.web_client)
+
+        state = {"called": False}
+
+        async def assert_target_called():
+            count = 0
+            while state["called"] is False and count < 20:
+                await asyncio.sleep(0.1)
+                count += 1
+            assert state["called"] is True
+            state["called"] = False
+
+        @app.event("app_mention")
+        async def handle_mention(agent: AsyncBoltAgent, context: AsyncBoltContext):
+            assert agent is not None
+            assert isinstance(agent, AsyncBoltAgent)
+            assert context.channel_id == "C111"
+            state["called"] = True
+
+        request = AsyncBoltRequest(body=app_mention_event_body, mode="socket_mode")
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_target_called()
+
+    @pytest.mark.asyncio
+    async def test_agent_chat_stream_uses_context_defaults(self):
+        """AsyncBoltAgent.chat_stream() passes context defaults to AsyncWebClient.chat_stream()."""
+        client = MagicMock(spec=AsyncWebClient)
+        client.chat_stream = AsyncMock(return_value=MagicMock(spec=AsyncChatStream))
+
+        agent = AsyncBoltAgent(
+            client=client,
+            channel_id="C111",
+            thread_ts="1234567890.123456",
+            team_id="T111",
+            user_id="W222",
+        )
+        stream = await agent.chat_stream()
+
+        client.chat_stream.assert_called_once_with(
+            channel="C111",
+            thread_ts="1234567890.123456",
+            recipient_team_id="T111",
+            recipient_user_id="W222",
+        )
+        assert stream is not None
+
+    @pytest.mark.asyncio
+    async def test_agent_chat_stream_overrides_context_defaults(self):
+        """Explicit kwargs to chat_stream() override context defaults."""
+        client = MagicMock(spec=AsyncWebClient)
+        client.chat_stream = AsyncMock(return_value=MagicMock(spec=AsyncChatStream))
+
+        agent = AsyncBoltAgent(
+            client=client,
+            channel_id="C111",
+            thread_ts="1234567890.123456",
+            team_id="T111",
+            user_id="W222",
+        )
+        stream = await agent.chat_stream(
+            channel="C999",
+            thread_ts="9999999999.999999",
+            recipient_team_id="T999",
+            recipient_user_id="U999",
+        )
+
+        client.chat_stream.assert_called_once_with(
+            channel="C999",
+            thread_ts="9999999999.999999",
+            recipient_team_id="T999",
+            recipient_user_id="U999",
+        )
+        assert stream is not None
+
+    @pytest.mark.asyncio
+    async def test_agent_chat_stream_passes_extra_kwargs(self):
+        """Extra kwargs are forwarded to AsyncWebClient.chat_stream()."""
+        client = MagicMock(spec=AsyncWebClient)
+        client.chat_stream = AsyncMock(return_value=MagicMock(spec=AsyncChatStream))
+
+        agent = AsyncBoltAgent(
+            client=client,
+            channel_id="C111",
+            thread_ts="1234567890.123456",
+            team_id="T111",
+            user_id="W222",
+        )
+        await agent.chat_stream(buffer_size=512)
+
+        client.chat_stream.assert_called_once_with(
+            channel="C111",
+            thread_ts="1234567890.123456",
+            recipient_team_id="T111",
+            recipient_user_id="W222",
+            buffer_size=512,
+        )
+
+    @pytest.mark.asyncio
+    async def test_agent_available_in_action_listener(self):
+        app = AsyncApp(client=self.web_client)
+
+        state = {"called": False}
+
+        async def assert_target_called():
+            count = 0
+            while state["called"] is False and count < 20:
+                await asyncio.sleep(0.1)
+                count += 1
+            assert state["called"] is True
+            state["called"] = False
+
+        @app.action("test_action")
+        async def handle_action(ack, agent: AsyncBoltAgent):
+            await ack()
+            assert agent is not None
+            assert isinstance(agent, AsyncBoltAgent)
+            state["called"] = True
+
+        request = AsyncBoltRequest(body=json.dumps(action_event_body), mode="socket_mode")
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_target_called()
+
+    @pytest.mark.asyncio
+    async def test_agent_accessible_via_context(self):
+        app = AsyncApp(client=self.web_client)
+
+        state = {"called": False}
+
+        async def assert_target_called():
+            count = 0
+            while state["called"] is False and count < 20:
+                await asyncio.sleep(0.1)
+                count += 1
+            assert state["called"] is True
+            state["called"] = False
+
+        @app.event("app_mention")
+        async def handle_mention(context: AsyncBoltContext):
+            agent = context.agent
+            assert agent is not None
+            assert isinstance(agent, AsyncBoltAgent)
+            # Verify the same instance is returned on subsequent access
+            assert context.agent is agent
+            state["called"] = True
+
+        request = AsyncBoltRequest(body=app_mention_event_body, mode="socket_mode")
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        await assert_target_called()
+
+    @pytest.mark.asyncio
+    async def test_agent_import_from_agent_module(self):
+        from slack_bolt.agent.async_agent import AsyncBoltAgent as ImportedAsyncBoltAgent
+
+        assert ImportedAsyncBoltAgent is AsyncBoltAgent
+
+
+# ---- Test event bodies ----
+
+
+def build_payload(event: dict) -> dict:
+    return {
+        "token": "verification_token",
+        "team_id": "T111",
+        "enterprise_id": "E111",
+        "api_app_id": "A111",
+        "event": event,
+        "type": "event_callback",
+        "event_id": "Ev111",
+        "event_time": 1599616881,
+        "authorizations": [
+            {
+                "enterprise_id": "E111",
+                "team_id": "T111",
+                "user_id": "W111",
+                "is_bot": True,
+                "is_enterprise_install": False,
+            }
+        ],
+    }
+
+
+app_mention_event_body = build_payload(
+    {
+        "type": "app_mention",
+        "user": "W222",
+        "text": "<@W111> hello",
+        "ts": "1234567890.123456",
+        "channel": "C111",
+        "event_ts": "1234567890.123456",
+    }
+)
+
+action_event_body = {
+    "type": "block_actions",
+    "user": {"id": "W222", "username": "test_user", "name": "test_user", "team_id": "T111"},
+    "api_app_id": "A111",
+    "token": "verification_token",
+    "container": {"type": "message", "message_ts": "1234567890.123456", "channel_id": "C111", "is_ephemeral": False},
+    "channel": {"id": "C111", "name": "test-channel"},
+    "team": {"id": "T111", "domain": "test"},
+    "enterprise": {"id": "E111", "name": "test"},
+    "trigger_id": "111.222.xxx",
+    "actions": [
+        {
+            "type": "button",
+            "block_id": "b",
+            "action_id": "test_action",
+            "text": {"type": "plain_text", "text": "Button"},
+            "action_ts": "1234567890.123456",
+        }
+    ],
+}

--- a/tests/slack_bolt/agent/test_tools.py
+++ b/tests/slack_bolt/agent/test_tools.py
@@ -1,0 +1,366 @@
+from unittest.mock import MagicMock, call
+
+import pytest
+from slack_sdk.web.chat_stream import ChatStream
+
+from slack_bolt.agent.tools import Tools, ToolDefinition, _introspect_handler
+
+
+# ---- Helpers ----
+
+
+def _make_stream():
+    stream = MagicMock(spec=ChatStream)
+    stream.append.return_value = None
+    return stream
+
+
+def _simple_handler(query: str, limit: int = 10) -> str:
+    """Search for something."""
+    return f"{query}:{limit}"
+
+
+# ======================================================================
+# add()
+# ======================================================================
+
+
+class TestAdd:
+    def test_decorator_usage(self):
+        tools = Tools()
+
+        @tools.add("search")
+        def search(query: str) -> str:
+            """Find stuff."""
+            return query
+
+        assert "search" in tools
+        assert len(tools) == 1
+
+    def test_programmatic_usage(self):
+        tools = Tools()
+        tools.add("search", handler=_simple_handler, description="Search")
+        assert "search" in tools
+
+    def test_duplicate_name_raises(self):
+        tools = Tools()
+        tools.add("search", handler=_simple_handler)
+        with pytest.raises(ValueError, match="already registered"):
+            tools.add("search", handler=_simple_handler)
+
+    def test_docstring_as_description(self):
+        tools = Tools()
+        tools.add("search", handler=_simple_handler)
+        defn = tools._definitions["search"]
+        assert defn.description == "Search for something."
+
+    def test_explicit_description_overrides_docstring(self):
+        tools = Tools()
+        tools.add("search", handler=_simple_handler, description="Custom desc")
+        assert tools._definitions["search"].description == "Custom desc"
+
+    def test_explicit_parameters_override_introspection(self):
+        tools = Tools()
+        custom_params = {"q": {"type": "string"}}
+        tools.add("search", handler=_simple_handler, parameters=custom_params)
+        assert tools._definitions["search"].parameters == custom_params
+
+    def test_explicit_required_override_introspection(self):
+        tools = Tools()
+        tools.add("search", handler=_simple_handler, required=["query", "limit"])
+        assert tools._definitions["search"].required == ["query", "limit"]
+
+    def test_decorator_returns_original_function(self):
+        tools = Tools()
+
+        @tools.add("search")
+        def search(query: str) -> str:
+            return query
+
+        assert callable(search)
+        assert search("hello") == "hello"
+
+    def test_programmatic_returns_none(self):
+        tools = Tools()
+        result = tools.add("search", handler=_simple_handler)
+        assert result is None
+
+
+# ======================================================================
+# _introspect_handler
+# ======================================================================
+
+
+class TestIntrospection:
+    def test_str_type(self):
+        def fn(x: str):
+            pass
+
+        info = _introspect_handler(fn)
+        assert info["parameters"]["x"]["type"] == "string"
+
+    def test_int_type(self):
+        def fn(x: int):
+            pass
+
+        info = _introspect_handler(fn)
+        assert info["parameters"]["x"]["type"] == "integer"
+
+    def test_float_type(self):
+        def fn(x: float):
+            pass
+
+        info = _introspect_handler(fn)
+        assert info["parameters"]["x"]["type"] == "number"
+
+    def test_bool_type(self):
+        def fn(x: bool):
+            pass
+
+        info = _introspect_handler(fn)
+        assert info["parameters"]["x"]["type"] == "boolean"
+
+    def test_list_type(self):
+        def fn(x: list):
+            pass
+
+        info = _introspect_handler(fn)
+        assert info["parameters"]["x"]["type"] == "array"
+
+    def test_dict_type(self):
+        def fn(x: dict):
+            pass
+
+        info = _introspect_handler(fn)
+        assert info["parameters"]["x"]["type"] == "object"
+
+    def test_no_type_hint_defaults_to_string(self):
+        def fn(x):
+            pass
+
+        info = _introspect_handler(fn)
+        assert info["parameters"]["x"]["type"] == "string"
+
+    def test_required_vs_optional(self):
+        def fn(a: str, b: int = 5):
+            pass
+
+        info = _introspect_handler(fn)
+        assert "a" in info["required"]
+        assert "b" not in info["required"]
+
+    def test_docstring_used_as_description(self):
+        def fn():
+            """Do something cool."""
+            pass
+
+        info = _introspect_handler(fn)
+        assert info["description"] == "Do something cool."
+
+    def test_no_docstring(self):
+        def fn():
+            pass
+
+        info = _introspect_handler(fn)
+        assert info["description"] == ""
+
+
+# ======================================================================
+# execute()
+# ======================================================================
+
+
+class TestExecute:
+    def test_status_lifecycle(self):
+        tools = Tools()
+        tools.add("echo", handler=lambda msg: msg)
+
+        stream = _make_stream()
+        result = tools.execute(stream, call_id="c1", name="echo", arguments={"msg": "hi"})
+
+        assert result == "hi"
+        assert stream.append.call_count == 2
+        calls = stream.append.call_args_list
+        assert calls[0] == call(markdown_text="", task_update={"call_id": "c1", "status": "in_progress"})
+        assert calls[1] == call(markdown_text="", task_update={"call_id": "c1", "status": "completed", "output": "hi"})
+
+    def test_unknown_tool_raises_keyerror(self):
+        tools = Tools()
+        stream = _make_stream()
+        with pytest.raises(KeyError, match="Unknown tool"):
+            tools.execute(stream, call_id="c1", name="nope")
+
+    def test_handler_exception_sends_failed_then_reraises(self):
+        def bad_handler():
+            raise RuntimeError("boom")
+
+        tools = Tools()
+        tools.add("bad", handler=bad_handler)
+        stream = _make_stream()
+
+        with pytest.raises(RuntimeError, match="boom"):
+            tools.execute(stream, call_id="c1", name="bad")
+
+        calls = stream.append.call_args_list
+        assert len(calls) == 2
+        assert calls[0] == call(markdown_text="", task_update={"call_id": "c1", "status": "in_progress"})
+        assert calls[1] == call(markdown_text="", task_update={"call_id": "c1", "status": "failed", "output": "boom"})
+
+    def test_arguments_forwarded_correctly(self):
+        captured = {}
+
+        def handler(a: str, b: int = 0):
+            captured["a"] = a
+            captured["b"] = b
+            return "ok"
+
+        tools = Tools()
+        tools.add("fn", handler=handler)
+        stream = _make_stream()
+        tools.execute(stream, call_id="c1", name="fn", arguments={"a": "hello", "b": 42})
+
+        assert captured == {"a": "hello", "b": 42}
+
+    def test_result_returned(self):
+        tools = Tools()
+        tools.add("add", handler=lambda x, y: str(int(x) + int(y)))
+        stream = _make_stream()
+        result = tools.execute(stream, call_id="c1", name="add", arguments={"x": "3", "y": "4"})
+        assert result == "7"
+
+    def test_none_arguments_treated_as_empty(self):
+        tools = Tools()
+        tools.add("noop", handler=lambda: "done")
+        stream = _make_stream()
+        result = tools.execute(stream, call_id="c1", name="noop", arguments=None)
+        assert result == "done"
+
+
+# ======================================================================
+# schema()
+# ======================================================================
+
+
+class TestSchema:
+    def test_openai_format(self):
+        tools = Tools()
+        tools.add("search", handler=_simple_handler)
+
+        schemas = tools.schema("openai")
+        assert len(schemas) == 1
+        s = schemas[0]
+        assert s["type"] == "function"
+        assert s["function"]["name"] == "search"
+        assert s["function"]["description"] == "Search for something."
+        params = s["function"]["parameters"]
+        assert params["type"] == "object"
+        assert "query" in params["properties"]
+        assert "limit" in params["properties"]
+        assert params["required"] == ["query"]
+
+    def test_anthropic_format(self):
+        tools = Tools()
+        tools.add("search", handler=_simple_handler)
+
+        schemas = tools.schema("anthropic")
+        assert len(schemas) == 1
+        s = schemas[0]
+        assert s["name"] == "search"
+        assert s["description"] == "Search for something."
+        assert "input_schema" in s
+        assert s["input_schema"]["type"] == "object"
+        assert "query" in s["input_schema"]["properties"]
+        assert s["input_schema"]["required"] == ["query"]
+
+    def test_unsupported_provider_raises(self):
+        tools = Tools()
+        with pytest.raises(ValueError, match="Unsupported provider"):
+            tools.schema("gemini")
+
+    def test_empty_registry(self):
+        tools = Tools()
+        assert tools.schema("openai") == []
+        assert tools.schema("anthropic") == []
+
+    def test_multiple_tools(self):
+        tools = Tools()
+        tools.add("a", handler=lambda: "x")
+        tools.add("b", handler=lambda: "y")
+
+        schemas = tools.schema("openai")
+        assert len(schemas) == 2
+        names = {s["function"]["name"] for s in schemas}
+        assert names == {"a", "b"}
+
+
+# ======================================================================
+# copy()
+# ======================================================================
+
+
+class TestCopy:
+    def test_independent_registry(self):
+        tools = Tools()
+        tools.add("search", handler=_simple_handler)
+        cloned = tools.copy()
+
+        cloned.add("other", handler=lambda: "x")
+        assert "other" in cloned
+        assert "other" not in tools
+
+    def test_shared_handler_references(self):
+        tools = Tools()
+        tools.add("search", handler=_simple_handler)
+        cloned = tools.copy()
+
+        assert tools._definitions["search"].handler is cloned._definitions["search"].handler
+
+    def test_deep_copied_parameters(self):
+        tools = Tools()
+        tools.add("search", handler=_simple_handler)
+        cloned = tools.copy()
+
+        cloned._definitions["search"].parameters["query"]["type"] = "integer"
+        assert tools._definitions["search"].parameters["query"]["type"] == "string"
+
+
+# ======================================================================
+# __len__ / __contains__
+# ======================================================================
+
+
+class TestConvenience:
+    def test_len_empty(self):
+        assert len(Tools()) == 0
+
+    def test_len_with_tools(self):
+        tools = Tools()
+        tools.add("a", handler=lambda: "x")
+        tools.add("b", handler=lambda: "y")
+        assert len(tools) == 2
+
+    def test_contains_true(self):
+        tools = Tools()
+        tools.add("search", handler=_simple_handler)
+        assert "search" in tools
+
+    def test_contains_false(self):
+        tools = Tools()
+        assert "search" not in tools
+
+
+# ======================================================================
+# Import paths
+# ======================================================================
+
+
+class TestImports:
+    def test_import_from_agent_module(self):
+        from slack_bolt.agent import Tools as ImportedTools
+
+        assert ImportedTools is Tools
+
+    def test_import_from_slack_bolt(self):
+        from slack_bolt import Tools as ImportedTools
+
+        assert ImportedTools is Tools

--- a/tests/slack_bolt_async/agent/test_async_agent.py
+++ b/tests/slack_bolt_async/agent/test_async_agent.py
@@ -1,0 +1,114 @@
+from unittest.mock import MagicMock
+
+import pytest
+from slack_sdk.web.async_client import AsyncWebClient
+from slack_sdk.web.async_chat_stream import AsyncChatStream
+
+from slack_bolt.agent.async_agent import AsyncBoltAgent
+
+
+def _make_async_chat_stream_mock():
+    mock_stream = MagicMock(spec=AsyncChatStream)
+    call_tracker = MagicMock()
+
+    async def fake_chat_stream(**kwargs):
+        call_tracker(**kwargs)
+        return mock_stream
+
+    return fake_chat_stream, call_tracker, mock_stream
+
+
+class TestAsyncBoltAgent:
+    @pytest.mark.asyncio
+    async def test_chat_stream_uses_context_defaults(self):
+        """AsyncBoltAgent.chat_stream() passes context defaults to AsyncWebClient.chat_stream()."""
+        client = MagicMock(spec=AsyncWebClient)
+        client.chat_stream, call_tracker, _ = _make_async_chat_stream_mock()
+
+        agent = AsyncBoltAgent(
+            client=client,
+            channel_id="C111",
+            thread_ts="1234567890.123456",
+            team_id="T111",
+            user_id="W222",
+        )
+        stream = await agent.chat_stream()
+
+        call_tracker.assert_called_once_with(
+            channel="C111",
+            thread_ts="1234567890.123456",
+            recipient_team_id="T111",
+            recipient_user_id="W222",
+        )
+        assert stream is not None
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_overrides_context_defaults(self):
+        """Explicit kwargs to chat_stream() override context defaults."""
+        client = MagicMock(spec=AsyncWebClient)
+        client.chat_stream, call_tracker, _ = _make_async_chat_stream_mock()
+
+        agent = AsyncBoltAgent(
+            client=client,
+            channel_id="C111",
+            thread_ts="1234567890.123456",
+            team_id="T111",
+            user_id="W222",
+        )
+        stream = await agent.chat_stream(
+            channel="C999",
+            thread_ts="9999999999.999999",
+            recipient_team_id="T999",
+            recipient_user_id="U999",
+        )
+
+        call_tracker.assert_called_once_with(
+            channel="C999",
+            thread_ts="9999999999.999999",
+            recipient_team_id="T999",
+            recipient_user_id="U999",
+        )
+        assert stream is not None
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_rejects_partial_overrides(self):
+        """Passing only some of the four context args raises ValueError."""
+        client = MagicMock(spec=AsyncWebClient)
+        agent = AsyncBoltAgent(
+            client=client,
+            channel_id="C111",
+            thread_ts="1234567890.123456",
+            team_id="T111",
+            user_id="W222",
+        )
+        with pytest.raises(ValueError, match="Either provide all of"):
+            await agent.chat_stream(channel="C999")
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_passes_extra_kwargs(self):
+        """Extra kwargs are forwarded to AsyncWebClient.chat_stream()."""
+        client = MagicMock(spec=AsyncWebClient)
+        client.chat_stream, call_tracker, _ = _make_async_chat_stream_mock()
+
+        agent = AsyncBoltAgent(
+            client=client,
+            channel_id="C111",
+            thread_ts="1234567890.123456",
+            team_id="T111",
+            user_id="W222",
+        )
+        await agent.chat_stream(buffer_size=512)
+
+        call_tracker.assert_called_once_with(
+            channel="C111",
+            thread_ts="1234567890.123456",
+            recipient_team_id="T111",
+            recipient_user_id="W222",
+            buffer_size=512,
+        )
+
+    @pytest.mark.asyncio
+    async def test_import_from_agent_module(self):
+        from slack_bolt.agent.async_agent import AsyncBoltAgent as ImportedAsyncBoltAgent
+
+        assert ImportedAsyncBoltAgent is AsyncBoltAgent


### PR DESCRIPTION
## Summary

  - Add Tools registry class for registering, executing, and exporting tool handlers in the agent module
  - Support decorator (@tools.add("name")) and programmatic registration with auto-introspection of handler signatures into JSON Schema
  - execute() dispatches to handlers with task_update status lifecycle via ChatStream
  - schema() exports definitions in OpenAI and Anthropic formats

### Testing

 - 39 new unit tests in tests/slack_bolt/agent/test_tools.py
  - Existing agent and scenario tests still pass

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
