### PR TITLE
fix: propagate Socket Mode retry_attempt and retry_reason to BoltRequest headers

### DIFF
--- a/slack_bolt/adapter/socket_mode/async_internals.py
+++ b/slack_bolt/adapter/socket_mode/async_internals.py
@@ -8,13 +8,14 @@ from slack_sdk.socket_mode.async_client import AsyncBaseSocketModeClient
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 
+from slack_bolt.adapter.socket_mode.internals import build_retry_headers
 from slack_bolt.app.async_app import AsyncApp
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 
 
 async def run_async_bolt_app(app: AsyncApp, req: SocketModeRequest):
-    bolt_req: AsyncBoltRequest = AsyncBoltRequest(mode="socket_mode", body=req.payload)
+    bolt_req: AsyncBoltRequest = AsyncBoltRequest(mode="socket_mode", body=req.payload, headers=build_retry_headers(req))
     bolt_resp: BoltResponse = await app.async_dispatch(bolt_req)
     return bolt_resp
 

--- a/slack_bolt/adapter/socket_mode/internals.py
+++ b/slack_bolt/adapter/socket_mode/internals.py
@@ -3,6 +3,7 @@
 import json
 import logging
 from time import time
+from typing import Dict, Optional, Sequence, Union
 
 from slack_sdk.socket_mode.client import BaseSocketModeClient
 from slack_sdk.socket_mode.request import SocketModeRequest
@@ -13,8 +14,18 @@ from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 
 
+def build_retry_headers(req: SocketModeRequest) -> Optional[Dict[str, Union[str, Sequence[str]]]]:
+    # Mirror the HTTP mode retry headers so middleware/listeners can detect Events API retries
+    headers: Dict[str, Union[str, Sequence[str]]] = {}
+    if req.retry_attempt is not None:
+        headers["x-slack-retry-num"] = str(req.retry_attempt)
+    if req.retry_reason is not None:
+        headers["x-slack-retry-reason"] = req.retry_reason
+    return headers or None
+
+
 def run_bolt_app(app: App, req: SocketModeRequest):
-    bolt_req: BoltRequest = BoltRequest(mode="socket_mode", body=req.payload)
+    bolt_req: BoltRequest = BoltRequest(mode="socket_mode", body=req.payload, headers=build_retry_headers(req))
     bolt_resp: BoltResponse = app.dispatch(bolt_req)
     return bolt_resp
 

--- a/tests/adapter_tests/socket_mode/test_internals.py
+++ b/tests/adapter_tests/socket_mode/test_internals.py
@@ -1,0 +1,39 @@
+from slack_sdk.socket_mode.request import SocketModeRequest
+
+from slack_bolt.adapter.socket_mode.internals import build_retry_headers, run_bolt_app
+
+
+class TestSocketModeInternals:
+    def test_build_retry_headers_without_retry(self):
+        req = SocketModeRequest(type="events_api", envelope_id="e1", payload={"type": "event_callback"})
+        assert build_retry_headers(req) is None
+
+    def test_build_retry_headers_with_retry(self):
+        req = SocketModeRequest(
+            type="events_api",
+            envelope_id="e1",
+            payload={"type": "event_callback"},
+            retry_attempt=2,
+            retry_reason="http_timeout",
+        )
+        headers = build_retry_headers(req)
+        assert headers == {"x-slack-retry-num": "2", "x-slack-retry-reason": "http_timeout"}
+
+    def test_run_bolt_app_propagates_retry_headers(self):
+        captured = {}
+
+        class FakeApp:
+            def dispatch(self, bolt_req):
+                captured["headers"] = bolt_req.headers
+                return None
+
+        req = SocketModeRequest(
+            type="events_api",
+            envelope_id="e1",
+            payload={"type": "event_callback", "event": {"type": "app_mention"}},
+            retry_attempt=1,
+            retry_reason="http_timeout",
+        )
+        run_bolt_app(FakeApp(), req)
+        assert captured["headers"]["x-slack-retry-num"] == ["1"]
+        assert captured["headers"]["x-slack-retry-reason"] == ["http_timeout"]


### PR DESCRIPTION
## Summary

In Socket Mode, `SocketModeRequest.retry_attempt` and `SocketModeRequest.retry_reason` were dropped when building the Bolt request, so middleware and listeners could not detect Events API retries the way they can in HTTP mode. This synthesizes the `x-slack-retry-num` / `x-slack-retry-reason` headers from the envelope so existing retry detection logic works unchanged under Socket Mode. Closes #1484.

### Testing

Run `python -m pytest tests/adapter_tests/socket_mode/test_internals.py tests/scenario_tests/test_events_socket_mode.py`.

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.

Note: I have not yet signed the Salesforce CLA; happy to do so if this is something you would like to accept.
