### PR TITLE
fix(agent): match channel_id api argument for set_status and set_suggested_prompts

### DIFF
--- a/slack_bolt/agent/agent.py
+++ b/slack_bolt/agent/agent.py
@@ -77,7 +77,7 @@ class BoltAgent:
         *,
         status: str,
         loading_messages: Optional[List[str]] = None,
-        channel: Optional[str] = None,
+        channel_id: Optional[str] = None,
         thread_ts: Optional[str] = None,
         **kwargs,
     ) -> SlackResponse:
@@ -86,7 +86,7 @@ class BoltAgent:
         Args:
             status: The status text to display.
             loading_messages: Optional list of loading messages to cycle through.
-            channel: Channel ID. Defaults to the channel from the event context.
+            channel_id: Channel ID. Defaults to the channel from the event context.
             thread_ts: Thread timestamp. Defaults to the thread_ts from the event context.
             **kwargs: Additional arguments passed to ``WebClient.assistant_threads_setStatus()``.
 
@@ -94,7 +94,7 @@ class BoltAgent:
             ``SlackResponse`` from the API call.
         """
         return self._client.assistant_threads_setStatus(
-            channel_id=channel or self._channel_id,  # type: ignore[arg-type]
+            channel_id=channel_id or self._channel_id,  # type: ignore[arg-type]
             thread_ts=thread_ts or self._thread_ts or self._ts,  # type: ignore[arg-type]
             status=status,
             loading_messages=loading_messages,
@@ -106,7 +106,7 @@ class BoltAgent:
         *,
         prompts: Sequence[Union[str, Dict[str, str]]],
         title: Optional[str] = None,
-        channel: Optional[str] = None,
+        channel_id: Optional[str] = None,
         thread_ts: Optional[str] = None,
         **kwargs,
     ) -> SlackResponse:
@@ -116,7 +116,7 @@ class BoltAgent:
             prompts: A sequence of prompts. Each prompt can be either a string
                 (used as both title and message) or a dict with 'title' and 'message' keys.
             title: Optional title for the suggested prompts section.
-            channel: Channel ID. Defaults to the channel from the event context.
+            channel_id: Channel ID. Defaults to the channel from the event context.
             thread_ts: Thread timestamp. Defaults to the thread_ts from the event context.
             **kwargs: Additional arguments passed to ``WebClient.assistant_threads_setSuggestedPrompts()``.
 
@@ -131,7 +131,7 @@ class BoltAgent:
                 prompts_arg.append(prompt)
 
         return self._client.assistant_threads_setSuggestedPrompts(
-            channel_id=channel or self._channel_id,  # type: ignore[arg-type]
+            channel_id=channel_id or self._channel_id,  # type: ignore[arg-type]
             thread_ts=thread_ts or self._thread_ts or self._ts,  # type: ignore[arg-type]
             prompts=prompts_arg,
             title=title,

--- a/slack_bolt/agent/async_agent.py
+++ b/slack_bolt/agent/async_agent.py
@@ -76,7 +76,7 @@ class AsyncBoltAgent:
         *,
         status: str,
         loading_messages: Optional[List[str]] = None,
-        channel: Optional[str] = None,
+        channel_id: Optional[str] = None,
         thread_ts: Optional[str] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
@@ -85,7 +85,7 @@ class AsyncBoltAgent:
         Args:
             status: The status text to display.
             loading_messages: Optional list of loading messages to cycle through.
-            channel: Channel ID. Defaults to the channel from the event context.
+            channel_id: Channel ID. Defaults to the channel from the event context.
             thread_ts: Thread timestamp. Defaults to the thread_ts from the event context.
             **kwargs: Additional arguments passed to ``AsyncWebClient.assistant_threads_setStatus()``.
 
@@ -93,7 +93,7 @@ class AsyncBoltAgent:
             ``AsyncSlackResponse`` from the API call.
         """
         return await self._client.assistant_threads_setStatus(
-            channel_id=channel or self._channel_id,  # type: ignore[arg-type]
+            channel_id=channel_id or self._channel_id,  # type: ignore[arg-type]
             thread_ts=thread_ts or self._thread_ts or self._ts,  # type: ignore[arg-type]
             status=status,
             loading_messages=loading_messages,
@@ -105,7 +105,7 @@ class AsyncBoltAgent:
         *,
         prompts: Sequence[Union[str, Dict[str, str]]],
         title: Optional[str] = None,
-        channel: Optional[str] = None,
+        channel_id: Optional[str] = None,
         thread_ts: Optional[str] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
@@ -115,7 +115,7 @@ class AsyncBoltAgent:
             prompts: A sequence of prompts. Each prompt can be either a string
                 (used as both title and message) or a dict with 'title' and 'message' keys.
             title: Optional title for the suggested prompts section.
-            channel: Channel ID. Defaults to the channel from the event context.
+            channel_id: Channel ID. Defaults to the channel from the event context.
             thread_ts: Thread timestamp. Defaults to the thread_ts from the event context.
             **kwargs: Additional arguments passed to ``AsyncWebClient.assistant_threads_setSuggestedPrompts()``.
 
@@ -130,7 +130,7 @@ class AsyncBoltAgent:
                 prompts_arg.append(prompt)
 
         return await self._client.assistant_threads_setSuggestedPrompts(
-            channel_id=channel or self._channel_id,  # type: ignore[arg-type]
+            channel_id=channel_id or self._channel_id,  # type: ignore[arg-type]
             thread_ts=thread_ts or self._thread_ts or self._ts,  # type: ignore[arg-type]
             prompts=prompts_arg,
             title=title,

--- a/tests/slack_bolt/agent/test_agent.py
+++ b/tests/slack_bolt/agent/test_agent.py
@@ -183,7 +183,7 @@ class TestBoltAgent:
         )
 
     def test_set_status_overrides_context_defaults(self):
-        """Explicit channel/thread_ts override context defaults."""
+        """Explicit channel_id/thread_ts override context defaults."""
         client = MagicMock(spec=WebClient)
         client.assistant_threads_setStatus.return_value = MagicMock()
 
@@ -196,7 +196,7 @@ class TestBoltAgent:
         )
         agent.set_status(
             status="Thinking...",
-            channel="C999",
+            channel_id="C999",
             thread_ts="9999999999.999999",
         )
 
