### PR TITLE
chore: improve testing around assistant utilities

### DIFF
--- a/tests/scenario_tests/test_events_assistant.py
+++ b/tests/scenario_tests/test_events_assistant.py
@@ -10,11 +10,11 @@ from tests.mock_web_api_server import (
 from tests.utils import remove_os_env_temporarily, restore_os_env
 
 
-def assert_target_called(called: dict, expected: bool = True, timeout: float = 0.5):
+def assert_target_called(called: dict, timeout: float = 0.5):
     deadline = time.time() + timeout
-    while called["value"] is not expected and time.time() < deadline:
+    while called["value"] is not True and time.time() < deadline:
         time.sleep(0.1)
-    assert called["value"] is expected
+    assert called["value"] is True
 
 
 class TestEventsAssistant:
@@ -142,8 +142,7 @@ class TestEventsAssistant:
         request = BoltRequest(body=message_changed_event_body, mode="socket_mode")
         response = app.dispatch(request)
         assert response.status == 200
-        assert_target_called(called, key="user_message", expected=False)
-        assert_target_called(called, key="bot_message", expected=False)
+        assert called["value"] is False
 
     def test_channel_user_message_ignored(self):
         app = App(client=self.web_client)
@@ -163,7 +162,7 @@ class TestEventsAssistant:
         request = BoltRequest(body=channel_user_message_event_body, mode="socket_mode")
         response = app.dispatch(request)
         assert response.status == 404
-        assert_target_called(called, expected=False)
+        assert called["value"] is False
 
     def test_channel_message_changed_ignored(self):
         app = App(client=self.web_client)
@@ -183,7 +182,7 @@ class TestEventsAssistant:
         request = BoltRequest(body=channel_message_changed_event_body, mode="socket_mode")
         response = app.dispatch(request)
         assert response.status == 404
-        assert_target_called(called, expected=False)
+        assert called["value"] is False
 
 
 def build_payload(event: dict) -> dict:

--- a/tests/scenario_tests/test_events_assistant_without_middleware.py
+++ b/tests/scenario_tests/test_events_assistant_without_middleware.py
@@ -8,6 +8,7 @@ from tests.mock_web_api_server import (
     cleanup_mock_web_api_server,
 )
 from tests.scenario_tests.test_events_assistant import (
+    assert_target_called,
     channel_message_changed_event_body,
     channel_user_message_event_body,
     message_changed_event_body,
@@ -16,7 +17,6 @@ from tests.scenario_tests.test_events_assistant import (
     user_message_event_body,
     user_message_event_body_with_assistant_thread,
 )
-from tests.scenario_tests.test_events_assistant import assert_target_called
 from tests.utils import remove_os_env_temporarily, restore_os_env
 
 
@@ -178,13 +178,13 @@ class TestEventsAssistantWithoutMiddleware:
             save_thread_context: SaveThreadContext,
             context: BoltContext,
         ):
-            assert context.thread_ts is not None
+            assert context.thread_ts is None
             assert say.thread_ts == context.thread_ts
-            assert set_status is not None
-            assert set_title is not None
-            assert set_suggested_prompts is not None
-            assert get_thread_context is not None
-            assert save_thread_context is not None
+            assert set_status is None
+            assert set_title is None
+            assert set_suggested_prompts is None
+            assert get_thread_context is None
+            assert save_thread_context is None
             called["value"] = True
 
         request = BoltRequest(body=message_changed_event_body, mode="socket_mode")
@@ -206,13 +206,13 @@ class TestEventsAssistantWithoutMiddleware:
             save_thread_context: SaveThreadContext,
             context: BoltContext,
         ):
-            assert context.thread_ts is not None
+            assert context.thread_ts is None
             assert say.thread_ts == context.thread_ts
-            assert set_status is not None
-            assert set_title is not None
-            assert set_suggested_prompts is not None
-            assert get_thread_context is not None
-            assert save_thread_context is not None
+            assert set_status is None
+            assert set_title is None
+            assert set_suggested_prompts is None
+            assert get_thread_context is None
+            assert save_thread_context is None
             called["value"] = True
 
         request = BoltRequest(body=channel_user_message_event_body, mode="socket_mode")
@@ -234,13 +234,13 @@ class TestEventsAssistantWithoutMiddleware:
             save_thread_context: SaveThreadContext,
             context: BoltContext,
         ):
-            assert context.thread_ts is not None
+            assert context.thread_ts is None
             assert say.thread_ts == context.thread_ts
-            assert set_status is not None
-            assert set_title is not None
-            assert set_suggested_prompts is not None
-            assert get_thread_context is not None
-            assert save_thread_context is not None
+            assert set_status is None
+            assert set_title is None
+            assert set_suggested_prompts is None
+            assert get_thread_context is None
+            assert save_thread_context is None
             called["value"] = True
 
         request = BoltRequest(body=channel_message_changed_event_body, mode="socket_mode")

