### PR TITLE
fix: defer SignatureVerifier construction so Socket Mode apps init without a signing secret

### DIFF
--- a/slack_bolt/middleware/request_verification/request_verification.py
+++ b/slack_bolt/middleware/request_verification/request_verification.py
@@ -20,10 +20,6 @@ class RequestVerification(Middleware):
             signing_secret: The signing secret
             base_logger: The base logger
         """
-        # The verifier is created lazily so that apps without a signing secret
-        # (e.g. Socket Mode) can be initialized. slack_sdk>=3.43.0 rejects an
-        # empty signing secret on construction, but request verification is
-        # skipped for those requests anyway (see `_can_skip`).
         self._signing_secret = signing_secret
         self._verifier: Optional[SignatureVerifier] = None
         self.logger = get_bolt_logger(RequestVerification, base_logger=base_logger)

--- a/slack_bolt/middleware/request_verification/request_verification.py
+++ b/slack_bolt/middleware/request_verification/request_verification.py
@@ -26,6 +26,8 @@ class RequestVerification(Middleware):
 
     @property
     def verifier(self) -> SignatureVerifier:
+        # Defer initialization to avoid errors of a missing signing secret for
+        # apps using Socket Mode connections
         if self._verifier is None:
             self._verifier = SignatureVerifier(signing_secret=self._signing_secret)
         return self._verifier

--- a/slack_bolt/middleware/request_verification/request_verification.py
+++ b/slack_bolt/middleware/request_verification/request_verification.py
@@ -1,5 +1,5 @@
 from logging import Logger
-from typing import Callable, Dict, Any, Optional
+from typing import Any, Callable, Dict, Optional
 
 from slack_sdk.signature import SignatureVerifier
 

--- a/slack_bolt/middleware/request_verification/request_verification.py
+++ b/slack_bolt/middleware/request_verification/request_verification.py
@@ -26,8 +26,7 @@ class RequestVerification(Middleware):
 
     @property
     def verifier(self) -> SignatureVerifier:
-        # Defer initialization to avoid errors of a missing signing secret for
-        # apps using Socket Mode connections
+        # Defer initialization to avoid errors during start up
         if self._verifier is None:
             self._verifier = SignatureVerifier(signing_secret=self._signing_secret)
         return self._verifier

--- a/slack_bolt/middleware/request_verification/request_verification.py
+++ b/slack_bolt/middleware/request_verification/request_verification.py
@@ -20,8 +20,19 @@ class RequestVerification(Middleware):
             signing_secret: The signing secret
             base_logger: The base logger
         """
-        self.verifier = SignatureVerifier(signing_secret=signing_secret)
+        # The verifier is created lazily so that apps without a signing secret
+        # (e.g. Socket Mode) can be initialized. slack_sdk>=3.43.0 rejects an
+        # empty signing secret on construction, but request verification is
+        # skipped for those requests anyway (see `_can_skip`).
+        self._signing_secret = signing_secret
+        self._verifier: Optional[SignatureVerifier] = None
         self.logger = get_bolt_logger(RequestVerification, base_logger=base_logger)
