### PR TITLE
Add async optional dependency extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,17 +150,18 @@ Most of the app's functionality will be inside listener functions (the `fn` para
 
 ## Creating an async app
 
-If you'd prefer to build your app with [asyncio](https://docs.python.org/3/library/asyncio.html), you can import the [AIOHTTP](https://docs.aiohttp.org/en/stable/) library and call the `AsyncApp` constructor. Within async apps, you can use the async/await pattern.
+If you'd prefer to build your app with [asyncio](https://docs.python.org/3/library/asyncio.html), you can install the async extra to include [AIOHTTP](https://docs.aiohttp.org/en/stable/) and call the `AsyncApp` constructor. Within async apps, you can use the async/await pattern.
 
 ```bash
-# Python 3.7+ required
+# Python 3.9+ required for the async extra
 python -m venv .venv
 source .venv/bin/activate
 
 pip install -U pip
-# aiohttp is required
-pip install slack_bolt aiohttp
+pip install "slack_bolt[async]"
 ```
+
+If you're using Python 3.7 or 3.8, install an `aiohttp` version compatible with your Python runtime separately.
 
 In async apps, all middleware/listeners must be async functions. When calling utility methods (like `ack` and `say`) within these functions, it's required to use the `await` keyword.
 

--- a/docs/english/concepts/async.md
+++ b/docs/english/concepts/async.md
@@ -1,11 +1,11 @@
 # Using async (asyncio)
 
-To use the async version of Bolt, you can import and initialize an `AsyncApp` instance (rather than `App`). `AsyncApp` relies on [AIOHTTP](https://docs.aiohttp.org) to make API requests, which means you'll need to install `aiohttp` (by adding to `requirements.txt` or running `pip install aiohttp`).
+To use the async version of Bolt, you can import and initialize an `AsyncApp` instance (rather than `App`). `AsyncApp` relies on [AIOHTTP](https://docs.aiohttp.org) to make API requests. On Python 3.9 and newer, install the async extra by running `pip install "slack_bolt[async]"`. If you're using Python 3.7 or 3.8, install an `aiohttp` version compatible with your Python runtime separately.
 
 Sample async projects can be found within the repository's [examples](https://github.com/slackapi/bolt-python/tree/main/examples) folder.
 
 ```python
-# Requirement: install aiohttp
+# Requirement: pip install "slack_bolt[async]"
 from slack_bolt.async_app import AsyncApp
 app = AsyncApp()
 

--- a/docs/japanese/concepts/async.md
+++ b/docs/japanese/concepts/async.md
@@ -1,11 +1,11 @@
 # Async（asyncio）の使用
 
-非同期バージョンの Bolt を使用する場合は、`App` の代わりに `AsyncApp` インスタンスをインポートして初期化します。`AsyncApp` では [AIOHTTP](https://docs.aiohttp.org/) を使って API リクエストを行うため、`aiohttp` をインストールする必要があります（`requirements.txt` に追記するか、`pip install aiohttp` を実行します）。
+非同期バージョンの Bolt を使用する場合は、`App` の代わりに `AsyncApp` インスタンスをインポートして初期化します。`AsyncApp` では [AIOHTTP](https://docs.aiohttp.org/) を使って API リクエストを行います。Python 3.9 以降では、`pip install "slack_bolt[async]"` を実行して async extra をインストールしてください。Python 3.7 または 3.8 を使用している場合は、その Python ランタイムと互換性のある `aiohttp` のバージョンを別途インストールしてください。
 
 非同期バージョンのプロジェクトのサンプルは、リポジトリの [`examples` フォルダ](https://github.com/slackapi/bolt-python/tree/main/examples)にあります。
 
 ```python
-# aiohttp のインストールが必要です
+# 必要条件: pip install "slack_bolt[async]"
 from slack_bolt.async_app import AsyncApp
 app = AsyncApp()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack_bolt"
-dynamic = ["version", "readme", "authors"]
+dynamic = ["version", "readme", "authors", "optional-dependencies"]
 description = "The Bolt Framework for Python"
 license = { text = "MIT" }
 classifiers = [
@@ -34,6 +34,7 @@ include = ["slack_bolt*"]
 [tool.setuptools.dynamic]
 version = { attr = "slack_bolt.version.__version__" }
 readme = { file = ["README.md"], content-type = "text/markdown" }
+optional-dependencies.async = { file = ["requirements/async.txt"] }
 
 [tool.distutils.bdist_wheel]
 universal = true

--- a/requirements/async.txt
+++ b/requirements/async.txt
@@ -1,0 +1,2 @@
+# pip install -r requirements/async.txt
+aiohttp>=3,<4; python_version >= "3.9"

--- a/slack_bolt/async_app.py
+++ b/slack_bolt/async_app.py
@@ -2,17 +2,18 @@
 
 ### Creating an async app
 
-If you'd prefer to build your app with [asyncio](https://docs.python.org/3/library/asyncio.html), you can import the [AIOHTTP](https://docs.aiohttp.org/en/stable/) library and call the `AsyncApp` constructor. Within async apps, you can use the async/await pattern.
+If you'd prefer to build your app with [asyncio](https://docs.python.org/3/library/asyncio.html), you can install the async extra to include [AIOHTTP](https://docs.aiohttp.org/en/stable/) and call the `AsyncApp` constructor. Within async apps, you can use the async/await pattern.
 
 ```bash
-# Python 3.7+ required
+# Python 3.9+ required for the async extra
 python -m venv .venv
 source .venv/bin/activate
 
 pip install -U pip
-# aiohttp is required
-pip install slack_bolt aiohttp
+pip install "slack_bolt[async]"
 ```
+
+If you're using Python 3.7 or 3.8, install an `aiohttp` version compatible with your Python runtime separately.
 
 In async apps, all middleware/listeners must be async functions. When calling utility methods (like `ack` and `say`) within these functions, it's required to use the `await` keyword.
 


### PR DESCRIPTION
## Summary

Fixes #1472 by adding a public `async` optional dependency group for installing Bolt's async support:

- adds `requirements/async.txt` as the public dependency source for the extra
- exposes `slack_bolt[async]` through package metadata
- updates async installation docs and the `AsyncApp` module docstring

### Alternatives considered

#### Reuse `requirements/async_dev.txt`

Rejected because `async_dev.txt` is a development/test requirements file. Exposing it through package extras would turn test-only dependency constraints into a public installation contract, which was the concern raised in #1423.

#### Support Python 3.7 and 3.8 through older `aiohttp` ranges

Rejected for this PR to keep the new public contract small. Bolt still supports Python 3.7+, but current `aiohttp` releases require Python 3.9+. Adding legacy ranges would make Bolt responsible for maintaining compatibility with older `aiohttp` versions.

#### Add `aiohttp` as a core dependency

Rejected because async support is optional and the core package should keep its current runtime dependency surface.

#### Keep documenting manual `aiohttp` installation only

Rejected because it leaves users responsible for discovering compatible async dependencies, which is the problem described in #1472.

### Testing

- [x] `pip wheel . --no-deps --no-build-isolation`
- [x] `./scripts/format.sh --no-install`
- [x] `./scripts/lint.sh --no-install`
- [x] `./scripts/run_tests.sh tests/slack_bolt_async`
- [x] `./scripts/run_mypy.sh --no-install`
- [x] `./scripts/install_all_and_run_tests.sh` (`910 passed, 81 warnings`)

### Category

* [ ] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [x] Others

## Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
