### PR TITLE
ci: send regression notifications if tests for code coverage error

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -176,6 +176,7 @@ jobs:
       - lint
       - typecheck
       - unittest
+      - codecov
     if: ${{ !success() && github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch' }}
     steps:
       - name: Send notifications of failing tests


### PR DESCRIPTION
## Summary

This PR adds the "codecov" job to lists of what regression notifications are sent for 📣 

### Testing

Let's hope to not find out! But earlier workflows erroring appear as:

<img width="636" height="415" alt="regressions" src="https://github.com/user-attachments/assets/021dd5b7-1b1e-48ca-a45a-bcc982713a3f" />

🔗 https://github.com/slackapi/bolt-python/actions/runs/25383886159/job/74439411695

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] Others

### Notes

- If this was intentional because of test duplication I wasn't sure, but I found the "x" on `main` to be confusing without having seen a notification in channel 🙏 ✨ 

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
