### PR TITLE
chore: improve testing around socket-mode header synthesization

### DIFF
--- a/slack_bolt/adapter/socket_mode/async_internals.py
+++ b/slack_bolt/adapter/socket_mode/async_internals.py
@@ -8,14 +8,14 @@ from slack_sdk.socket_mode.async_client import AsyncBaseSocketModeClient
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 
-from slack_bolt.adapter.socket_mode.internals import build_retry_headers
+from slack_bolt.adapter.socket_mode.internals import build_headers
 from slack_bolt.app.async_app import AsyncApp
 from slack_bolt.request.async_request import AsyncBoltRequest
 from slack_bolt.response import BoltResponse
 
 
 async def run_async_bolt_app(app: AsyncApp, req: SocketModeRequest):
-    bolt_req: AsyncBoltRequest = AsyncBoltRequest(mode="socket_mode", body=req.payload, headers=build_retry_headers(req))
+    bolt_req: AsyncBoltRequest = AsyncBoltRequest(mode="socket_mode", body=req.payload, headers=build_headers(req))
     bolt_resp: BoltResponse = await app.async_dispatch(bolt_req)
     return bolt_resp
 

--- a/slack_bolt/adapter/socket_mode/internals.py
+++ b/slack_bolt/adapter/socket_mode/internals.py
@@ -14,7 +14,7 @@ from slack_bolt.request import BoltRequest
 from slack_bolt.response import BoltResponse
 
 
-def build_retry_headers(req: SocketModeRequest) -> Optional[Dict[str, Union[str, Sequence[str]]]]:
+def build_headers(req: SocketModeRequest) -> Optional[Dict[str, Union[str, Sequence[str]]]]:
     # Mirror the HTTP mode retry headers so middleware/listeners can detect Events API retries
     headers: Dict[str, Union[str, Sequence[str]]] = {}
     if req.retry_attempt is not None:
