### PR TITLE
Add explicit Assistant listener registration mode

### DIFF
--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -681,10 +681,6 @@ class App:
             middleware_or_callable = args[0]
             if isinstance(middleware_or_callable, Middleware):
                 middleware: Middleware = middleware_or_callable
-                if isinstance(middleware, Assistant) and middleware.auto_inherit_app_middleware is True:
-                    # In this opt-in mode, Assistant handlers should run through the app listener pipeline.
-                    self._register_assistant_listeners(middleware)
-                    return None
                 self._middleware_list.append(middleware)
                 if isinstance(middleware, Assistant) and middleware.thread_context_store is not None:
                     self._assistant_thread_context_store = middleware.thread_context_store
@@ -713,8 +709,13 @@ class App:
     # -------------------------
     # AI Agents & Assistants
 
-    def assistant(self, assistant: Assistant) -> Optional[Callable]:
-        return self.middleware(assistant)
+    def assistant(self, assistant: Assistant, mode: str = "middleware") -> Optional[Callable]:
+        if mode == "middleware":
+            return self.middleware(assistant)
+        if mode == "listeners":
+            self._register_assistant_listeners(assistant)
+            return None
+        raise BoltError(f"Unsupported Assistant registration mode ({mode})")
 
     # -------------------------
     # Workflows: Steps from apps

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -682,6 +682,7 @@ class App:
             if isinstance(middleware_or_callable, Middleware):
                 middleware: Middleware = middleware_or_callable
                 if isinstance(middleware, Assistant) and middleware.auto_inherit_app_middleware is True:
+                    # In this opt-in mode, Assistant handlers should run through the app listener pipeline.
                     self._register_assistant_listeners(middleware)
                     return None
                 self._middleware_list.append(middleware)
@@ -705,6 +706,7 @@ class App:
             self._assistant_thread_context_store = assistant.thread_context_store
 
         def register_listener(listener: Listener) -> None:
+            # Keep Assistant listeners before catch-all listeners while preserving Assistant registration order.
             self._listeners.insert(self._assistant_listener_insertion_index, listener)
             self._assistant_listener_insertion_index += 1
 

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -20,6 +20,7 @@ from slack_bolt.authorization.authorize import (
     CallableAuthorize,
 )
 
+from slack_bolt.app.listener_registry import ListenerRegistry
 from slack_bolt.context.assistant.thread_context_store.store import AssistantThreadContextStore
 
 from slack_bolt.error import BoltError, BoltUnhandledRequestError
@@ -348,8 +349,7 @@ class App:
         # --------------------------------------
 
         self._middleware_list: List[Middleware] = []
-        self._listeners: List[Listener] = []
-        self._assistant_listener_insertion_index = 0
+        self._listeners: ListenerRegistry[Listener] = ListenerRegistry()
 
         if listener_executor is None:
             listener_executor = ThreadPoolExecutor(max_workers=5)
@@ -706,9 +706,7 @@ class App:
             self._assistant_thread_context_store = assistant.thread_context_store
 
         def register_listener(listener: Listener) -> None:
-            # Keep Assistant listeners before catch-all listeners while preserving Assistant registration order.
-            self._listeners.insert(self._assistant_listener_insertion_index, listener)
-            self._assistant_listener_insertion_index += 1
+            self._listeners.append_assistant(listener)
 
         assistant._register_app_listeners(register_listener)
 

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -688,12 +688,13 @@ class App:
                 if isinstance(middleware, Assistant) and middleware.thread_context_store is not None:
                     self._assistant_thread_context_store = middleware.thread_context_store
             elif callable(middleware_or_callable):
