### PR TITLE
fix: Require signatures for ssl_check request verification

### DIFF
--- a/slack_bolt/middleware/request_verification/request_verification.py
+++ b/slack_bolt/middleware/request_verification/request_verification.py
@@ -49,7 +49,7 @@ class RequestVerification(Middleware):
 
     @staticmethod
     def _can_skip(mode: str, body: Dict[str, Any]) -> bool:
-        return mode == "socket_mode" or (body is not None and body.get("ssl_check") == "1")
+        return mode == "socket_mode"
 
     @staticmethod
     def _build_error_response() -> BoltResponse:

--- a/tests/adapter_tests/wsgi/test_wsgi_http.py
+++ b/tests/adapter_tests/wsgi/test_wsgi_http.py
@@ -89,6 +89,47 @@ class TestWsgiHttp:
         assert response.headers.get("content-type") == "text/plain;charset=utf-8"
         assert_auth_test_count(self, 1)
 
+    def test_ssl_check_param_does_not_bypass_request_verification(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            ssl_check_enabled=False,
+        )
+        command_called = False
+
+        def command_handler(ack):
+            nonlocal command_called
+            command_called = True
+            ack()
+
+        app.command("/hello-world")(command_handler)
+
+        body = (
+            "token=verification_token"
+            "&team_id=T111"
+            "&team_domain=test-domain"
+            "&channel_id=C111"
+            "&channel_name=random"
+            "&user_id=W111"
+            "&user_name=primary-owner"
+            "&command=%2Fhello-world"
+            "&text=Hi"
+            "&enterprise_id=E111"
+            "&enterprise_name=Org+Name"
+            "&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT111%2F111%2Fxxxxx"
+            "&trigger_id=111.111.xxx"
+            "&ssl_check=1"
+        )
+        headers = self.build_raw_headers("0", body)
+        headers["x-slack-signature"] = "v0=invalid"
+
+        wsgi_server = WsgiTestServer(SlackRequestHandler(app))
+        response = wsgi_server.http(method="POST", headers=headers, body=body)
+
+        assert response.status == "401 Unauthorized"
+        assert response.body == """{"error": "invalid request"}"""
+        assert command_called is False
+
     def test_events(self):
         app = App(
             client=self.web_client,

--- a/tests/scenario_tests/test_slash_command.py
+++ b/tests/scenario_tests/test_slash_command.py
@@ -93,6 +93,34 @@ class TestSlashCommand:
         assert response.status == 404
         assert_auth_test_count(self, 1)
 
+    def test_ssl_check_param_does_not_bypass_request_verification(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            ssl_check_enabled=False,
+        )
+        command_called = False
+
+        def command_handler(ack):
+            nonlocal command_called
+            command_called = True
+            ack()
+
+        app.command("/hello-world")(command_handler)
+
+        request = BoltRequest(
+            body=f"{slash_command_body}&ssl_check=1",
+            headers={
+                "content-type": ["application/x-www-form-urlencoded"],
+                "x-slack-signature": ["v0=invalid"],
+                "x-slack-request-timestamp": ["0"],
+            },
+        )
+        response = app.dispatch(request)
+        assert response.status == 401
+        assert response.body == """{"error": "invalid request"}"""
+        assert command_called is False
+
 
 slash_command_body = (
     "token=verification_token"

--- a/tests/scenario_tests_async/test_slash_command.py
+++ b/tests/scenario_tests_async/test_slash_command.py
@@ -100,6 +100,35 @@ class TestAsyncSlashCommand:
         assert response.status == 404
         await assert_auth_test_count_async(self, 1)
 
+    @pytest.mark.asyncio
+    async def test_ssl_check_param_does_not_bypass_request_verification(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+            ssl_check_enabled=False,
+        )
+        command_called = False
+
+        async def command_handler(ack):
+            nonlocal command_called
+            command_called = True
+            await ack()
+
+        app.command("/hello-world")(command_handler)
+
+        request = AsyncBoltRequest(
+            body=f"{slash_command_body}&ssl_check=1",
+            headers={
+                "content-type": ["application/x-www-form-urlencoded"],
+                "x-slack-signature": ["v0=invalid"],
+                "x-slack-request-timestamp": ["0"],
+            },
+        )
+        response = await app.async_dispatch(request)
+        assert response.status == 401
+        assert response.body == """{"error": "invalid request"}"""
+        assert command_called is False
+
 
 slash_command_body = (
     "token=verification_token"

--- a/tests/slack_bolt/middleware/request_verification/test_request_verification.py
+++ b/tests/slack_bolt/middleware/request_verification/test_request_verification.py
@@ -45,3 +45,18 @@ class TestRequestVerification:
         resp = middleware.process(req=req, resp=resp, next=next)
         assert resp.status == 401
         assert resp.body == """{"error": "invalid request"}"""
+
+    def test_ssl_check_param_requires_valid_signature(self):
+        middleware = RequestVerification(signing_secret=self.signing_secret)
+        req = BoltRequest(
+            body="token=random&ssl_check=1",
+            headers={
+                "content-type": ["application/x-www-form-urlencoded"],
+                "x-slack-signature": ["v0=invalid"],
+                "x-slack-request-timestamp": ["0"],
+            },
+        )
+        resp = BoltResponse(status=404)
+        resp = middleware.process(req=req, resp=resp, next=next)
+        assert resp.status == 401
+        assert resp.body == """{"error": "invalid request"}"""

--- a/tests/slack_bolt_async/middleware/request_verification/test_request_verification.py
+++ b/tests/slack_bolt_async/middleware/request_verification/test_request_verification.py
@@ -50,3 +50,19 @@ class TestAsyncRequestVerification:
         resp = await middleware.async_process(req=req, resp=resp, next=next)
         assert resp.status == 401
         assert resp.body == """{"error": "invalid request"}"""
+
+    @pytest.mark.asyncio
+    async def test_ssl_check_param_requires_valid_signature(self):
+        middleware = AsyncRequestVerification(signing_secret="secret")
+        req = AsyncBoltRequest(
+            body="token=random&ssl_check=1",
+            headers={
+                "content-type": ["application/x-www-form-urlencoded"],
+                "x-slack-signature": ["v0=invalid"],
+                "x-slack-request-timestamp": ["0"],
+            },
+        )
+        resp = BoltResponse(status=404)
+        resp = await middleware.async_process(req=req, resp=resp, next=next)
+        assert resp.status == 401
+        assert resp.body == """{"error": "invalid request"}"""


### PR DESCRIPTION
## Summary
- stop `RequestVerification` from skipping HMAC validation solely because a form body contains `ssl_check=1`
- keep the existing Socket Mode verification skip
- add regression coverage for sync, async, and WSGI dispatch paths

## Why
When `ssl_check_enabled=False`, the SSL-check middleware does not intercept `ssl_check=1` requests. Request verification still needs to authenticate those HTTP requests before they can reach normal middleware or slash command listeners.

Fixes #1494.

## Testing
- `./scripts/run_tests.sh "tests/slack_bolt/middleware/request_verification/test_request_verification.py tests/slack_bolt_async/middleware/request_verification/test_request_verification.py tests/scenario_tests/test_slash_command.py tests/scenario_tests_async/test_slash_command.py tests/adapter_tests/wsgi/test_wsgi_http.py"`
- `./scripts/lint.sh --no-install`
- `./scripts/run_mypy.sh --no-install`