### PR TITLE
docs: removing external links for unified nav

### DIFF
--- a/docs/english/_sidebar.json
+++ b/docs/english/_sidebar.json
@@ -202,21 +202,5 @@
 				"items": ["tools/bolt-python/ja-jp/legacy/steps-from-apps"]
 			}
 		]
-	},
-	{ "type": "html", "value": "<hr>" },
-	{
-		"type": "link",
-		"label": "Release notes",
-		"href": "https://github.com/slackapi/bolt-python/releases"
-	},
-	{
-		"type": "link",
-		"label": "Code on GitHub",
-		"href": "https://github.com/SlackAPI/bolt-python"
-	},
-	{
-		"type": "link",
-		"label": "Contributors Guide",
-		"href": "https://github.com/SlackAPI/bolt-python/blob/main/.github/contributing.md"
 	}
 ]

--- a/docs/english/index.md
+++ b/docs/english/index.md
@@ -19,3 +19,7 @@ These docs live within the [Bolt-Python](https://github.com/slackapi/bolt-python
 
 We welcome contributions from everyone! Please check out our
 [Contributor's Guide](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) for how to contribute in a helpful and collaborative way.
+
+## Release notes
+
+Check out the [Bolt for Python release notes](https://github.com/slackapi/bolt-python/releases) for all the latest happenings.

--- a/docs/english/index.md
+++ b/docs/english/index.md
@@ -13,13 +13,13 @@ If you otherwise get stuck, we're here to help. The following are the best ways 
 * [Issue Tracker](http://github.com/slackapi/bolt-python/issues) for questions, bug reports, feature requests, and general discussion related to Bolt for Python. Try searching for an existing issue before creating a new one.
 * [Email](mailto:support@slack.com) our developer support team: `support@slack.com`.
 
+## Release notes
+
+Check out the [Bolt for Python release notes](https://github.com/slackapi/bolt-python/releases) for all the latest happenings.
+
 ## Contributing
 
 These docs live within the [Bolt-Python](https://github.com/slackapi/bolt-python/) repository and are open source.
 
 We welcome contributions from everyone! Please check out our
 [Contributor's Guide](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) for how to contribute in a helpful and collaborative way.
-
-## Release notes
-
-Check out the [Bolt for Python release notes](https://github.com/slackapi/bolt-python/releases) for all the latest happenings.


### PR DESCRIPTION
## Summary

I'm working on uniting the nav bar for all of the tools so that you don't lose the context of the rest of the nav when you click on one of the tools. In this PR, I'm removing the external links (release notes, github repo, contributor's guide) to cut down on bloat in the nav menu when they are all united. Since the github repo and contributor's guide are already mentioned in the landing page, I just added the release notes link to that. 

Preview for one nav here: https://docs-slack-d-unified-na-idfrpr.herokuapp.com/tools
PR for unified nav here: https://github.com/slackapi/docs/pull/605

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [x] Document pages under `/docs`
* [ ] Others

## Requirements <!-- place an `x` in each `[ ]` -->

Please read the [Contributing guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.
