### PR TITLE
fix: broken python 3.10 unit test

### DIFF
--- a/tests/adapter_tests_async/test_async_falcon.py
+++ b/tests/adapter_tests_async/test_async_falcon.py
@@ -2,8 +2,9 @@ import json
 from time import time
 from urllib.parse import quote
 
+import pytest
 import falcon
-from falcon import testing
+from falcon.testing import ASGIConductor
 
 from slack_sdk.signature import SignatureVerifier
 from slack_sdk.web.async_client import AsyncWebClient
@@ -55,7 +56,8 @@ class TestAsyncFalcon:
             "x-slack-request-timestamp": timestamp,
         }
 
-    def test_events(self):
+    @pytest.mark.asyncio
+    async def test_events(self):
         app = AsyncApp(
             client=self.web_client,
             signing_secret=self.signing_secret,
@@ -92,16 +94,17 @@ class TestAsyncFalcon:
         resource = AsyncSlackAppResource(app)
         api.add_route("/slack/events", resource)
 
-        client = testing.TestClient(api)
-        response = client.simulate_post(
-            "/slack/events",
-            body=body,
-            headers=self.build_headers(timestamp, body),
-        )
+        async with ASGIConductor(api) as conductor:
+            response = await conductor.simulate_post(
+                "/slack/events",
+                body=body,
+                headers=self.build_headers(timestamp, body),
+            )
         assert response.status_code == 200
         assert_auth_test_count(self, 1)
 
-    def test_shortcuts(self):
+    @pytest.mark.asyncio
+    async def test_shortcuts(self):
         app = AsyncApp(
             client=self.web_client,
             signing_secret=self.signing_secret,
@@ -133,16 +136,17 @@ class TestAsyncFalcon:
         resource = AsyncSlackAppResource(app)
         api.add_route("/slack/events", resource)
 
-        client = testing.TestClient(api)
-        response = client.simulate_post(
-            "/slack/events",
-            body=body,
-            headers=self.build_headers(timestamp, body),
-        )
+        async with ASGIConductor(api) as conductor:
+            response = await conductor.simulate_post(
+                "/slack/events",
+                body=body,
+                headers=self.build_headers(timestamp, body),
+            )
         assert response.status_code == 200
         assert_auth_test_count(self, 1)
 
-    def test_commands(self):
+    @pytest.mark.asyncio
+    async def test_commands(self):
         app = AsyncApp(
             client=self.web_client,
             signing_secret=self.signing_secret,
@@ -174,16 +178,17 @@ class TestAsyncFalcon:
         resource = AsyncSlackAppResource(app)
         api.add_route("/slack/events", resource)
 
-        client = testing.TestClient(api)
-        response = client.simulate_post(
-            "/slack/events",
-            body=body,
-            headers=self.build_headers(timestamp, body),
-        )
+        async with ASGIConductor(api) as conductor:
+            response = await conductor.simulate_post(
+                "/slack/events",
+                body=body,
+                headers=self.build_headers(timestamp, body),
+            )
         assert response.status_code == 200
         assert_auth_test_count(self, 1)
 
-    def test_oauth(self):
+    @pytest.mark.asyncio
+    async def test_oauth(self):
         app = AsyncApp(
             client=self.web_client,
             signing_secret=self.signing_secret,
@@ -197,8 +202,8 @@ class TestAsyncFalcon:
         resource = AsyncSlackAppResource(app)
         api.add_route("/slack/install", resource)
 
-        client = testing.TestClient(api)
-        response = client.simulate_get("/slack/install")
+        async with ASGIConductor(api) as conductor:
+            response = await conductor.simulate_get("/slack/install")
         assert response.status_code == 200
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
         assert response.headers.get("content-length") == "607"


### PR DESCRIPTION
## Summary

This PR aims to fix broken python 3.10 broken continuous integration pipeline that was relying on deprecated features of falcon

### Testing

Continuous integration tests should be sufficient

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