-                middleware = CustomMiddleware(
-                    app_name=self.name,
-                    func=middleware_or_callable,
-                    base_logger=self._base_logger,
+                self._middleware_list.append(
+                    CustomMiddleware(
+                        app_name=self.name,
+                        func=middleware_or_callable,
+                        base_logger=self._base_logger,
+                    )
                 )
-                self._middleware_list.append(middleware)
                 return middleware_or_callable
             else:
                 raise BoltError(f"Unexpected type for a middleware ({type(middleware_or_callable)})")

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -349,6 +349,7 @@ class App:
 
         self._middleware_list: List[Middleware] = []
         self._listeners: List[Listener] = []
+        self._assistant_listener_insertion_index = 0
 
         if listener_executor is None:
             listener_executor = ThreadPoolExecutor(max_workers=5)
@@ -680,11 +681,12 @@ class App:
             middleware_or_callable = args[0]
             if isinstance(middleware_or_callable, Middleware):
                 middleware: Middleware = middleware_or_callable
+                if isinstance(middleware, Assistant) and middleware.auto_inherit_app_middleware is True:
+                    self._register_assistant_listeners(middleware)
+                    return None
                 self._middleware_list.append(middleware)
                 if isinstance(middleware, Assistant) and middleware.thread_context_store is not None:
                     self._assistant_thread_context_store = middleware.thread_context_store
-                elif not isinstance(middleware, Assistant):
-                    self._inherit_app_middleware_for_assistants(middleware)
             elif callable(middleware_or_callable):
                 middleware = CustomMiddleware(
                     app_name=self.name,
@@ -692,16 +694,20 @@ class App:
                     base_logger=self._base_logger,
                 )
                 self._middleware_list.append(middleware)
-                self._inherit_app_middleware_for_assistants(middleware)
                 return middleware_or_callable
             else:
                 raise BoltError(f"Unexpected type for a middleware ({type(middleware_or_callable)})")
         return None
 
-    def _inherit_app_middleware_for_assistants(self, middleware: Middleware) -> None:
-        for registered_middleware in self._middleware_list[:-1]:
-            if isinstance(registered_middleware, Assistant):
-                registered_middleware.inherit_app_middleware(middleware)
+    def _register_assistant_listeners(self, assistant: Assistant) -> None:
+        if assistant.thread_context_store is not None:
+            self._assistant_thread_context_store = assistant.thread_context_store
+
+        def register_listener(listener: Listener) -> None:
+            self._listeners.insert(self._assistant_listener_insertion_index, listener)
+            self._assistant_listener_insertion_index += 1
+
+        assistant._register_app_listeners(register_listener)
 
     # -------------------------
     # AI Agents & Assistants

--- a/slack_bolt/app/app.py
+++ b/slack_bolt/app/app.py
@@ -683,18 +683,25 @@ class App:
                 self._middleware_list.append(middleware)
                 if isinstance(middleware, Assistant) and middleware.thread_context_store is not None:
                     self._assistant_thread_context_store = middleware.thread_context_store
+                elif not isinstance(middleware, Assistant):
+                    self._inherit_app_middleware_for_assistants(middleware)
             elif callable(middleware_or_callable):
-                self._middleware_list.append(
-                    CustomMiddleware(
-                        app_name=self.name,
-                        func=middleware_or_callable,
-                        base_logger=self._base_logger,
-                    )
+                middleware = CustomMiddleware(
+                    app_name=self.name,
+                    func=middleware_or_callable,
+                    base_logger=self._base_logger,
                 )
+                self._middleware_list.append(middleware)
+                self._inherit_app_middleware_for_assistants(middleware)
                 return middleware_or_callable
             else:
                 raise BoltError(f"Unexpected type for a middleware ({type(middleware_or_callable)})")
         return None
+
+    def _inherit_app_middleware_for_assistants(self, middleware: Middleware) -> None:
+        for registered_middleware in self._middleware_list[:-1]:
+            if isinstance(registered_middleware, Assistant):
+                registered_middleware.inherit_app_middleware(middleware)
 
     # -------------------------
     # AI Agents & Assistants

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -710,18 +710,25 @@ class AsyncApp:
                 self._async_middleware_list.append(middleware)
                 if isinstance(middleware, AsyncAssistant) and middleware.thread_context_store is not None:
                     self._assistant_thread_context_store = middleware.thread_context_store
+                elif not isinstance(middleware, AsyncAssistant):
+                    self._inherit_app_middleware_for_assistants(middleware)
             elif callable(middleware_or_callable):
-                self._async_middleware_list.append(
-                    AsyncCustomMiddleware(
-                        app_name=self.name,
-                        func=middleware_or_callable,
-                        base_logger=self._base_logger,
-                    )
+                middleware = AsyncCustomMiddleware(
+                    app_name=self.name,
+                    func=middleware_or_callable,
+                    base_logger=self._base_logger,
                 )
+                self._async_middleware_list.append(middleware)
+                self._inherit_app_middleware_for_assistants(middleware)
                 return middleware_or_callable
             else:
                 raise BoltError(f"Unexpected type for a middleware ({type(middleware_or_callable)})")
         return None
+
+    def _inherit_app_middleware_for_assistants(self, middleware: AsyncMiddleware) -> None:
+        for registered_middleware in self._async_middleware_list[:-1]:
+            if isinstance(registered_middleware, AsyncAssistant):
+                registered_middleware.inherit_app_middleware(middleware)
 
     def assistant(self, assistant: AsyncAssistant) -> Optional[Callable]:
         return self.middleware(assistant)

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -361,6 +361,7 @@ class AsyncApp:
 
         self._async_middleware_list: List[AsyncMiddleware] = []
         self._async_listeners: List[AsyncListener] = []
+        self._assistant_listener_insertion_index = 0
 
         self._assistant_thread_context_store = assistant_thread_context_store
         self._attaching_conversation_kwargs_enabled = attaching_conversation_kwargs_enabled
@@ -707,11 +708,12 @@ class AsyncApp:
             middleware_or_callable = args[0]
             if isinstance(middleware_or_callable, AsyncMiddleware):
                 middleware: AsyncMiddleware = middleware_or_callable
+                if isinstance(middleware, AsyncAssistant) and middleware.auto_inherit_app_middleware is True:
+                    self._register_assistant_listeners(middleware)
+                    return None
                 self._async_middleware_list.append(middleware)
                 if isinstance(middleware, AsyncAssistant) and middleware.thread_context_store is not None:
                     self._assistant_thread_context_store = middleware.thread_context_store
-                elif not isinstance(middleware, AsyncAssistant):
-                    self._inherit_app_middleware_for_assistants(middleware)
             elif callable(middleware_or_callable):
                 middleware = AsyncCustomMiddleware(
                     app_name=self.name,
@@ -719,16 +721,20 @@ class AsyncApp:
                     base_logger=self._base_logger,
                 )
                 self._async_middleware_list.append(middleware)
-                self._inherit_app_middleware_for_assistants(middleware)
                 return middleware_or_callable
             else:
                 raise BoltError(f"Unexpected type for a middleware ({type(middleware_or_callable)})")
         return None
 
-    def _inherit_app_middleware_for_assistants(self, middleware: AsyncMiddleware) -> None:
-        for registered_middleware in self._async_middleware_list[:-1]:
-            if isinstance(registered_middleware, AsyncAssistant):
-                registered_middleware.inherit_app_middleware(middleware)
+    def _register_assistant_listeners(self, assistant: AsyncAssistant) -> None:
+        if assistant.thread_context_store is not None:
+            self._assistant_thread_context_store = assistant.thread_context_store
+
+        def register_listener(listener: AsyncListener) -> None:
+            self._async_listeners.insert(self._assistant_listener_insertion_index, listener)
+            self._assistant_listener_insertion_index += 1
+
+        assistant._register_app_listeners(register_listener)
 
     def assistant(self, assistant: AsyncAssistant) -> Optional[Callable]:
         return self.middleware(assistant)

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -708,10 +708,6 @@ class AsyncApp:
             middleware_or_callable = args[0]
             if isinstance(middleware_or_callable, AsyncMiddleware):
                 middleware: AsyncMiddleware = middleware_or_callable
-                if isinstance(middleware, AsyncAssistant) and middleware.auto_inherit_app_middleware is True:
-                    # In this opt-in mode, Assistant handlers should run through the app listener pipeline.
-                    self._register_assistant_listeners(middleware)
-                    return None
                 self._async_middleware_list.append(middleware)
                 if isinstance(middleware, AsyncAssistant) and middleware.thread_context_store is not None:
                     self._assistant_thread_context_store = middleware.thread_context_store
@@ -737,8 +733,13 @@ class AsyncApp:
 
         assistant._register_app_listeners(register_listener)
 
-    def assistant(self, assistant: AsyncAssistant) -> Optional[Callable]:
-        return self.middleware(assistant)
+    def assistant(self, assistant: AsyncAssistant, mode: str = "middleware") -> Optional[Callable]:
+        if mode == "middleware":
+            return self.middleware(assistant)
+        if mode == "listeners":
+            self._register_assistant_listeners(assistant)
+            return None
+        raise BoltError(f"Unsupported Assistant registration mode ({mode})")
 
     # -------------------------
     # Workflows: Steps from apps

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -715,12 +715,13 @@ class AsyncApp:
                 if isinstance(middleware, AsyncAssistant) and middleware.thread_context_store is not None:
                     self._assistant_thread_context_store = middleware.thread_context_store
             elif callable(middleware_or_callable):
-                middleware = AsyncCustomMiddleware(
-                    app_name=self.name,
-                    func=middleware_or_callable,
-                    base_logger=self._base_logger,
+                self._async_middleware_list.append(
+                    AsyncCustomMiddleware(
+                        app_name=self.name,
+                        func=middleware_or_callable,
+                        base_logger=self._base_logger,
+                    )
                 )
-                self._async_middleware_list.append(middleware)
                 return middleware_or_callable
             else:
                 raise BoltError(f"Unexpected type for a middleware ({type(middleware_or_callable)})")

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -8,6 +8,7 @@ import warnings
 from aiohttp import web
 
 from slack_bolt.app.async_server import AsyncSlackAppServer
+from slack_bolt.app.listener_registry import ListenerRegistry
 from slack_bolt.context.assistant.thread_context_store.async_store import (
     AsyncAssistantThreadContextStore,
 )
@@ -360,8 +361,7 @@ class AsyncApp:
         # --------------------------------------
 
         self._async_middleware_list: List[AsyncMiddleware] = []
-        self._async_listeners: List[AsyncListener] = []
-        self._assistant_listener_insertion_index = 0
+        self._async_listeners: ListenerRegistry[AsyncListener] = ListenerRegistry()
 
         self._assistant_thread_context_store = assistant_thread_context_store
         self._attaching_conversation_kwargs_enabled = attaching_conversation_kwargs_enabled
@@ -733,9 +733,7 @@ class AsyncApp:
             self._assistant_thread_context_store = assistant.thread_context_store
 
         def register_listener(listener: AsyncListener) -> None:
-            # Keep Assistant listeners before catch-all listeners while preserving Assistant registration order.
-            self._async_listeners.insert(self._assistant_listener_insertion_index, listener)
-            self._assistant_listener_insertion_index += 1
+            self._async_listeners.append_assistant(listener)
 
         assistant._register_app_listeners(register_listener)
 

--- a/slack_bolt/app/async_app.py
+++ b/slack_bolt/app/async_app.py
@@ -709,6 +709,7 @@ class AsyncApp:
             if isinstance(middleware_or_callable, AsyncMiddleware):
                 middleware: AsyncMiddleware = middleware_or_callable
                 if isinstance(middleware, AsyncAssistant) and middleware.auto_inherit_app_middleware is True:
+                    # In this opt-in mode, Assistant handlers should run through the app listener pipeline.
                     self._register_assistant_listeners(middleware)
                     return None
                 self._async_middleware_list.append(middleware)
@@ -732,6 +733,7 @@ class AsyncApp:
             self._assistant_thread_context_store = assistant.thread_context_store
 
         def register_listener(listener: AsyncListener) -> None:
+            # Keep Assistant listeners before catch-all listeners while preserving Assistant registration order.
             self._async_listeners.insert(self._assistant_listener_insertion_index, listener)
             self._assistant_listener_insertion_index += 1
 

--- a/slack_bolt/app/listener_registry.py
+++ b/slack_bolt/app/listener_registry.py
@@ -1,0 +1,33 @@
+from typing import Generic, Iterator, List, TypeVar, Union, overload
+
+ListenerT = TypeVar("ListenerT")
+
+
+class ListenerRegistry(Generic[ListenerT]):
+    def __init__(self) -> None:
+        self._assistant_listeners: List[ListenerT] = []
+        self._listeners: List[ListenerT] = []
+
+    def append(self, listener: ListenerT) -> None:
+        self._listeners.append(listener)
+
+    def append_assistant(self, listener: ListenerT) -> None:
+        self._assistant_listeners.append(listener)
+
+    def __iter__(self) -> Iterator[ListenerT]:
+        yield from self._assistant_listeners
+        yield from self._listeners
+
+    def __len__(self) -> int:
+        return len(self._assistant_listeners) + len(self._listeners)
+
+    @overload
+    def __getitem__(self, index: int) -> ListenerT:
+        pass
+
+    @overload
+    def __getitem__(self, index: slice) -> List[ListenerT]:
+        pass
+
+    def __getitem__(self, index: Union[int, slice]) -> Union[ListenerT, List[ListenerT]]:
+        return list(self)[index]

--- a/slack_bolt/middleware/assistant/assistant.py
+++ b/slack_bolt/middleware/assistant/assistant.py
@@ -1,7 +1,7 @@
 import logging
 from functools import wraps
 from logging import Logger
-from typing import List, Optional, Union, Callable, Tuple
+from typing import List, Optional, Union, Callable
 
 from slack_bolt.context.save_thread_context import SaveThreadContext
 from slack_bolt.context.assistant.thread_context_store.store import AssistantThreadContextStore
@@ -32,6 +32,8 @@ class Assistant(Middleware):
     _thread_context_changed_listeners: Optional[List[Listener]]
     _user_message_listeners: Optional[List[Listener]]
     _bot_message_listeners: Optional[List[Listener]]
+    _other_message_sub_event_listeners: Optional[List[Listener]]
+    _app_listener_registrars: List[Callable[[Listener], None]]
 
     thread_context_store: Optional[AssistantThreadContextStore]
     base_logger: Optional[logging.Logger]
@@ -48,18 +50,13 @@ class Assistant(Middleware):
         self.thread_context_store = thread_context_store
         self.base_logger = logger
         self.auto_inherit_app_middleware = auto_inherit_app_middleware
-        self._inherited_app_middleware: List[Middleware] = []
 
         self._thread_started_listeners = None
         self._thread_context_changed_listeners = None
         self._user_message_listeners = None
         self._bot_message_listeners = None
-
-    def inherit_app_middleware(self, middleware: Middleware) -> None:
-        if self.auto_inherit_app_middleware is False:
-            return
-
-        self._inherited_app_middleware.append(middleware)
+        self._other_message_sub_event_listeners = None
+        self._app_listener_registrars = []
 
     def thread_started(
         self,
@@ -73,23 +70,25 @@ class Assistant(Middleware):
         all_matchers = self._merge_matchers(is_assistant_thread_started_event, matchers)
         if is_used_without_argument(args):
             func = args[0]
-            self._thread_started_listeners.append(
+            self._append_listener(
+                self._thread_started_listeners,
                 self.build_listener(
                     listener_or_functions=func,
                     matchers=all_matchers,
                     middleware=middleware,  # type: ignore[arg-type]
-                )
+                ),
             )
             return func
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._thread_started_listeners.append(
+            self._append_listener(
+                self._thread_started_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
                     matchers=all_matchers,
                     middleware=middleware,
-                )
+                ),
             )
 
             @wraps(func)
@@ -112,23 +111,25 @@ class Assistant(Middleware):
         all_matchers = self._merge_matchers(is_user_message_event_in_assistant_thread, matchers)
         if is_used_without_argument(args):
             func = args[0]
-            self._user_message_listeners.append(
+            self._append_listener(
+                self._user_message_listeners,
                 self.build_listener(
                     listener_or_functions=func,
                     matchers=all_matchers,
                     middleware=middleware,  # type: ignore[arg-type]
-                )
+                ),
             )
             return func
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._user_message_listeners.append(
+            self._append_listener(
+                self._user_message_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
                     matchers=all_matchers,
                     middleware=middleware,
-                )
+                ),
             )
 
             @wraps(func)
@@ -151,23 +152,25 @@ class Assistant(Middleware):
         all_matchers = self._merge_matchers(is_bot_message_event_in_assistant_thread, matchers)
         if is_used_without_argument(args):
             func = args[0]
-            self._bot_message_listeners.append(
+            self._append_listener(
+                self._bot_message_listeners,
                 self.build_listener(
                     listener_or_functions=func,
                     matchers=all_matchers,
                     middleware=middleware,  # type: ignore[arg-type]
-                )
+                ),
             )
             return func
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._bot_message_listeners.append(
+            self._append_listener(
+                self._bot_message_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
                     matchers=all_matchers,
                     middleware=middleware,
-                )
+                ),
             )
 
             @wraps(func)
@@ -190,23 +193,25 @@ class Assistant(Middleware):
         all_matchers = self._merge_matchers(is_assistant_thread_context_changed_event, matchers)
         if is_used_without_argument(args):
             func = args[0]
-            self._thread_context_changed_listeners.append(
+            self._append_listener(
+                self._thread_context_changed_listeners,
                 self.build_listener(
                     listener_or_functions=func,
                     matchers=all_matchers,
                     middleware=middleware,  # type: ignore[arg-type]
-                )
+                ),
             )
             return func
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._thread_context_changed_listeners.append(
+            self._append_listener(
+                self._thread_context_changed_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
                     matchers=all_matchers,
                     middleware=middleware,
-                )
+                ),
             )
 
             @wraps(func)
@@ -230,11 +235,53 @@ class Assistant(Middleware):
     def default_thread_context_changed(save_thread_context: SaveThreadContext, payload: dict):
         save_thread_context(payload["assistant_thread"]["context"])
 
-    def process(  # type: ignore[return]
-        self, *, req: BoltRequest, resp: BoltResponse, next: Callable[[], BoltResponse]
-    ) -> Optional[BoltResponse]:
+    @staticmethod
+    def default_other_message_sub_event(ack):
+        ack()
+
+    def _register_app_listeners(self, listener_registrar: Callable[[Listener], None]) -> None:
+        self._ensure_default_thread_context_changed_listener()
+        self._ensure_other_message_sub_event_listener()
+        for listener in self._app_listeners:
+            listener_registrar(listener)
+        self._app_listener_registrars.append(listener_registrar)
+
+    @property
+    def _app_listeners(self) -> List[Listener]:
+        listeners: List[Listener] = []
+        for listener_list in [
+            self._thread_started_listeners,
+            self._thread_context_changed_listeners,
+            self._user_message_listeners,
+            self._bot_message_listeners,
+            self._other_message_sub_event_listeners,
+        ]:
+            if listener_list is not None:
+                listeners.extend(listener_list)
+        return listeners
+
+    def _append_listener(self, listeners: List[Listener], listener: Listener) -> None:
+        listeners.append(listener)
+        for registrar in self._app_listener_registrars:
+            registrar(listener)
+
+    def _ensure_default_thread_context_changed_listener(self) -> None:
         if self._thread_context_changed_listeners is None:
             self.thread_context_changed(self.default_thread_context_changed)
+
+    def _ensure_other_message_sub_event_listener(self) -> None:
+        if self._other_message_sub_event_listeners is None:
+            self._other_message_sub_event_listeners = []
+            self._append_listener(
+                self._other_message_sub_event_listeners,
+                self.build_listener(
+                    listener_or_functions=self.default_other_message_sub_event,
+                    matchers=[is_other_message_sub_event_in_assistant_thread],
+                ),
+            )
+
+    def process(self, *, req: BoltRequest, resp: BoltResponse, next: Callable[[], BoltResponse]) -> Optional[BoltResponse]:
+        self._ensure_default_thread_context_changed_listener()
 
         listener_runner: ThreadListenerRunner = req.context.listener_runner
         for listeners in [
@@ -246,11 +293,7 @@ class Assistant(Middleware):
             if listeners is not None:
                 for listener in listeners:
                     if listener.matches(req=req, resp=resp):
-                        middleware_resp, next_was_not_called = self._run_middleware(
-                            listener=listener,
-                            req=req,
-                            resp=resp,
-                        )
+                        middleware_resp, next_was_not_called = listener.run_middleware(req=req, resp=resp)
                         if next_was_not_called:
                             if middleware_resp is not None:
                                 return middleware_resp
@@ -270,33 +313,7 @@ class Assistant(Middleware):
             return req.context.ack()
 
         next()
-
-    def _run_middleware(
-        self,
-        *,
-        listener: Listener,
-        req: BoltRequest,
-        resp: BoltResponse,
-    ) -> Tuple[Optional[BoltResponse], bool]:
-        middleware = list(listener.middleware)
-        if len(self._inherited_app_middleware) > 0:
-            insertion_index = 1 if len(middleware) > 0 and isinstance(middleware[0], AttachingConversationKwargs) else 0
-            middleware = [
-                *middleware[:insertion_index],
-                *self._inherited_app_middleware,
-                *middleware[insertion_index:],
-            ]
-
-        for m in middleware:
-            middleware_state = {"next_called": False}
-
-            def next_():
-                middleware_state["next_called"] = True
-
-            resp = m.process(req=req, resp=resp, next=next_)  # type: ignore[assignment]
-            if not middleware_state["next_called"]:
-                return resp, True
-        return resp, False
+        return None
 
     def build_listener(
         self,

--- a/slack_bolt/middleware/assistant/assistant.py
+++ b/slack_bolt/middleware/assistant/assistant.py
@@ -240,36 +240,8 @@ class Assistant(Middleware):
         ack()
 
     def _register_app_listeners(self, listener_registrar: Callable[[Listener], None]) -> None:
-        self._ensure_default_thread_context_changed_listener()
-        self._ensure_other_message_sub_event_listener()
-        for listener in self._app_listeners:
-            listener_registrar(listener)
-        self._app_listener_registrars.append(listener_registrar)
-
-    @property
-    def _app_listeners(self) -> List[Listener]:
-        listeners: List[Listener] = []
-        for listener_list in [
-            self._thread_started_listeners,
-            self._thread_context_changed_listeners,
-            self._user_message_listeners,
-            self._bot_message_listeners,
-            self._other_message_sub_event_listeners,
-        ]:
-            if listener_list is not None:
-                listeners.extend(listener_list)
-        return listeners
-
-    def _append_listener(self, listeners: List[Listener], listener: Listener) -> None:
-        listeners.append(listener)
-        for registrar in self._app_listener_registrars:
-            registrar(listener)
-
-    def _ensure_default_thread_context_changed_listener(self) -> None:
         if self._thread_context_changed_listeners is None:
             self.thread_context_changed(self.default_thread_context_changed)
-
-    def _ensure_other_message_sub_event_listener(self) -> None:
         if self._other_message_sub_event_listeners is None:
             self._other_message_sub_event_listeners = []
             self._append_listener(
@@ -279,9 +251,28 @@ class Assistant(Middleware):
                     matchers=[is_other_message_sub_event_in_assistant_thread],
                 ),
             )
+        for listener_list in [
+            self._thread_started_listeners,
+            self._thread_context_changed_listeners,
+            self._user_message_listeners,
+            self._bot_message_listeners,
+            self._other_message_sub_event_listeners,
+        ]:
+            if listener_list is not None:
+                for listener in listener_list:
+                    listener_registrar(listener)
+        self._app_listener_registrars.append(listener_registrar)
 
-    def process(self, *, req: BoltRequest, resp: BoltResponse, next: Callable[[], BoltResponse]) -> Optional[BoltResponse]:
-        self._ensure_default_thread_context_changed_listener()
+    def _append_listener(self, listeners: List[Listener], listener: Listener) -> None:
+        listeners.append(listener)
+        for registrar in self._app_listener_registrars:
+            registrar(listener)
+
+    def process(  # type: ignore[return]
+        self, *, req: BoltRequest, resp: BoltResponse, next: Callable[[], BoltResponse]
+    ) -> Optional[BoltResponse]:
+        if self._thread_context_changed_listeners is None:
+            self.thread_context_changed(self.default_thread_context_changed)
 
         listener_runner: ThreadListenerRunner = req.context.listener_runner
         for listeners in [
@@ -313,7 +304,6 @@ class Assistant(Middleware):
             return req.context.ack()
 
         next()
-        return None
 
     def build_listener(
         self,
@@ -328,10 +318,8 @@ class Assistant(Middleware):
         if isinstance(listener_or_functions, Listener):
             return listener_or_functions
         elif isinstance(listener_or_functions, list):
-            middleware = [
-                AttachingConversationKwargs(self.thread_context_store),
-                *(middleware if middleware else []),
-            ]
+            middleware = middleware if middleware else []
+            middleware.insert(0, AttachingConversationKwargs(self.thread_context_store))
             functions = listener_or_functions
             ack_function = functions.pop(0)
 

--- a/slack_bolt/middleware/assistant/assistant.py
+++ b/slack_bolt/middleware/assistant/assistant.py
@@ -1,7 +1,7 @@
 import logging
 from functools import wraps
 from logging import Logger
-from typing import List, Optional, Union, Callable
+from typing import List, Optional, Union, Callable, Tuple
 
 from slack_bolt.context.save_thread_context import SaveThreadContext
 from slack_bolt.context.assistant.thread_context_store.store import AssistantThreadContextStore
@@ -42,15 +42,24 @@ class Assistant(Middleware):
         app_name: str = "assistant",
         thread_context_store: Optional[AssistantThreadContextStore] = None,
         logger: Optional[logging.Logger] = None,
+        auto_inherit_app_middleware: bool = False,
     ):
         self.app_name = app_name
         self.thread_context_store = thread_context_store
         self.base_logger = logger
+        self.auto_inherit_app_middleware = auto_inherit_app_middleware
+        self._inherited_app_middleware: List[Middleware] = []
 
         self._thread_started_listeners = None
         self._thread_context_changed_listeners = None
         self._user_message_listeners = None
         self._bot_message_listeners = None
+
+    def inherit_app_middleware(self, middleware: Middleware) -> None:
+        if self.auto_inherit_app_middleware is False:
+            return
+
+        self._inherited_app_middleware.append(middleware)
 
     def thread_started(
         self,
@@ -237,7 +246,11 @@ class Assistant(Middleware):
             if listeners is not None:
                 for listener in listeners:
                     if listener.matches(req=req, resp=resp):
-                        middleware_resp, next_was_not_called = listener.run_middleware(req=req, resp=resp)
+                        middleware_resp, next_was_not_called = self._run_middleware(
+                            listener=listener,
+                            req=req,
+                            resp=resp,
+                        )
                         if next_was_not_called:
                             if middleware_resp is not None:
                                 return middleware_resp
@@ -258,6 +271,33 @@ class Assistant(Middleware):
 
         next()
 
+    def _run_middleware(
+        self,
+        *,
+        listener: Listener,
+        req: BoltRequest,
+        resp: BoltResponse,
+    ) -> Tuple[Optional[BoltResponse], bool]:
+        middleware = list(listener.middleware)
+        if len(self._inherited_app_middleware) > 0:
+            insertion_index = 1 if len(middleware) > 0 and isinstance(middleware[0], AttachingConversationKwargs) else 0
+            middleware = [
+                *middleware[:insertion_index],
+                *self._inherited_app_middleware,
+                *middleware[insertion_index:],
+            ]
+
+        for m in middleware:
+            middleware_state = {"next_called": False}
+
+            def next_():
+                middleware_state["next_called"] = True
+
+            resp = m.process(req=req, resp=resp, next=next_)  # type: ignore[assignment]
+            if not middleware_state["next_called"]:
+                return resp, True
+        return resp, False
+
     def build_listener(
         self,
         listener_or_functions: Union[Listener, Callable, List[Callable]],
@@ -271,8 +311,10 @@ class Assistant(Middleware):
         if isinstance(listener_or_functions, Listener):
             return listener_or_functions
         elif isinstance(listener_or_functions, list):
-            middleware = middleware if middleware else []
-            middleware.insert(0, AttachingConversationKwargs(self.thread_context_store))
+            middleware = [
+                AttachingConversationKwargs(self.thread_context_store),
+                *(middleware if middleware else []),
+            ]
             functions = listener_or_functions
             ack_function = functions.pop(0)
 

--- a/slack_bolt/middleware/assistant/assistant.py
+++ b/slack_bolt/middleware/assistant/assistant.py
@@ -70,7 +70,7 @@ class Assistant(Middleware):
         all_matchers = self._merge_matchers(is_assistant_thread_started_event, matchers)
         if is_used_without_argument(args):
             func = args[0]
-            self._append_listener(
+            self._append_and_register_listener(
                 self._thread_started_listeners,
                 self.build_listener(
                     listener_or_functions=func,
@@ -82,7 +82,7 @@ class Assistant(Middleware):
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._append_listener(
+            self._append_and_register_listener(
                 self._thread_started_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
@@ -111,7 +111,7 @@ class Assistant(Middleware):
         all_matchers = self._merge_matchers(is_user_message_event_in_assistant_thread, matchers)
         if is_used_without_argument(args):
             func = args[0]
-            self._append_listener(
+            self._append_and_register_listener(
                 self._user_message_listeners,
                 self.build_listener(
                     listener_or_functions=func,
@@ -123,7 +123,7 @@ class Assistant(Middleware):
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._append_listener(
+            self._append_and_register_listener(
                 self._user_message_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
@@ -152,7 +152,7 @@ class Assistant(Middleware):
         all_matchers = self._merge_matchers(is_bot_message_event_in_assistant_thread, matchers)
         if is_used_without_argument(args):
             func = args[0]
-            self._append_listener(
+            self._append_and_register_listener(
                 self._bot_message_listeners,
                 self.build_listener(
                     listener_or_functions=func,
@@ -164,7 +164,7 @@ class Assistant(Middleware):
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._append_listener(
+            self._append_and_register_listener(
                 self._bot_message_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
@@ -193,7 +193,7 @@ class Assistant(Middleware):
         all_matchers = self._merge_matchers(is_assistant_thread_context_changed_event, matchers)
         if is_used_without_argument(args):
             func = args[0]
-            self._append_listener(
+            self._append_and_register_listener(
                 self._thread_context_changed_listeners,
                 self.build_listener(
                     listener_or_functions=func,
@@ -205,7 +205,7 @@ class Assistant(Middleware):
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._append_listener(
+            self._append_and_register_listener(
                 self._thread_context_changed_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
@@ -244,7 +244,8 @@ class Assistant(Middleware):
             self.thread_context_changed(self.default_thread_context_changed)
         if self._other_message_sub_event_listeners is None:
             self._other_message_sub_event_listeners = []
-            self._append_listener(
+            # Preserve the middleware path's ack behavior for message_changed, message_deleted, and similar subevents.
+            self._append_and_register_listener(
                 self._other_message_sub_event_listeners,
                 self.build_listener(
                     listener_or_functions=self.default_other_message_sub_event,
@@ -263,7 +264,7 @@ class Assistant(Middleware):
                     listener_registrar(listener)
         self._app_listener_registrars.append(listener_registrar)
 
-    def _append_listener(self, listeners: List[Listener], listener: Listener) -> None:
+    def _append_and_register_listener(self, listeners: List[Listener], listener: Listener) -> None:
         listeners.append(listener)
         for registrar in self._app_listener_registrars:
             registrar(listener)

--- a/slack_bolt/middleware/assistant/assistant.py
+++ b/slack_bolt/middleware/assistant/assistant.py
@@ -44,12 +44,10 @@ class Assistant(Middleware):
         app_name: str = "assistant",
         thread_context_store: Optional[AssistantThreadContextStore] = None,
         logger: Optional[logging.Logger] = None,
-        auto_inherit_app_middleware: bool = False,
     ):
         self.app_name = app_name
         self.thread_context_store = thread_context_store
         self.base_logger = logger
-        self.auto_inherit_app_middleware = auto_inherit_app_middleware
 
         self._thread_started_listeners = None
         self._thread_context_changed_listeners = None

--- a/slack_bolt/middleware/assistant/async_assistant.py
+++ b/slack_bolt/middleware/assistant/async_assistant.py
@@ -1,7 +1,7 @@
 import logging
 from functools import wraps
 from logging import Logger
-from typing import List, Optional, Union, Callable, Awaitable
+from typing import List, Optional, Union, Callable, Awaitable, Tuple
 
 from slack_bolt.context.save_thread_context.async_save_thread_context import AsyncSaveThreadContext
 from slack_bolt.context.assistant.thread_context_store.async_store import AsyncAssistantThreadContextStore
@@ -42,15 +42,24 @@ class AsyncAssistant(AsyncMiddleware):
         app_name: str = "assistant",
         thread_context_store: Optional[AsyncAssistantThreadContextStore] = None,
         logger: Optional[logging.Logger] = None,
+        auto_inherit_app_middleware: bool = False,
     ):
         self.app_name = app_name
         self.thread_context_store = thread_context_store
         self.base_logger = logger
+        self.auto_inherit_app_middleware = auto_inherit_app_middleware
+        self._inherited_app_middleware: List[AsyncMiddleware] = []
 
         self._thread_started_listeners = None
         self._thread_context_changed_listeners = None
         self._user_message_listeners = None
         self._bot_message_listeners = None
+
+    def inherit_app_middleware(self, middleware: AsyncMiddleware) -> None:
+        if self.auto_inherit_app_middleware is False:
+            return
+
+        self._inherited_app_middleware.append(middleware)
 
     def thread_started(
         self,
@@ -268,7 +277,11 @@ class AsyncAssistant(AsyncMiddleware):
             if listeners is not None:
                 for listener in listeners:
                     if listener is not None and await listener.async_matches(req=req, resp=resp):
-                        middleware_resp, next_was_not_called = await listener.run_async_middleware(req=req, resp=resp)
+                        middleware_resp, next_was_not_called = await self._run_middleware(
+                            listener=listener,
+                            req=req,
+                            resp=resp,
+                        )
                         if next_was_not_called:
                             if middleware_resp is not None:
                                 return middleware_resp
@@ -289,6 +302,33 @@ class AsyncAssistant(AsyncMiddleware):
 
         await next()
 
+    async def _run_middleware(
+        self,
+        *,
+        listener: AsyncListener,
+        req: AsyncBoltRequest,
+        resp: BoltResponse,
+    ) -> Tuple[Optional[BoltResponse], bool]:
+        middleware = list(listener.middleware)
+        if len(self._inherited_app_middleware) > 0:
+            insertion_index = 1 if len(middleware) > 0 and isinstance(middleware[0], AsyncAttachingConversationKwargs) else 0
+            middleware = [
+                *middleware[:insertion_index],
+                *self._inherited_app_middleware,
+                *middleware[insertion_index:],
+            ]
+
+        for m in middleware:
+            middleware_state = {"next_called": False}
+
+            async def next_():
+                middleware_state["next_called"] = True
+
+            resp = await m.async_process(req=req, resp=resp, next=next_)  # type: ignore[assignment]
+            if not middleware_state["next_called"]:
+                return resp, True
+        return resp, False
+
     def build_listener(
         self,
         listener_or_functions: Union[AsyncListener, Callable, List[Callable]],
@@ -302,8 +342,10 @@ class AsyncAssistant(AsyncMiddleware):
         if isinstance(listener_or_functions, AsyncListener):
             return listener_or_functions
         elif isinstance(listener_or_functions, list):
-            middleware = middleware if middleware else []
-            middleware.insert(0, AsyncAttachingConversationKwargs(self.thread_context_store))
+            middleware = [
+                AsyncAttachingConversationKwargs(self.thread_context_store),
+                *(middleware if middleware else []),
+            ]
             functions = listener_or_functions
             ack_function = functions.pop(0)
 

--- a/slack_bolt/middleware/assistant/async_assistant.py
+++ b/slack_bolt/middleware/assistant/async_assistant.py
@@ -77,7 +77,7 @@ class AsyncAssistant(AsyncMiddleware):
         )
         if is_used_without_argument(args):
             func = args[0]
-            self._append_listener(
+            self._append_and_register_listener(
                 self._thread_started_listeners,
                 self.build_listener(
                     listener_or_functions=func,
@@ -89,7 +89,7 @@ class AsyncAssistant(AsyncMiddleware):
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._append_listener(
+            self._append_and_register_listener(
                 self._thread_started_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
@@ -125,7 +125,7 @@ class AsyncAssistant(AsyncMiddleware):
         )
         if is_used_without_argument(args):
             func = args[0]
-            self._append_listener(
+            self._append_and_register_listener(
                 self._user_message_listeners,
                 self.build_listener(
                     listener_or_functions=func,
@@ -137,7 +137,7 @@ class AsyncAssistant(AsyncMiddleware):
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._append_listener(
+            self._append_and_register_listener(
                 self._user_message_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
@@ -173,7 +173,7 @@ class AsyncAssistant(AsyncMiddleware):
         )
         if is_used_without_argument(args):
             func = args[0]
-            self._append_listener(
+            self._append_and_register_listener(
                 self._bot_message_listeners,
                 self.build_listener(
                     listener_or_functions=func,
@@ -185,7 +185,7 @@ class AsyncAssistant(AsyncMiddleware):
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._append_listener(
+            self._append_and_register_listener(
                 self._bot_message_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
@@ -221,7 +221,7 @@ class AsyncAssistant(AsyncMiddleware):
         )
         if is_used_without_argument(args):
             func = args[0]
-            self._append_listener(
+            self._append_and_register_listener(
                 self._thread_context_changed_listeners,
                 self.build_listener(
                     listener_or_functions=func,
@@ -233,7 +233,7 @@ class AsyncAssistant(AsyncMiddleware):
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._append_listener(
+            self._append_and_register_listener(
                 self._thread_context_changed_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
@@ -279,7 +279,8 @@ class AsyncAssistant(AsyncMiddleware):
                 ),  # type: ignore[arg-type]
                 None,
             )
-            self._append_listener(
+            # Preserve the middleware path's ack behavior for message_changed, message_deleted, and similar subevents.
+            self._append_and_register_listener(
                 self._other_message_sub_event_listeners,
                 self.build_listener(
                     listener_or_functions=self.default_other_message_sub_event,
@@ -298,7 +299,7 @@ class AsyncAssistant(AsyncMiddleware):
                     listener_registrar(listener)
         self._app_listener_registrars.append(listener_registrar)
 
-    def _append_listener(self, listeners: List[AsyncListener], listener: AsyncListener) -> None:
+    def _append_and_register_listener(self, listeners: List[AsyncListener], listener: AsyncListener) -> None:
         listeners.append(listener)
         for registrar in self._app_listener_registrars:
             registrar(listener)

--- a/slack_bolt/middleware/assistant/async_assistant.py
+++ b/slack_bolt/middleware/assistant/async_assistant.py
@@ -1,7 +1,7 @@
 import logging
 from functools import wraps
 from logging import Logger
-from typing import List, Optional, Union, Callable, Awaitable, cast
+from typing import List, Optional, Union, Callable, Awaitable
 
 from slack_bolt.context.save_thread_context.async_save_thread_context import AsyncSaveThreadContext
 from slack_bolt.context.assistant.thread_context_store.async_store import AsyncAssistantThreadContextStore
@@ -267,15 +267,25 @@ class AsyncAssistant(AsyncMiddleware):
         await ack()
 
     def _register_app_listeners(self, listener_registrar: Callable[[AsyncListener], None]) -> None:
-        self._ensure_default_thread_context_changed_listener()
-        self._ensure_other_message_sub_event_listener()
-        for listener in self._app_listeners:
-            listener_registrar(listener)
-        self._app_listener_registrars.append(listener_registrar)
-
-    @property
-    def _app_listeners(self) -> List[AsyncListener]:
-        listeners: List[AsyncListener] = []
+        if self._thread_context_changed_listeners is None:
+            self.thread_context_changed(self.default_thread_context_changed)
+        if self._other_message_sub_event_listeners is None:
+            self._other_message_sub_event_listeners = []
+            all_matchers = self._merge_matchers(
+                build_listener_matcher(
+                    func=is_other_message_sub_event_in_assistant_thread,
+                    asyncio=True,
+                    base_logger=self.base_logger,
+                ),  # type: ignore[arg-type]
+                None,
+            )
+            self._append_listener(
+                self._other_message_sub_event_listeners,
+                self.build_listener(
+                    listener_or_functions=self.default_other_message_sub_event,
+                    matchers=all_matchers,
+                ),
+            )
         for listener_list in [
             self._thread_started_listeners,
             self._thread_context_changed_listeners,
@@ -284,46 +294,24 @@ class AsyncAssistant(AsyncMiddleware):
             self._other_message_sub_event_listeners,
         ]:
             if listener_list is not None:
-                listeners.extend(listener_list)
-        return listeners
+                for listener in listener_list:
+                    listener_registrar(listener)
+        self._app_listener_registrars.append(listener_registrar)
 
     def _append_listener(self, listeners: List[AsyncListener], listener: AsyncListener) -> None:
         listeners.append(listener)
         for registrar in self._app_listener_registrars:
             registrar(listener)
 
-    def _ensure_default_thread_context_changed_listener(self) -> None:
-        if self._thread_context_changed_listeners is None:
-            self.thread_context_changed(self.default_thread_context_changed)
-
-    def _ensure_other_message_sub_event_listener(self) -> None:
-        if self._other_message_sub_event_listeners is None:
-            self._other_message_sub_event_listeners = []
-            self._append_listener(
-                self._other_message_sub_event_listeners,
-                self.build_listener(
-                    listener_or_functions=self.default_other_message_sub_event,
-                    matchers=[
-                        cast(
-                            AsyncListenerMatcher,
-                            build_listener_matcher(
-                                func=is_other_message_sub_event_in_assistant_thread,
-                                asyncio=True,
-                                base_logger=self.base_logger,
-                            ),
-                        )
-                    ],
-                ),
-            )
-
-    async def async_process(
+    async def async_process(  # type: ignore[return]
         self,
         *,
         req: AsyncBoltRequest,
         resp: BoltResponse,
         next: Callable[[], Awaitable[BoltResponse]],
     ) -> Optional[BoltResponse]:
-        self._ensure_default_thread_context_changed_listener()
+        if self._thread_context_changed_listeners is None:
+            self.thread_context_changed(self.default_thread_context_changed)
 
         listener_runner: AsyncioListenerRunner = req.context.listener_runner
         for listeners in [
@@ -355,7 +343,6 @@ class AsyncAssistant(AsyncMiddleware):
             return await req.context.ack()
 
         await next()
-        return None
 
     def build_listener(
         self,
@@ -370,10 +357,8 @@ class AsyncAssistant(AsyncMiddleware):
         if isinstance(listener_or_functions, AsyncListener):
             return listener_or_functions
         elif isinstance(listener_or_functions, list):
-            middleware = [
-                AsyncAttachingConversationKwargs(self.thread_context_store),
-                *(middleware if middleware else []),
-            ]
+            middleware = middleware if middleware else []
+            middleware.insert(0, AsyncAttachingConversationKwargs(self.thread_context_store))
             functions = listener_or_functions
             ack_function = functions.pop(0)
 

--- a/slack_bolt/middleware/assistant/async_assistant.py
+++ b/slack_bolt/middleware/assistant/async_assistant.py
@@ -44,12 +44,10 @@ class AsyncAssistant(AsyncMiddleware):
         app_name: str = "assistant",
         thread_context_store: Optional[AsyncAssistantThreadContextStore] = None,
         logger: Optional[logging.Logger] = None,
-        auto_inherit_app_middleware: bool = False,
     ):
         self.app_name = app_name
         self.thread_context_store = thread_context_store
         self.base_logger = logger
-        self.auto_inherit_app_middleware = auto_inherit_app_middleware
 
         self._thread_started_listeners = None
         self._thread_context_changed_listeners = None

--- a/slack_bolt/middleware/assistant/async_assistant.py
+++ b/slack_bolt/middleware/assistant/async_assistant.py
@@ -1,7 +1,7 @@
 import logging
 from functools import wraps
 from logging import Logger
-from typing import List, Optional, Union, Callable, Awaitable, Tuple
+from typing import List, Optional, Union, Callable, Awaitable, cast
 
 from slack_bolt.context.save_thread_context.async_save_thread_context import AsyncSaveThreadContext
 from slack_bolt.context.assistant.thread_context_store.async_store import AsyncAssistantThreadContextStore
@@ -32,6 +32,8 @@ class AsyncAssistant(AsyncMiddleware):
     _user_message_listeners: Optional[List[AsyncListener]]
     _bot_message_listeners: Optional[List[AsyncListener]]
     _thread_context_changed_listeners: Optional[List[AsyncListener]]
+    _other_message_sub_event_listeners: Optional[List[AsyncListener]]
+    _app_listener_registrars: List[Callable[[AsyncListener], None]]
 
     thread_context_store: Optional[AsyncAssistantThreadContextStore]
     base_logger: Optional[logging.Logger]
@@ -48,18 +50,13 @@ class AsyncAssistant(AsyncMiddleware):
         self.thread_context_store = thread_context_store
         self.base_logger = logger
         self.auto_inherit_app_middleware = auto_inherit_app_middleware
-        self._inherited_app_middleware: List[AsyncMiddleware] = []
 
         self._thread_started_listeners = None
         self._thread_context_changed_listeners = None
         self._user_message_listeners = None
         self._bot_message_listeners = None
-
-    def inherit_app_middleware(self, middleware: AsyncMiddleware) -> None:
-        if self.auto_inherit_app_middleware is False:
-            return
-
-        self._inherited_app_middleware.append(middleware)
+        self._other_message_sub_event_listeners = None
+        self._app_listener_registrars = []
 
     def thread_started(
         self,
@@ -80,23 +77,25 @@ class AsyncAssistant(AsyncMiddleware):
         )
         if is_used_without_argument(args):
             func = args[0]
-            self._thread_started_listeners.append(
+            self._append_listener(
+                self._thread_started_listeners,
                 self.build_listener(
                     listener_or_functions=func,
                     matchers=all_matchers,
                     middleware=middleware,  # type: ignore[arg-type]
-                )
+                ),
             )
             return func
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._thread_started_listeners.append(
+            self._append_listener(
+                self._thread_started_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
                     matchers=all_matchers,
                     middleware=middleware,
-                )
+                ),
             )
 
             @wraps(func)
@@ -126,23 +125,25 @@ class AsyncAssistant(AsyncMiddleware):
         )
         if is_used_without_argument(args):
             func = args[0]
-            self._user_message_listeners.append(
+            self._append_listener(
+                self._user_message_listeners,
                 self.build_listener(
                     listener_or_functions=func,
                     matchers=all_matchers,
                     middleware=middleware,  # type: ignore[arg-type]
-                )
+                ),
             )
             return func
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._user_message_listeners.append(
+            self._append_listener(
+                self._user_message_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
                     matchers=all_matchers,
                     middleware=middleware,
-                )
+                ),
             )
 
             @wraps(func)
@@ -172,23 +173,25 @@ class AsyncAssistant(AsyncMiddleware):
         )
         if is_used_without_argument(args):
             func = args[0]
-            self._bot_message_listeners.append(
+            self._append_listener(
+                self._bot_message_listeners,
                 self.build_listener(
                     listener_or_functions=func,
                     matchers=all_matchers,
                     middleware=middleware,  # type: ignore[arg-type]
-                )
+                ),
             )
             return func
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._bot_message_listeners.append(
+            self._append_listener(
+                self._bot_message_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
                     matchers=all_matchers,
                     middleware=middleware,
-                )
+                ),
             )
 
             @wraps(func)
@@ -218,23 +221,25 @@ class AsyncAssistant(AsyncMiddleware):
         )
         if is_used_without_argument(args):
             func = args[0]
-            self._thread_context_changed_listeners.append(
+            self._append_listener(
+                self._thread_context_changed_listeners,
                 self.build_listener(
                     listener_or_functions=func,
                     matchers=all_matchers,
                     middleware=middleware,  # type: ignore[arg-type]
-                )
+                ),
             )
             return func
 
         def _inner(func):
             functions = [func] + (lazy if lazy is not None else [])
-            self._thread_context_changed_listeners.append(
+            self._append_listener(
+                self._thread_context_changed_listeners,
                 self.build_listener(
                     listener_or_functions=functions,
                     matchers=all_matchers,
                     middleware=middleware,
-                )
+                ),
             )
 
             @wraps(func)
@@ -257,15 +262,68 @@ class AsyncAssistant(AsyncMiddleware):
         new_context: dict = payload["assistant_thread"]["context"]
         await save_thread_context(new_context)
 
-    async def async_process(  # type: ignore[return]
+    @staticmethod
+    async def default_other_message_sub_event(ack):
+        await ack()
+
+    def _register_app_listeners(self, listener_registrar: Callable[[AsyncListener], None]) -> None:
+        self._ensure_default_thread_context_changed_listener()
+        self._ensure_other_message_sub_event_listener()
+        for listener in self._app_listeners:
+            listener_registrar(listener)
+        self._app_listener_registrars.append(listener_registrar)
+
+    @property
+    def _app_listeners(self) -> List[AsyncListener]:
+        listeners: List[AsyncListener] = []
+        for listener_list in [
+            self._thread_started_listeners,
+            self._thread_context_changed_listeners,
+            self._user_message_listeners,
+            self._bot_message_listeners,
+            self._other_message_sub_event_listeners,
+        ]:
+            if listener_list is not None:
+                listeners.extend(listener_list)
+        return listeners
+
+    def _append_listener(self, listeners: List[AsyncListener], listener: AsyncListener) -> None:
+        listeners.append(listener)
+        for registrar in self._app_listener_registrars:
+            registrar(listener)
+
+    def _ensure_default_thread_context_changed_listener(self) -> None:
+        if self._thread_context_changed_listeners is None:
+            self.thread_context_changed(self.default_thread_context_changed)
+
+    def _ensure_other_message_sub_event_listener(self) -> None:
+        if self._other_message_sub_event_listeners is None:
+            self._other_message_sub_event_listeners = []
+            self._append_listener(
+                self._other_message_sub_event_listeners,
+                self.build_listener(
+                    listener_or_functions=self.default_other_message_sub_event,
+                    matchers=[
+                        cast(
+                            AsyncListenerMatcher,
+                            build_listener_matcher(
+                                func=is_other_message_sub_event_in_assistant_thread,
+                                asyncio=True,
+                                base_logger=self.base_logger,
+                            ),
+                        )
+                    ],
+                ),
+            )
+
+    async def async_process(
         self,
         *,
         req: AsyncBoltRequest,
         resp: BoltResponse,
         next: Callable[[], Awaitable[BoltResponse]],
     ) -> Optional[BoltResponse]:
-        if self._thread_context_changed_listeners is None:
-            self.thread_context_changed(self.default_thread_context_changed)
+        self._ensure_default_thread_context_changed_listener()
 
         listener_runner: AsyncioListenerRunner = req.context.listener_runner
         for listeners in [
@@ -277,11 +335,7 @@ class AsyncAssistant(AsyncMiddleware):
             if listeners is not None:
                 for listener in listeners:
                     if listener is not None and await listener.async_matches(req=req, resp=resp):
-                        middleware_resp, next_was_not_called = await self._run_middleware(
-                            listener=listener,
-                            req=req,
-                            resp=resp,
-                        )
+                        middleware_resp, next_was_not_called = await listener.run_async_middleware(req=req, resp=resp)
                         if next_was_not_called:
                             if middleware_resp is not None:
                                 return middleware_resp
@@ -301,33 +355,7 @@ class AsyncAssistant(AsyncMiddleware):
             return await req.context.ack()
 
         await next()
-
-    async def _run_middleware(
-        self,
-        *,
-        listener: AsyncListener,
-        req: AsyncBoltRequest,
-        resp: BoltResponse,
-    ) -> Tuple[Optional[BoltResponse], bool]:
-        middleware = list(listener.middleware)
-        if len(self._inherited_app_middleware) > 0:
-            insertion_index = 1 if len(middleware) > 0 and isinstance(middleware[0], AsyncAttachingConversationKwargs) else 0
-            middleware = [
-                *middleware[:insertion_index],
-                *self._inherited_app_middleware,
-                *middleware[insertion_index:],
-            ]
-
-        for m in middleware:
-            middleware_state = {"next_called": False}
-
-            async def next_():
-                middleware_state["next_called"] = True
-
-            resp = await m.async_process(req=req, resp=resp, next=next_)  # type: ignore[assignment]
-            if not middleware_state["next_called"]:
-                return resp, True
-        return resp, False
+        return None
 
     def build_listener(
         self,

--- a/tests/slack_bolt/app/test_app_assistant_middleware.py
+++ b/tests/slack_bolt/app/test_app_assistant_middleware.py
@@ -30,6 +30,35 @@ async def async_authorize_test_app(context, enterprise_id, team_id, user_id):
 
 
 class TestAppAssistantMiddleware:
+    def test_auto_inherit_assistant_registers_handlers_as_app_listeners(self):
+        app = App(client=WebClient(token=None), authorize=authorize_test_app, process_before_response=True)
+        assistant = Assistant(auto_inherit_app_middleware=True)
+
+        @app.message("")
+        def catch_all():
+            pass
+
+        @assistant.user_message
+        def handle_user_message():
+            pass
+
+        app.assistant(assistant)
+
+        second_assistant = Assistant(auto_inherit_app_middleware=True)
+
+        @second_assistant.user_message
+        def handle_second_user_message():
+            pass
+
+        app.assistant(second_assistant)
+
+        assert assistant not in app._middleware_list
+        listener_functions = [listener.ack_function for listener in app._listeners]
+        assert handle_user_message in listener_functions
+        assert listener_functions.index(handle_user_message) < listener_functions.index(catch_all)
+        assert listener_functions.index(handle_user_message) < listener_functions.index(handle_second_user_message)
+        assert listener_functions.index(handle_second_user_message) < listener_functions.index(catch_all)
+
     def test_assistant_inherits_app_middleware_registered_after_assistant(self):
         app = App(client=WebClient(token=None), authorize=authorize_test_app, process_before_response=True)
         assistant = Assistant(auto_inherit_app_middleware=True)
@@ -38,6 +67,8 @@ class TestAppAssistantMiddleware:
         class ListenerMiddleware(Middleware):
             def process(self, *, req: BoltRequestType, resp: BoltResponse, next: Callable[[], BoltResponse]):
                 calls.append("listener")
+                assert req.context.get("set_status") is not None
+                assert req.context.get("set_title") is not None
                 return next()
 
         @assistant.user_message(middleware=[ListenerMiddleware()])
@@ -49,8 +80,6 @@ class TestAppAssistantMiddleware:
         @app.middleware
         def app_middleware(req, next):
             calls.append("app")
-            assert req.context.get("set_status") is not None
-            assert req.context.get("set_title") is not None
             return next()
 
         request = BoltRequest(body=user_message_event_body, mode="socket_mode")
@@ -126,6 +155,35 @@ class TestAppAssistantMiddleware:
 
 
 class TestAsyncAppAssistantMiddleware:
+    def test_auto_inherit_assistant_registers_handlers_as_app_listeners(self):
+        app = AsyncApp(client=AsyncWebClient(token=None), authorize=async_authorize_test_app, process_before_response=True)
+        assistant = AsyncAssistant(auto_inherit_app_middleware=True)
+
+        @app.message("")
+        async def catch_all():
+            pass
+
+        @assistant.user_message
+        async def handle_user_message():
+            pass
+
+        app.assistant(assistant)
+
+        second_assistant = AsyncAssistant(auto_inherit_app_middleware=True)
+
+        @second_assistant.user_message
+        async def handle_second_user_message():
+            pass
+
+        app.assistant(second_assistant)
+
+        assert assistant not in app._async_middleware_list
+        listener_functions = [listener.ack_function for listener in app._async_listeners]
+        assert handle_user_message in listener_functions
+        assert listener_functions.index(handle_user_message) < listener_functions.index(catch_all)
+        assert listener_functions.index(handle_user_message) < listener_functions.index(handle_second_user_message)
+        assert listener_functions.index(handle_second_user_message) < listener_functions.index(catch_all)
+
     @pytest.mark.asyncio
     async def test_assistant_inherits_app_middleware_registered_after_assistant(self):
         app = AsyncApp(client=AsyncWebClient(token=None), authorize=async_authorize_test_app, process_before_response=True)
@@ -141,6 +199,8 @@ class TestAsyncAppAssistantMiddleware:
                 next: Callable[[], Awaitable[BoltResponse]],
             ) -> Optional[BoltResponse]:
                 calls.append("listener")
+                assert req.context.get("set_status") is not None
+                assert req.context.get("set_title") is not None
                 return await next()
 
         @assistant.user_message(middleware=[ListenerMiddleware()])
@@ -152,8 +212,6 @@ class TestAsyncAppAssistantMiddleware:
         @app.middleware
         async def app_middleware(req, next):
             calls.append("app")
-            assert req.context.get("set_status") is not None
-            assert req.context.get("set_title") is not None
             return await next()
 
         request = AsyncBoltRequest(body=user_message_event_body, mode="socket_mode")

--- a/tests/slack_bolt/app/test_app_assistant_middleware.py
+++ b/tests/slack_bolt/app/test_app_assistant_middleware.py
@@ -7,6 +7,7 @@ from slack_sdk.web.async_client import AsyncWebClient
 from slack_bolt import App, Assistant, BoltRequest
 from slack_bolt.async_app import AsyncApp, AsyncAssistant, AsyncBoltRequest
 from slack_bolt.authorization import AuthorizeResult
+from slack_bolt.error import BoltError
 from slack_bolt.middleware import Middleware
 from slack_bolt.middleware.async_middleware import AsyncMiddleware
 from slack_bolt.request import BoltRequest as BoltRequestType
@@ -30,9 +31,9 @@ async def async_authorize_test_app(context, enterprise_id, team_id, user_id):
 
 
 class TestAppAssistantMiddleware:
-    def test_auto_inherit_assistant_registers_handlers_as_app_listeners(self):
+    def test_assistant_listener_mode_registers_handlers_as_app_listeners(self):
         app = App(client=WebClient(token=None), authorize=authorize_test_app, process_before_response=True)
-        assistant = Assistant(auto_inherit_app_middleware=True)
+        assistant = Assistant()
 
         @app.message("")
         def catch_all():
@@ -42,15 +43,15 @@ class TestAppAssistantMiddleware:
         def handle_user_message():
             pass
 
-        app.assistant(assistant)
+        app.assistant(assistant, mode="listeners")
 
-        second_assistant = Assistant(auto_inherit_app_middleware=True)
+        second_assistant = Assistant()
 
         @second_assistant.user_message
         def handle_second_user_message():
             pass
 
-        app.assistant(second_assistant)
+        app.assistant(second_assistant, mode="listeners")
 
         assert assistant not in app._middleware_list
         listener_functions = [listener.ack_function for listener in app._listeners]
@@ -59,9 +60,9 @@ class TestAppAssistantMiddleware:
         assert listener_functions.index(handle_user_message) < listener_functions.index(handle_second_user_message)
         assert listener_functions.index(handle_second_user_message) < listener_functions.index(catch_all)
 
-    def test_assistant_inherits_app_middleware_registered_after_assistant(self):
+    def test_assistant_listener_mode_inherits_app_middleware_registered_after_assistant(self):
         app = App(client=WebClient(token=None), authorize=authorize_test_app, process_before_response=True)
-        assistant = Assistant(auto_inherit_app_middleware=True)
+        assistant = Assistant()
         calls = []
 
         class ListenerMiddleware(Middleware):
@@ -75,7 +76,7 @@ class TestAppAssistantMiddleware:
         def handle_user_message():
             calls.append("handler")
 
-        app.assistant(assistant)
+        app.assistant(assistant, mode="listeners")
 
         @app.middleware
         def app_middleware(req, next):
@@ -109,9 +110,9 @@ class TestAppAssistantMiddleware:
         assert response.status == 200
         assert calls == ["handler"]
 
-    def test_assistant_inherits_app_middleware_for_listeners_registered_later(self):
+    def test_assistant_middleware_mode_does_not_inherit_app_middleware(self):
         app = App(client=WebClient(token=None), authorize=authorize_test_app, process_before_response=True)
-        assistant = Assistant(auto_inherit_app_middleware=True)
+        assistant = Assistant()
         calls = []
 
         class AppMiddleware(Middleware):
@@ -119,7 +120,29 @@ class TestAppAssistantMiddleware:
                 calls.append("app")
                 return next()
 
-        app.assistant(assistant)
+        @assistant.user_message
+        def handle_user_message():
+            calls.append("handler")
+
+        app.assistant(assistant, mode="middleware")
+        app.middleware(AppMiddleware())
+
+        request = BoltRequest(body=user_message_event_body, mode="socket_mode")
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert calls == ["handler"]
+
+    def test_assistant_listener_mode_inherits_app_middleware_for_listeners_registered_later(self):
+        app = App(client=WebClient(token=None), authorize=authorize_test_app, process_before_response=True)
+        assistant = Assistant()
+        calls = []
+
+        class AppMiddleware(Middleware):
+            def process(self, *, req: BoltRequestType, resp: BoltResponse, next: Callable[[], BoltResponse]):
+                calls.append("app")
+                return next()
+
+        app.assistant(assistant, mode="listeners")
         app.middleware(AppMiddleware())
 
         @assistant.user_message
@@ -131,9 +154,9 @@ class TestAppAssistantMiddleware:
         assert response.status == 200
         assert calls == ["app", "handler"]
 
-    def test_assistant_inherited_app_middleware_can_short_circuit(self):
+    def test_assistant_listener_mode_inherited_app_middleware_can_short_circuit(self):
         app = App(client=WebClient(token=None), authorize=authorize_test_app, process_before_response=True)
-        assistant = Assistant(auto_inherit_app_middleware=True)
+        assistant = Assistant()
         calls = []
 
         class BlockingMiddleware(Middleware):
@@ -145,7 +168,7 @@ class TestAppAssistantMiddleware:
         def start_thread():
             calls.append("handler")
 
-        app.assistant(assistant)
+        app.assistant(assistant, mode="listeners")
         app.middleware(BlockingMiddleware())
 
         request = BoltRequest(body=thread_started_event_body, mode="socket_mode")
@@ -153,11 +176,17 @@ class TestAppAssistantMiddleware:
         assert response.status == 201
         assert calls == ["app"]
 
+    def test_assistant_rejects_unknown_mode(self):
+        app = App(client=WebClient(token=None), authorize=authorize_test_app, process_before_response=True)
+
+        with pytest.raises(BoltError, match="Unsupported Assistant registration mode"):
+            app.assistant(Assistant(), mode="something")
+
 
 class TestAsyncAppAssistantMiddleware:
-    def test_auto_inherit_assistant_registers_handlers_as_app_listeners(self):
+    def test_assistant_listener_mode_registers_handlers_as_app_listeners(self):
         app = AsyncApp(client=AsyncWebClient(token=None), authorize=async_authorize_test_app, process_before_response=True)
-        assistant = AsyncAssistant(auto_inherit_app_middleware=True)
+        assistant = AsyncAssistant()
 
         @app.message("")
         async def catch_all():
@@ -167,15 +196,15 @@ class TestAsyncAppAssistantMiddleware:
         async def handle_user_message():
             pass
 
-        app.assistant(assistant)
+        app.assistant(assistant, mode="listeners")
 
-        second_assistant = AsyncAssistant(auto_inherit_app_middleware=True)
+        second_assistant = AsyncAssistant()
 
         @second_assistant.user_message
         async def handle_second_user_message():
             pass
 
-        app.assistant(second_assistant)
+        app.assistant(second_assistant, mode="listeners")
 
         assert assistant not in app._async_middleware_list
         listener_functions = [listener.ack_function for listener in app._async_listeners]
@@ -185,9 +214,9 @@ class TestAsyncAppAssistantMiddleware:
         assert listener_functions.index(handle_second_user_message) < listener_functions.index(catch_all)
 
     @pytest.mark.asyncio
-    async def test_assistant_inherits_app_middleware_registered_after_assistant(self):
+    async def test_assistant_listener_mode_inherits_app_middleware_registered_after_assistant(self):
         app = AsyncApp(client=AsyncWebClient(token=None), authorize=async_authorize_test_app, process_before_response=True)
-        assistant = AsyncAssistant(auto_inherit_app_middleware=True)
+        assistant = AsyncAssistant()
         calls = []
 
         class ListenerMiddleware(AsyncMiddleware):
@@ -207,7 +236,7 @@ class TestAsyncAppAssistantMiddleware:
         async def handle_user_message():
             calls.append("handler")
 
-        app.assistant(assistant)
+        app.assistant(assistant, mode="listeners")
 
         @app.middleware
         async def app_middleware(req, next):
@@ -249,9 +278,9 @@ class TestAsyncAppAssistantMiddleware:
         assert calls == ["handler"]
 
     @pytest.mark.asyncio
-    async def test_assistant_inherits_app_middleware_for_listeners_registered_later(self):
+    async def test_assistant_middleware_mode_does_not_inherit_app_middleware(self):
         app = AsyncApp(client=AsyncWebClient(token=None), authorize=async_authorize_test_app, process_before_response=True)
-        assistant = AsyncAssistant(auto_inherit_app_middleware=True)
+        assistant = AsyncAssistant()
         calls = []
 
         class AppMiddleware(AsyncMiddleware):
@@ -265,7 +294,36 @@ class TestAsyncAppAssistantMiddleware:
                 calls.append("app")
                 return await next()
 
-        app.assistant(assistant)
+        @assistant.user_message
+        async def handle_user_message():
+            calls.append("handler")
+
+        app.assistant(assistant, mode="middleware")
+        app.middleware(AppMiddleware())
+
+        request = AsyncBoltRequest(body=user_message_event_body, mode="socket_mode")
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert calls == ["handler"]
+
+    @pytest.mark.asyncio
+    async def test_assistant_listener_mode_inherits_app_middleware_for_listeners_registered_later(self):
+        app = AsyncApp(client=AsyncWebClient(token=None), authorize=async_authorize_test_app, process_before_response=True)
+        assistant = AsyncAssistant()
+        calls = []
+
+        class AppMiddleware(AsyncMiddleware):
+            async def async_process(
+                self,
+                *,
+                req: AsyncBoltRequest,
+                resp: BoltResponse,
+                next: Callable[[], Awaitable[BoltResponse]],
+            ) -> Optional[BoltResponse]:
+                calls.append("app")
+                return await next()
+
+        app.assistant(assistant, mode="listeners")
         app.middleware(AppMiddleware())
 
         @assistant.user_message
@@ -278,9 +336,9 @@ class TestAsyncAppAssistantMiddleware:
         assert calls == ["app", "handler"]
 
     @pytest.mark.asyncio
-    async def test_assistant_inherited_app_middleware_can_short_circuit(self):
+    async def test_assistant_listener_mode_inherited_app_middleware_can_short_circuit(self):
         app = AsyncApp(client=AsyncWebClient(token=None), authorize=async_authorize_test_app, process_before_response=True)
-        assistant = AsyncAssistant(auto_inherit_app_middleware=True)
+        assistant = AsyncAssistant()
         calls = []
 
         class BlockingMiddleware(AsyncMiddleware):
@@ -298,10 +356,16 @@ class TestAsyncAppAssistantMiddleware:
         async def start_thread():
             calls.append("handler")
 
-        app.assistant(assistant)
+        app.assistant(assistant, mode="listeners")
         app.middleware(BlockingMiddleware())
 
         request = AsyncBoltRequest(body=thread_started_event_body, mode="socket_mode")
         response = await app.async_dispatch(request)
         assert response.status == 201
         assert calls == ["app"]
+
+    def test_assistant_rejects_unknown_mode(self):
+        app = AsyncApp(client=AsyncWebClient(token=None), authorize=async_authorize_test_app, process_before_response=True)
+
+        with pytest.raises(BoltError, match="Unsupported Assistant registration mode"):
+            app.assistant(AsyncAssistant(), mode="something")

--- a/tests/slack_bolt/app/test_app_assistant_middleware.py
+++ b/tests/slack_bolt/app/test_app_assistant_middleware.py
@@ -1,0 +1,249 @@
+from typing import Awaitable, Callable, Optional
+
+import pytest
+from slack_sdk import WebClient
+from slack_sdk.web.async_client import AsyncWebClient
+
+from slack_bolt import App, Assistant, BoltRequest
+from slack_bolt.async_app import AsyncApp, AsyncAssistant, AsyncBoltRequest
+from slack_bolt.authorization import AuthorizeResult
+from slack_bolt.middleware import Middleware
+from slack_bolt.middleware.async_middleware import AsyncMiddleware
+from slack_bolt.request import BoltRequest as BoltRequestType
+from slack_bolt.response import BoltResponse
+from tests.scenario_tests.test_events_assistant import thread_started_event_body, user_message_event_body
+
+
+def authorize_test_app(context, enterprise_id, team_id, user_id):
+    return AuthorizeResult(
+        enterprise_id=enterprise_id,
+        team_id=team_id,
+        user_id=user_id,
+        bot_user_id="W111",
+        bot_id="B111",
+        bot_token="xoxb-valid",
+    )
+
+
+async def async_authorize_test_app(context, enterprise_id, team_id, user_id):
+    return authorize_test_app(context, enterprise_id, team_id, user_id)
+
+
+class TestAppAssistantMiddleware:
+    def test_assistant_inherits_app_middleware_registered_after_assistant(self):
+        app = App(client=WebClient(token=None), authorize=authorize_test_app, process_before_response=True)
+        assistant = Assistant(auto_inherit_app_middleware=True)
+        calls = []
+
+        class ListenerMiddleware(Middleware):
+            def process(self, *, req: BoltRequestType, resp: BoltResponse, next: Callable[[], BoltResponse]):
+                calls.append("listener")
+                return next()
+
+        @assistant.user_message(middleware=[ListenerMiddleware()])
+        def handle_user_message():
+            calls.append("handler")
+
+        app.assistant(assistant)
+
+        @app.middleware
+        def app_middleware(req, next):
+            calls.append("app")
+            assert req.context.get("set_status") is not None
+            assert req.context.get("set_title") is not None
+            return next()
+
+        request = BoltRequest(body=user_message_event_body, mode="socket_mode")
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert calls == ["app", "listener", "handler"]
+
+    def test_assistant_does_not_inherit_app_middleware_by_default(self):
+        app = App(client=WebClient(token=None), authorize=authorize_test_app, process_before_response=True)
+        assistant = Assistant()
+        calls = []
+
+        class AppMiddleware(Middleware):
+            def process(self, *, req: BoltRequestType, resp: BoltResponse, next: Callable[[], BoltResponse]):
+                calls.append("app")
+                return next()
+
+        @assistant.user_message
+        def handle_user_message():
+            calls.append("handler")
+
+        app.assistant(assistant)
+        app.middleware(AppMiddleware())
+
+        request = BoltRequest(body=user_message_event_body, mode="socket_mode")
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert calls == ["handler"]
+
+    def test_assistant_inherits_app_middleware_for_listeners_registered_later(self):
+        app = App(client=WebClient(token=None), authorize=authorize_test_app, process_before_response=True)
+        assistant = Assistant(auto_inherit_app_middleware=True)
+        calls = []
+
+        class AppMiddleware(Middleware):
+            def process(self, *, req: BoltRequestType, resp: BoltResponse, next: Callable[[], BoltResponse]):
+                calls.append("app")
+                return next()
+
+        app.assistant(assistant)
+        app.middleware(AppMiddleware())
+
+        @assistant.user_message
+        def handle_user_message():
+            calls.append("handler")
+
+        request = BoltRequest(body=user_message_event_body, mode="socket_mode")
+        response = app.dispatch(request)
+        assert response.status == 200
+        assert calls == ["app", "handler"]
+
+    def test_assistant_inherited_app_middleware_can_short_circuit(self):
+        app = App(client=WebClient(token=None), authorize=authorize_test_app, process_before_response=True)
+        assistant = Assistant(auto_inherit_app_middleware=True)
+        calls = []
+
+        class BlockingMiddleware(Middleware):
+            def process(self, *, req: BoltRequestType, resp: BoltResponse, next: Callable[[], BoltResponse]):
+                calls.append("app")
+                return BoltResponse(status=201)
+
+        @assistant.thread_started
+        def start_thread():
+            calls.append("handler")
+
+        app.assistant(assistant)
+        app.middleware(BlockingMiddleware())
+
+        request = BoltRequest(body=thread_started_event_body, mode="socket_mode")
+        response = app.dispatch(request)
+        assert response.status == 201
+        assert calls == ["app"]
+
+
+class TestAsyncAppAssistantMiddleware:
+    @pytest.mark.asyncio
+    async def test_assistant_inherits_app_middleware_registered_after_assistant(self):
+        app = AsyncApp(client=AsyncWebClient(token=None), authorize=async_authorize_test_app, process_before_response=True)
+        assistant = AsyncAssistant(auto_inherit_app_middleware=True)
+        calls = []
+
+        class ListenerMiddleware(AsyncMiddleware):
+            async def async_process(
+                self,
+                *,
+                req: AsyncBoltRequest,
+                resp: BoltResponse,
+                next: Callable[[], Awaitable[BoltResponse]],
+            ) -> Optional[BoltResponse]:
+                calls.append("listener")
+                return await next()
+
+        @assistant.user_message(middleware=[ListenerMiddleware()])
+        async def handle_user_message():
+            calls.append("handler")
+
+        app.assistant(assistant)
+
+        @app.middleware
+        async def app_middleware(req, next):
+            calls.append("app")
+            assert req.context.get("set_status") is not None
+            assert req.context.get("set_title") is not None
+            return await next()
+
+        request = AsyncBoltRequest(body=user_message_event_body, mode="socket_mode")
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert calls == ["app", "listener", "handler"]
+
+    @pytest.mark.asyncio
+    async def test_assistant_does_not_inherit_app_middleware_by_default(self):
+        app = AsyncApp(client=AsyncWebClient(token=None), authorize=async_authorize_test_app, process_before_response=True)
+        assistant = AsyncAssistant()
+        calls = []
+
+        class AppMiddleware(AsyncMiddleware):
+            async def async_process(
+                self,
+                *,
+                req: AsyncBoltRequest,
+                resp: BoltResponse,
+                next: Callable[[], Awaitable[BoltResponse]],
+            ) -> Optional[BoltResponse]:
+                calls.append("app")
+                return await next()
+
+        @assistant.user_message
+        async def handle_user_message():
+            calls.append("handler")
+
+        app.assistant(assistant)
+        app.middleware(AppMiddleware())
+
+        request = AsyncBoltRequest(body=user_message_event_body, mode="socket_mode")
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert calls == ["handler"]
+
+    @pytest.mark.asyncio
+    async def test_assistant_inherits_app_middleware_for_listeners_registered_later(self):
+        app = AsyncApp(client=AsyncWebClient(token=None), authorize=async_authorize_test_app, process_before_response=True)
+        assistant = AsyncAssistant(auto_inherit_app_middleware=True)
+        calls = []
+
+        class AppMiddleware(AsyncMiddleware):
+            async def async_process(
+                self,
+                *,
+                req: AsyncBoltRequest,
+                resp: BoltResponse,
+                next: Callable[[], Awaitable[BoltResponse]],
+            ) -> Optional[BoltResponse]:
+                calls.append("app")
+                return await next()
+
+        app.assistant(assistant)
+        app.middleware(AppMiddleware())
+
+        @assistant.user_message
+        async def handle_user_message():
+            calls.append("handler")
+
+        request = AsyncBoltRequest(body=user_message_event_body, mode="socket_mode")
+        response = await app.async_dispatch(request)
+        assert response.status == 200
+        assert calls == ["app", "handler"]
+
+    @pytest.mark.asyncio
+    async def test_assistant_inherited_app_middleware_can_short_circuit(self):
+        app = AsyncApp(client=AsyncWebClient(token=None), authorize=async_authorize_test_app, process_before_response=True)
+        assistant = AsyncAssistant(auto_inherit_app_middleware=True)
+        calls = []
+
+        class BlockingMiddleware(AsyncMiddleware):
+            async def async_process(
+                self,
+                *,
+                req: AsyncBoltRequest,
+                resp: BoltResponse,
+                next: Callable[[], Awaitable[BoltResponse]],
+            ) -> Optional[BoltResponse]:
+                calls.append("app")
+                return BoltResponse(status=201)
+
+        @assistant.thread_started
+        async def start_thread():
+            calls.append("handler")
+
+        app.assistant(assistant)
+        app.middleware(BlockingMiddleware())
+
+        request = AsyncBoltRequest(body=thread_started_event_body, mode="socket_mode")
+        response = await app.async_dispatch(request)
+        assert response.status == 201
+        assert calls == ["app"]


### PR DESCRIPTION
## Summary

Addresses #1346 by adding an explicit Assistant registration mode to `App.assistant()` and `AsyncApp.assistant()`.

By default, `app.assistant(assistant)` continues to behave as it does today: it registers Assistant as middleware. This preserves the existing Assistant middleware dispatch path and keeps `app.use(assistant)` / `app.middleware(assistant)` behavior unchanged.

Apps can now opt into listener-based registration:

```python
app.assistant(assistant, mode="listeners")
```

In this mode, Assistant handlers are registered as normal App listeners. This lets assistant-specific handlers participate in the App listener pipeline and inherit app-level middleware such as authorization, auditing, rate limiting, or request enrichment.

The PR also adds an internal listener registry so Assistant listeners can be evaluated before broad catch-all listeners without exposing a general listener priority API. Registration order is preserved within Assistant listeners and ordinary App listeners, and sync/async behavior is kept mirrored.

### Testing

- `./scripts/format.sh --no-install`
- `./scripts/lint.sh --no-install`
- `./scripts/run_tests.sh tests/slack_bolt/app/test_app_assistant_middleware.py` (`14 passed`)
- `./scripts/run_mypy.sh --no-install` (`Success: no issues found in 235 source files`)
- `./scripts/install_all_and_run_tests.sh` (`924 passed`, `81 warnings`; mypy: `Success: no issues found in 235 source files`)

### Category <!-- place an `x` in each of the `[ ]`  -->

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