@@ -295,7 +295,7 @@ class TestBoltAgent:
         )
 
     def test_set_suggested_prompts_overrides_context_defaults(self):
-        """Explicit channel/thread_ts override context defaults."""
+        """Explicit channel_id/thread_ts override context defaults."""
         client = MagicMock(spec=WebClient)
         client.assistant_threads_setSuggestedPrompts.return_value = MagicMock()
 
@@ -308,7 +308,7 @@ class TestBoltAgent:
         )
         agent.set_suggested_prompts(
             prompts=["Hello"],
-            channel="C999",
+            channel_id="C999",
             thread_ts="9999999999.999999",
         )
 

--- a/tests/slack_bolt_async/agent/test_async_agent.py
+++ b/tests/slack_bolt_async/agent/test_async_agent.py
@@ -214,7 +214,7 @@ class TestAsyncBoltAgent:
 
     @pytest.mark.asyncio
     async def test_set_status_overrides_context_defaults(self):
-        """Explicit channel/thread_ts override context defaults."""
+        """Explicit channel_id/thread_ts override context defaults."""
         client = MagicMock(spec=AsyncWebClient)
         client.assistant_threads_setStatus, call_tracker, _ = _make_async_api_mock()
 
@@ -227,7 +227,7 @@ class TestAsyncBoltAgent:
         )
         await agent.set_status(
             status="Thinking...",
-            channel="C999",
+            channel_id="C999",
             thread_ts="9999999999.999999",
         )
 
@@ -331,7 +331,7 @@ class TestAsyncBoltAgent:
 
     @pytest.mark.asyncio
     async def test_set_suggested_prompts_overrides_context_defaults(self):
-        """Explicit channel/thread_ts override context defaults."""
+        """Explicit channel_id/thread_ts override context defaults."""
         client = MagicMock(spec=AsyncWebClient)
         client.assistant_threads_setSuggestedPrompts, call_tracker, _ = _make_async_api_mock()
 
@@ -344,7 +344,7 @@ class TestAsyncBoltAgent:
         )
         await agent.set_suggested_prompts(
             prompts=["Hello"],
-            channel="C999",
+            channel_id="C999",
             thread_ts="9999999999.999999",
         )
 


### PR DESCRIPTION
## Summary

This PR follows #1441 and #1442 with updates to `channel_id` to match the API arguments for these methods:

- https://docs.slack.dev/reference/methods/assistant.threads.setStatus#arguments
- https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts/#arguments

I forget if this was meant to match the chat_stream arguments, which is [`channel`](https://docs.slack.dev/reference/methods/chat.startStream#arguments) still, but matching the API arguments might make references most clear I think!

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