--- a/tests/scenario_tests_async/test_events_assistant.py
+++ b/tests/scenario_tests_async/test_events_assistant.py
@@ -18,11 +18,11 @@ from tests.mock_web_api_server import (
 from tests.utils import remove_os_env_temporarily, restore_os_env
 
 
-async def assert_target_called(called: dict, expected: bool = True, timeout: float = 0.5):
+async def assert_target_called(called: dict, timeout: float = 0.5):
     deadline = time.time() + timeout
-    while called["value"] is not expected and time.time() < deadline:
+    while called["value"] is not True and time.time() < deadline:
         await asyncio.sleep(0.1)
-    assert called["value"] is expected
+    assert called["value"] is True
 
 
 class TestAsyncEventsAssistant:
@@ -166,7 +166,7 @@ class TestAsyncEventsAssistant:
         request = AsyncBoltRequest(body=message_changed_event_body, mode="socket_mode")
         response = await app.async_dispatch(request)
         assert response.status == 200
-        await assert_target_called(called, expected=False)
+        assert called["value"] is False
 
     @pytest.mark.asyncio
     async def test_channel_user_message_ignored(self):
@@ -187,7 +187,7 @@ class TestAsyncEventsAssistant:
         request = AsyncBoltRequest(body=channel_user_message_event_body, mode="socket_mode")
         response = await app.async_dispatch(request)
         assert response.status == 404
-        await assert_target_called(called, expected=False)
+        assert called["value"] is False
 
     @pytest.mark.asyncio
     async def test_channel_message_changed_ignored(self):
@@ -208,7 +208,7 @@ class TestAsyncEventsAssistant:
         request = AsyncBoltRequest(body=channel_message_changed_event_body, mode="socket_mode")
         response = await app.async_dispatch(request)
         assert response.status == 404
-        await assert_target_called(called, expected=False)
+        assert called["value"] is False
 
 
 def build_payload(event: dict) -> dict:

--- a/tests/scenario_tests_async/test_events_assistant_without_middleware.py
+++ b/tests/scenario_tests_async/test_events_assistant_without_middleware.py
@@ -15,6 +15,7 @@ from tests.mock_web_api_server import (
     setup_mock_web_api_server_async,
 )
 from tests.scenario_tests_async.test_events_assistant import (
+    assert_target_called,
     channel_message_changed_event_body,
     channel_user_message_event_body,
     message_changed_event_body,
@@ -23,7 +24,6 @@ from tests.scenario_tests_async.test_events_assistant import (
     user_message_event_body,
     user_message_event_body_with_assistant_thread,
 )
-from tests.scenario_tests_async.test_events_assistant import assert_target_called
 from tests.utils import remove_os_env_temporarily, restore_os_env
 
 
@@ -195,13 +195,13 @@ class TestAsyncEventsAssistantWithoutMiddleware:
             save_thread_context: AsyncSaveThreadContext,
             context: AsyncBoltContext,
         ):
-            assert context.thread_ts is not None
+            assert context.thread_ts is None
             assert say.thread_ts == context.thread_ts
-            assert set_status is not None
-            assert set_title is not None
-            assert set_suggested_prompts is not None
-            assert get_thread_context is not None
-            assert save_thread_context is not None
+            assert set_status is None
+            assert set_title is None
+            assert set_suggested_prompts is None
+            assert get_thread_context is None
+            assert save_thread_context is None
             called["value"] = True
 
         request = AsyncBoltRequest(body=message_changed_event_body, mode="socket_mode")
@@ -224,13 +224,13 @@ class TestAsyncEventsAssistantWithoutMiddleware:
             save_thread_context: AsyncSaveThreadContext,
             context: AsyncBoltContext,
         ):
-            assert context.thread_ts is not None
+            assert context.thread_ts is None
             assert say.thread_ts == context.thread_ts
-            assert set_status is not None
-            assert set_title is not None
-            assert set_suggested_prompts is not None
-            assert get_thread_context is not None
-            assert save_thread_context is not None
+            assert set_status is None
+            assert set_title is None
+            assert set_suggested_prompts is None
+            assert get_thread_context is None
+            assert save_thread_context is None
             called["value"] = True
 
         request = AsyncBoltRequest(body=channel_user_message_event_body, mode="socket_mode")
@@ -253,13 +253,13 @@ class TestAsyncEventsAssistantWithoutMiddleware:
             save_thread_context: AsyncSaveThreadContext,
             context: AsyncBoltContext,
         ):
-            assert context.thread_ts is not None
+            assert context.thread_ts is None
             assert say.thread_ts == context.thread_ts
-            assert set_status is not None
-            assert set_title is not None
-            assert set_suggested_prompts is not None
-            assert get_thread_context is not None
-            assert save_thread_context is not None
+            assert set_status is None
+            assert set_title is None
+            assert set_suggested_prompts is None
+            assert get_thread_context is None
+            assert save_thread_context is None
             called["value"] = True
 
         request = AsyncBoltRequest(body=channel_message_changed_event_body, mode="socket_mode")


### PR DESCRIPTION
## Summary

These changes aim to improve the coverage of tests around the assistant utilities 

### Testing

CI should be sufficient

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
