### PR TITLE
fix(falcon/async_resource): replace the use of removed resp.body

### DIFF
--- a/slack_bolt/adapter/falcon/async_resource.py
+++ b/slack_bolt/adapter/falcon/async_resource.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from http import HTTPStatus
 
+from falcon import MEDIA_TEXT
 from falcon import version as falcon_version
 from falcon.asgi import Request, Response
 from slack_bolt import BoltResponse
@@ -40,9 +41,9 @@ class AsyncSlackAppResource:
                 await self._write_response(bolt_resp, resp)
                 return
 
-        resp.status = "404"
-        # Falcon 4.x w/ mypy fails to correctly infer the str type here
-        resp.body = "The page is not found..."
+        resp.status = HTTPStatus.NOT_FOUND
+        resp.content_type = MEDIA_TEXT
+        resp.text = "The page is not found..."
 
     async def on_post(self, req: Request, resp: Response):
         bolt_req = await self._to_bolt_request(req)

--- a/slack_bolt/adapter/falcon/resource.py
+++ b/slack_bolt/adapter/falcon/resource.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from http import HTTPStatus
 
+from falcon import MEDIA_TEXT
 from falcon import Request, Response, version as falcon_version
 
 from slack_bolt import BoltResponse
@@ -34,9 +35,9 @@ class SlackAppResource:
                 self._write_response(bolt_resp, resp)
                 return
 
-        resp.status = "404"
-        # Falcon 4.x w/ mypy fails to correctly infer the str type here
-        resp.body = "The page is not found..."
+        resp.status = HTTPStatus.NOT_FOUND
+        resp.content_type = MEDIA_TEXT
+        resp.text = "The page is not found..."
 
     def on_post(self, req: Request, resp: Response):
         bolt_req = self._to_bolt_request(req)

--- a/tests/adapter_tests/falcon/test_falcon.py
+++ b/tests/adapter_tests/falcon/test_falcon.py
@@ -205,3 +205,17 @@ class TestFalcon:
         response = client.simulate_get("/slack/install")
         assert response.status_code == 200
         assert "https://slack.com/oauth/v2/authorize?state=" in response.text
+
+    def test_get_no_oauth(self):
+        app = App(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        api = new_falcon_app()
+        resource = SlackAppResource(app)
+        api.add_route("/slack/events", resource)
+
+        client = testing.TestClient(api)
+        response = client.simulate_get("/slack/events")
+        assert response.status_code == 404
+        assert "The page is not found" in response.text

--- a/tests/adapter_tests_async/test_async_falcon.py
+++ b/tests/adapter_tests_async/test_async_falcon.py
@@ -208,3 +208,18 @@ class TestAsyncFalcon:
         assert response.headers.get("content-type") == "text/html; charset=utf-8"
         assert response.headers.get("content-length") == "607"
         assert "https://slack.com/oauth/v2/authorize?state=" in response.text
+
+    @pytest.mark.asyncio
+    async def test_get_no_oauth(self):
+        app = AsyncApp(
+            client=self.web_client,
+            signing_secret=self.signing_secret,
+        )
+        api = new_falcon_app()
+        resource = AsyncSlackAppResource(app)
+        api.add_route("/slack/events", resource)
+
+        async with ASGIConductor(api) as conductor:
+            response = await conductor.simulate_get("/slack/events")
+        assert response.status_code == 404
+        assert "The page is not found" in response.text


### PR DESCRIPTION
## Summary

<!-- Describe the goal of this PR. Mention any related issue numbers -->

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [x] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