+
+    @property
+    def verifier(self) -> SignatureVerifier:
+        if self._verifier is None:
+            self._verifier = SignatureVerifier(signing_secret=self._signing_secret)
+        return self._verifier
 
     def process(
         self,

--- a/tests/scenario_tests/test_app.py
+++ b/tests/scenario_tests/test_app.py
@@ -97,9 +97,6 @@ class TestApp:
         assert self.received_requests.get("/auth.test") is None
 
     def test_socket_mode_app_without_signing_secret(self):
-        # A Socket Mode app has no signing secret. Initializing the app must not
-        # raise, even though slack_sdk>=3.43.0 rejects an empty signing secret
-        # when the request verification middleware builds its SignatureVerifier.
         app = App(
             client=self.web_client,
             token_verification_enabled=False,

--- a/tests/scenario_tests/test_app.py
+++ b/tests/scenario_tests/test_app.py
@@ -96,6 +96,16 @@ class TestApp:
 
         assert self.received_requests.get("/auth.test") is None
 
+    def test_socket_mode_app_without_signing_secret(self):
+        # A Socket Mode app has no signing secret. Initializing the app must not
+        # raise, even though slack_sdk>=3.43.0 rejects an empty signing secret
+        # when the request verification middleware builds its SignatureVerifier.
+        app = App(
+            client=self.web_client,
+            token_verification_enabled=False,
+        )
+        assert app is not None
+
     # --------------------------
     # multi teams auth
     # --------------------------

--- a/tests/slack_bolt/middleware/request_verification/test_request_verification.py
+++ b/tests/slack_bolt/middleware/request_verification/test_request_verification.py
@@ -60,3 +60,17 @@ class TestRequestVerification:
         resp = middleware.process(req=req, resp=resp, next=next)
         assert resp.status == 401
         assert resp.body == """{"error": "invalid request"}"""
+
+    def test_empty_signing_secret_does_not_raise_on_init(self):
+        # A Socket Mode app has no signing secret. Constructing the middleware
+        # must not raise, even though slack_sdk>=3.43.0 rejects an empty
+        # signing secret when the SignatureVerifier is created.
+        RequestVerification(signing_secret="")
+
+    def test_socket_mode_request_skips_verification_without_signing_secret(self):
+        middleware = RequestVerification(signing_secret="")
+        req = BoltRequest(mode="socket_mode", body="payload={}", headers={})
+        resp = BoltResponse(status=404, body="default")
+        resp = middleware.process(req=req, resp=resp, next=next)
+        assert resp.status == 200
+        assert resp.body == "next"

--- a/tests/slack_bolt/middleware/request_verification/test_request_verification.py
+++ b/tests/slack_bolt/middleware/request_verification/test_request_verification.py
@@ -1,5 +1,6 @@
 from time import time
 
+import pytest
 from slack_sdk.signature import SignatureVerifier
 
 from slack_bolt.middleware import RequestVerification
@@ -62,9 +63,6 @@ class TestRequestVerification:
         assert resp.body == """{"error": "invalid request"}"""
 
     def test_empty_signing_secret_does_not_raise_on_init(self):
-        # A Socket Mode app has no signing secret. Constructing the middleware
-        # must not raise, even though slack_sdk>=3.43.0 rejects an empty
-        # signing secret when the SignatureVerifier is created.
         RequestVerification(signing_secret="")
 
     def test_socket_mode_request_skips_verification_without_signing_secret(self):
@@ -74,3 +72,10 @@ class TestRequestVerification:
         resp = middleware.process(req=req, resp=resp, next=next)
         assert resp.status == 200
         assert resp.body == "next"
+
+    def test_http_request_with_empty_signing_secret_raises(self):
+        middleware = RequestVerification(signing_secret="")
+        req = BoltRequest(body="payload={}", headers={})
+        resp = BoltResponse(status=404)
+        with pytest.raises(ValueError):
+            middleware.process(req=req, resp=resp, next=next)

--- a/tests/slack_bolt_async/middleware/request_verification/test_request_verification.py
+++ b/tests/slack_bolt_async/middleware/request_verification/test_request_verification.py
@@ -66,3 +66,18 @@ class TestAsyncRequestVerification:
         resp = await middleware.async_process(req=req, resp=resp, next=next)
         assert resp.status == 401
         assert resp.body == """{"error": "invalid request"}"""
+
+    def test_empty_signing_secret_does_not_raise_on_init(self):
+        # A Socket Mode app has no signing secret. Constructing the middleware
+        # must not raise, even though slack_sdk>=3.43.0 rejects an empty
+        # signing secret when the SignatureVerifier is created.
+        AsyncRequestVerification(signing_secret="")
+
+    @pytest.mark.asyncio
+    async def test_socket_mode_request_skips_verification_without_signing_secret(self):
+        middleware = AsyncRequestVerification(signing_secret="")
+        req = AsyncBoltRequest(mode="socket_mode", body="payload={}", headers={})
+        resp = BoltResponse(status=404, body="default")
+        resp = await middleware.async_process(req=req, resp=resp, next=next)
+        assert resp.status == 200
+        assert resp.body == "next"

--- a/tests/slack_bolt_async/middleware/request_verification/test_request_verification.py
+++ b/tests/slack_bolt_async/middleware/request_verification/test_request_verification.py
@@ -68,9 +68,6 @@ class TestAsyncRequestVerification:
         assert resp.body == """{"error": "invalid request"}"""
 
     def test_empty_signing_secret_does_not_raise_on_init(self):
-        # A Socket Mode app has no signing secret. Constructing the middleware
-        # must not raise, even though slack_sdk>=3.43.0 rejects an empty
-        # signing secret when the SignatureVerifier is created.
         AsyncRequestVerification(signing_secret="")
 
     @pytest.mark.asyncio
@@ -81,3 +78,11 @@ class TestAsyncRequestVerification:
         resp = await middleware.async_process(req=req, resp=resp, next=next)
         assert resp.status == 200
         assert resp.body == "next"
+
+    @pytest.mark.asyncio
+    async def test_http_request_with_empty_signing_secret_raises(self):
+        middleware = AsyncRequestVerification(signing_secret="")
+        req = AsyncBoltRequest(body="payload={}", headers={})
+        resp = BoltResponse(status=404)
+        with pytest.raises(ValueError):
+            await middleware.async_process(req=req, resp=resp, next=next)


### PR DESCRIPTION
## Summary

This pull request fixes a regression where a Socket Mode app fails to initialize with `ValueError: signing_secret must not be empty.` when running on `slack_sdk>=3.43.0`.

- `slack_sdk` 3.43.0 made `SignatureVerifier.signing_secret` a validated property whose setter rejects an empty/whitespace secret on construction (it was a plain, unvalidated attribute in 3.42.0).
- `App.__init__` eagerly builds the `RequestVerification` middleware — and therefore a `SignatureVerifier` — for every app, including Socket Mode apps that legitimately have no signing secret, so initialization now blows up.
- Fix: construct the `SignatureVerifier` lazily on first use. Request verification is already skipped for Socket Mode requests (`_can_skip`), so the verifier is never built for them; the once-per-app construction is memoized.
- HTTP-mode behavior is unchanged: a valid signing secret is still required, and an empty secret still fails when a request actually needs verifying (preserving #1495).
- `AsyncRequestVerification` inherits this `__init__`, so both sync and async paths are covered by the single change.

Fixes #1535

### Testing

This is an init-time regression that only reproduces against `slack_sdk>=3.43.0` (the version range bolt-python already allows; CI may resolve an earlier patch). To reproduce and verify manually:

1. In a fresh environment, install this branch alongside `slack_sdk==3.43.0`.
2. Before the fix, constructing a Socket Mode app raises the error:
   ```python
   from slack_bolt import App
   App(token="xoxb-...", token_verification_enabled=False)  # raises ValueError: signing_secret must not be empty.
   ```
3. With the fix, the same construction succeeds, and an actual Socket Mode app started with `SocketModeHandler` connects and handles events normally.
4. Confirm HTTP mode is unaffected: an HTTP app with a valid signing secret still verifies request signatures, and requests with an invalid/missing signature are still rejected with `401`.

### Category

* [x] `slack_bolt.App` and/or its core components
* [x] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [ ] Others

## Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've run `./scripts/install_all_and_run_tests.sh` after making the changes.