@@ -25,7 +25,7 @@ def build_retry_headers(req: SocketModeRequest) -> Optional[Dict[str, Union[str,
 
 
 def run_bolt_app(app: App, req: SocketModeRequest):
-    bolt_req: BoltRequest = BoltRequest(mode="socket_mode", body=req.payload, headers=build_retry_headers(req))
+    bolt_req: BoltRequest = BoltRequest(mode="socket_mode", body=req.payload, headers=build_headers(req))
     bolt_resp: BoltResponse = app.dispatch(bolt_req)
     return bolt_resp
 

--- a/tests/adapter_tests/socket_mode/test_interactions_builtin.py
+++ b/tests/adapter_tests/socket_mode/test_interactions_builtin.py
@@ -36,7 +36,7 @@ class TestSocketModeBuiltin:
     def test_interactions(self):
         app = App(client=self.web_client)
 
-        result = {"shortcut": False, "command": False}
+        result = {"shortcut": False, "command": False, "message": False}
 
         @app.shortcut("do-something")
         def shortcut_handler(ack):
@@ -46,6 +46,13 @@ class TestSocketModeBuiltin:
         @app.command("/hello-socket-mode")
         def command_handler(ack):
             result["command"] = True
+            ack()
+
+        @app.message("<@W111>")
+        def message_handler(ack, req):
+            result["message"] = req.headers.get("x-slack-retry-num") == ["1"] and req.headers.get(
+                "x-slack-retry-reason"
+            ) == ["timeout"]
             ack()
 
         handler = SocketModeHandler(
@@ -66,5 +73,6 @@ class TestSocketModeBuiltin:
             time.sleep(2)
             assert result["shortcut"] is True
             assert result["command"] is True
+            assert result["message"] is True
         finally:
             handler.client.close()

--- a/tests/adapter_tests/socket_mode/test_interactions_websocket_client.py
+++ b/tests/adapter_tests/socket_mode/test_interactions_websocket_client.py
@@ -37,7 +37,7 @@ class TestSocketModeWebsocketClient:
 
         app = App(client=self.web_client)
 
-        result = {"shortcut": False, "command": False}
+        result = {"shortcut": False, "command": False, "message": False}
 
         @app.shortcut("do-something")
         def shortcut_handler(ack):
@@ -47,6 +47,13 @@ class TestSocketModeWebsocketClient:
         @app.command("/hello-socket-mode")
         def command_handler(ack):
             result["command"] = True
+            ack()
+
+        @app.message("<@W111>")
+        def message_handler(ack, req):
+            result["message"] = req.headers.get("x-slack-retry-num") == ["1"] and req.headers.get(
+                "x-slack-retry-reason"
+            ) == ["timeout"]
             ack()
 
         handler = SocketModeHandler(
@@ -67,5 +74,6 @@ class TestSocketModeWebsocketClient:
             time.sleep(2)
             assert result["shortcut"] is True
             assert result["command"] is True
+            assert result["message"] is True
         finally:
             handler.client.close()

--- a/tests/adapter_tests/socket_mode/test_internals.py
+++ b/tests/adapter_tests/socket_mode/test_internals.py
@@ -1,12 +1,12 @@
 from slack_sdk.socket_mode.request import SocketModeRequest
 
-from slack_bolt.adapter.socket_mode.internals import build_retry_headers, run_bolt_app
+from slack_bolt.adapter.socket_mode.internals import build_headers, run_bolt_app
 
 
 class TestSocketModeInternals:
     def test_build_retry_headers_without_retry(self):
         req = SocketModeRequest(type="events_api", envelope_id="e1", payload={"type": "event_callback"})
-        assert build_retry_headers(req) is None
+        assert build_headers(req) is None
 
     def test_build_retry_headers_with_retry(self):
         req = SocketModeRequest(
@@ -16,24 +16,5 @@ class TestSocketModeInternals:
             retry_attempt=2,
             retry_reason="http_timeout",
         )
-        headers = build_retry_headers(req)
+        headers = build_headers(req)
         assert headers == {"x-slack-retry-num": "2", "x-slack-retry-reason": "http_timeout"}
-
-    def test_run_bolt_app_propagates_retry_headers(self):
-        captured = {}
-
-        class FakeApp:
-            def dispatch(self, bolt_req):
-                captured["headers"] = bolt_req.headers
-                return None
-
-        req = SocketModeRequest(
-            type="events_api",
-            envelope_id="e1",
-            payload={"type": "event_callback", "event": {"type": "app_mention"}},
-            retry_attempt=1,
-            retry_reason="http_timeout",
-        )
-        run_bolt_app(FakeApp(), req)
-        assert captured["headers"]["x-slack-retry-num"] == ["1"]
-        assert captured["headers"]["x-slack-retry-reason"] == ["http_timeout"]

--- a/tests/adapter_tests_async/socket_mode/test_async_aiohttp.py
+++ b/tests/adapter_tests_async/socket_mode/test_async_aiohttp.py
@@ -40,7 +40,7 @@ class TestSocketModeAiohttp:
 
         app = AsyncApp(client=self.web_client)
 
-        result = {"shortcut": False, "command": False}
+        result = {"shortcut": False, "command": False, "message": False}
 
         @app.shortcut("do-something")
         async def shortcut_handler(ack):
@@ -50,6 +50,13 @@ class TestSocketModeAiohttp:
         @app.command("/hello-socket-mode")
         async def command_handler(ack):
             result["command"] = True
+            await ack()
+
+        @app.message("<@W111>")
+        async def message_handler(ack, req):
+            result["message"] = req.headers.get("x-slack-retry-num") == ["1"] and req.headers.get(
+                "x-slack-retry-reason"
+            ) == ["timeout"]
             await ack()
 
         handler = AsyncSocketModeHandler(
@@ -67,6 +74,7 @@ class TestSocketModeAiohttp:
             await asyncio.sleep(2)
             assert result["shortcut"] is True
             assert result["command"] is True
+            assert result["message"] is True
         finally:
             await handler.client.close()
             stop_socket_mode_server(self)

--- a/tests/adapter_tests_async/socket_mode/test_async_websockets.py
+++ b/tests/adapter_tests_async/socket_mode/test_async_websockets.py
@@ -40,7 +40,7 @@ class TestSocketModeWebsockets:
 
         app = AsyncApp(client=self.web_client)
 
-        result = {"shortcut": False, "command": False}
+        result = {"shortcut": False, "command": False, "message": False}
 
         @app.shortcut("do-something")
         async def shortcut_handler(ack):
@@ -50,6 +50,13 @@ class TestSocketModeWebsockets:
         @app.command("/hello-socket-mode")
         async def command_handler(ack):
             result["command"] = True
+            await ack()
+
+        @app.message("<@W111>")
+        async def message_handler(ack, req):
+            result["message"] = req.headers.get("x-slack-retry-num") == ["1"] and req.headers.get(
+                "x-slack-retry-reason"
+            ) == ["timeout"]
             await ack()
 
         handler = AsyncSocketModeHandler(
@@ -67,6 +74,7 @@ class TestSocketModeWebsockets:
             await asyncio.sleep(2)
             assert result["shortcut"] is True
             assert result["command"] is True
+            assert result["message"] is True
         finally:
             await handler.client.close()
             stop_socket_mode_server(self)


### PR DESCRIPTION
## Summary

- Renamed `build_retry_headers` to `build_headers` in `slack_bolt/adapter/socket_mode/internals.py` to better reflect that this function synthesizes all HTTP-equivalent headers for Socket Mode requests, not just retry-related ones.
- Removed the isolated unit test (`test_run_bolt_app_propagates_retry_headers`) that used a `FakeApp mock` to verify header propagation, in favor of higher-fidelity integration tests.
- Added message event handler assertions to the four Socket Mode integration test suites, verify retry headers (x-slack-retry-num, x-slack-retry-reason) are correctly synthesized from the `SocketModeRequest` and accessible to listeners via `req.headers`.

Motivation:

The previous test coverage for retry header propagation relied on a mock (FakeApp). By moving this verification into the existing integration tests we get stronger confidence that headers flow end-to-end through the actual framework pipeline.

### Testing

Continuous integration test should be sufficient

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
