### PR TITLE
fix: handle malformed user/view payloads in extract_team_id

### DIFF
--- a/slack_bolt/request/internals.py
+++ b/slack_bolt/request/internals.py
@@ -112,9 +112,9 @@ def extract_team_id(payload: Dict[str, Any]) -> Optional[str]:
     if isinstance(payload.get("event"), dict):
         return extract_team_id(payload["event"])
     if isinstance(payload.get("user"), dict):
-        return payload["user"]["team_id"]
+        return payload["user"].get("team_id")
     if isinstance(payload.get("view"), dict):
-        return payload["view"]["team_id"]
+        return payload["view"].get("team_id")
     return None
 
 

--- a/tests/slack_bolt/request/test_internals.py
+++ b/tests/slack_bolt/request/test_internals.py
@@ -1253,8 +1253,10 @@ class TestRequestInternals:
         invalid_payloads = {
             "event": {"event": "some_event_type"},
             "user": {"user": "U12345"},
+            "user_missing_team_id": {"user": {"id": "U12345"}},
             "team": {"team": "T12345"},
             "view": {"view": "V12345"},
+            "view_missing_team_id": {"view": {"id": "V12345"}},
             "message": {"message": "some text"},
             "item": {"item": "item_id"},
             "function_data": {"function_data": "fd_123"},


### PR DESCRIPTION
## Summary
This prevents `extract_team_id()` from raising `KeyError` when malformed payloads contain `user` or `view` objects without a `team_id` key.

## Changes
- use `.get("team_id")` for `payload["user"]` and `payload["view"]` lookup in `extract_team_id`
- extend invalid-payload coverage in `test_extraction_functions_invalid_dict_keys`

## Why
Slack requests should still be rejected by request verification, but malformed traffic should not crash context extraction before middleware runs.

## Testing
- `python3 -m compileall -q slack_bolt/request/internals.py tests/slack_bolt/request/test_internals.py`

Fixes #1447

Greetings, saschabuehrle
