### PR TITLE
ci: do not fail CI when Codecov test-results upload errors

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -129,7 +129,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           directory: ./reports/
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           flags: ${{ matrix.python-version }}
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

The `unittest` job's **Upload test results to Codecov** step currently sets `fail_ci_if_error: true`, so a transient Codecov outage or upload hiccup fails the whole CI pipeline even when every test passed.

Uploading test results to Codecov is a best-effort reporting side-channel, not a gate on code correctness. This PR flips that step to `fail_ci_if_error: false` — a "send and forget" upload — so a third-party upload failure no longer reddens an otherwise green build.

Scope is intentionally limited to the test-results upload. The separate coverage upload in the `codecov` job is left unchanged.

### Testing

- `fail_ci_if_error: false` is a documented `codecov/codecov-action` input; the workflow YAML still parses.
- CI behavior is exercised by the workflow running on this PR.

### Category

* [ ] `slack_bolt.App` and/or its core components
* [ ] `slack_bolt.async_app.AsyncApp` and/or its core components
* [ ] Adapters in `slack_bolt.adapter`
* [ ] Document pages under `/docs`
* [x] Others (CI workflow)

## Requirements

* [x] I've read and understood the Contributing Guidelines and have done my best effort to follow them.
* [x] I've read and agree to the Code of Conduct.
* [ ] I've run `./scripts/install_all_and_run_tests.sh` after making the changes. (CI-only change; no source code affected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)